### PR TITLE
Add required_trunk_version

### DIFF
--- a/trunk.yaml
+++ b/trunk.yaml
@@ -1,4 +1,5 @@
 version: 0.1
+required_trunk_version: ">0.16.1"
 actions:
   definitions:
     - id: commitlint


### PR DESCRIPTION
Adds the required_trunk_version field to enforce trunk version stability when loading the plugin repo as a source