### PR TITLE
Define git-lfs in the plugins repo under actions

### DIFF
--- a/trunk.yaml
+++ b/trunk.yaml
@@ -8,6 +8,12 @@ actions:
       run: commitlint --edit ${1}
       triggers:
         - git_hooks: [commit-msg]
+    - id: git-lfs
+      display_name: Git LFS
+      description: Git LFS hooks
+      run: git lfs "${hook}" "${@}"
+      triggers:
+        - git_hooks: [post-checkout, post-commit, post-merge, pre-push]
 lint:
   definitions:
     # Inserts "#pragma once" if it wasn't there


### PR DESCRIPTION
Define git-lfs in the plugins actions repo. 

They'll be double defined for a bit - but namespace resolution would kick in for now until we have hoisting and then it'll be a conflict that needs resolution. In the meantime the docs point to this as an example so thought it should be in there.