### PR TITLE
feat: introduce codespell and example linters

### DIFF
--- a/codespell_to_sarif.py
+++ b/codespell_to_sarif.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+def to_result_sarif(path: str, line_number: int, column_number: int, rule_id: str, message: str):
+  return {
+         "level": "error",
+         "locations": [{
+           "physicalLocation": {
+             "artifactLocation": {
+               "uri": path,
+             },
+             "region": {
+               "startColumn": column_number,
+               "startLine": line_number,
+             }
+           }
+         }],
+         "message": {
+           "text": message,
+         },
+         "ruleId": rule_id,
+       }
+
+# the engrish langauge is easy to mispell
+
+def main(argv):
+
+  results = []
+
+  for line in sys.stdin.readlines():
+    filename, line_number, message = line.split(':')
+    results.append(to_result_sarif(filename, int(line_number), 0, 'misspelled', message.strip()))
+  
+
+  sarif = {
+   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+   "version": "2.1.0",
+   "runs": [{
+     "results": results
+   }],
+  }
+
+  print(json.dumps(sarif, indent=2))
+
+
+
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/example_linter.sh
+++ b/example_linter.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+LINE_NUMBER=0
+COLUMN_NUMBER=0
+SEVERITY="error"
+MESSAGE="example message"
+CODE="example-finding"
+
+for PATH in "${BASH_ARGV[@]}"
+do
+  echo "${PATH}:${LINE_NUMBER}:${COLUMN_NUMBER}: [${SEVERITY}] ${MESSAGE} (${CODE})"
+done

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -1,6 +1,25 @@
 version: 0.1
 lint:
   definitions:
+    - name: example
+      files: [ALL]
+      commands:
+        - output: parsable
+          run: ${actionroot}/example_linter.sh ${target}
+          success_codes: [0]
+          read_output_from: stdout
+    - name: codespell
+      files: [ALL]
+      runtime: python
+      package: codespell
+      commands:
+        - output: sarif
+          run: codespell ${target}
+          success_codes: [0, 65]
+          read_output_from: stdout
+          parser:
+            runtime: python
+            run: ${actionroot}/codespell_to_sarif.py
     - name: sqlfluff
       files: [sql]
       runtime: python
@@ -13,4 +32,3 @@ lint:
           parser:
             runtime: python
             run: ${actionroot}/sqlfluff_to_sarif.py
-


### PR DESCRIPTION
Set up `codespell`, a simple spelling linter, and `example`, a wholly custom linter which is defined 100% in the plugins repo.