### PR TITLE
feat: add cspell linter

### DIFF
--- a/trunk.yaml
+++ b/trunk.yaml
@@ -44,15 +44,18 @@ lint:
         - javascript
         - typescript
         - python
+        - php
+        - c#
         - c++-header
         - c++-source
+        - latex
         - go
         - html
         - css
       runtime: node
       package: cspell
       commands:
-        - output: parsable
+        - output: regex
           parse_regex: ((?P<path>.*):(?P<line>\d+):(?P<col>\d+) - (?P<message>.*))
           run: cspell ${target}
           batch: true

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -38,3 +38,42 @@ lint:
           parser:
             runtime: python
             run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
+
+    - name: cspell
+      files:
+        - javascript
+        - typescript
+        - python
+        - c++-header
+        - c++-source
+        - go
+        - html
+        - css
+      runtime: node
+      package: cspell
+      commands:
+        - output: parsable
+          parse_regex: ((?P<path>.*):(?P<line>\d+):(?P<col>\d+) - (?P<message>.*))
+          run: cspell ${target}
+          batch: true
+          read_output_from: stdout
+          success_codes: [0, 1]
+          cache_results: true
+      direct_configs:
+        - .cspell.json
+        - cspell.json
+        - .cSpell.json
+        - cSpell.json
+        - cspell.config.js
+        - cspell.config.cjs
+        - cspell.config.json
+        - cspell.config.yaml
+        - cspell.config.yml
+        - cspell.yaml
+        - cspell.yml
+      affects_cache:
+        - package.json
+      known_good_version: 6.5.0
+      version_command:
+        parse_regex: ${semver}
+        run: cspell --version


### PR DESCRIPTION
Add linter definition for [cspell](https://cspell.org/).

Will add PHP, C#, and LaTeX files into definition later after defining in primary trunk

Sample output: 
`/.../run.cc:120:33 - Unknown word (compelete)`