### PR TITLE
Fix cspell caching so the custom dictionary path works correctly

### DIFF
--- a/.trunk/cspell-words.txt
+++ b/.trunk/cspell-words.txt
@@ -1,0 +1,10 @@
+codespell
+commitlint
+eamodio
+markdownlint
+nofail
+sarif
+scrollback
+SCRIPTDIR
+sqlfluff
+trunkio

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,7 +4,6 @@ plugins:
     - id: trunk
       ref: v0.0.4
       uri: https://github.com/trunk-io/plugins
-      local: /home/eli/Github/plugins
 cli:
   version: 0.17.0-beta
 lint:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,10 +4,12 @@ plugins:
     - id: trunk
       ref: v0.0.4
       uri: https://github.com/trunk-io/plugins
+      local: /home/eli/Github/plugins
 cli:
   version: 0.17.0-beta
 lint:
   enabled:
+    - cspell@6.8.1
     - actionlint@1.6.15
     - black@22.6.0
     - flake8@4.0.1:

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Copyright (c) 2022 Trunk Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
+in the Software without restricting, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Copyright (c) 2022 Trunk Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restricting, including without limitation the rights
+in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,9 +1,9 @@
 ---
 $schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
-version: '0.2'
+version: "0.2"
 dictionaryDefinitions:
   - name: plugin-words
-    path: '.trunk/cspell-words.txt'
+    path: ".trunk/cspell-words.txt"
     addWords: true
 dictionaries:
   - plugin-words

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,9 @@
+---
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+version: '0.2'
+dictionaryDefinitions:
+  - name: plugin-words
+    path: '.trunk/cspell-words.txt'
+    addWords: true
+dictionaries:
+  - plugin-words

--- a/readme.md
+++ b/readme.md
@@ -48,4 +48,4 @@ Read more about how to use plugins [here](https://docs.trunk.io/docs/plugins).
 
 ### Mission
 
-Our goal is to make engineering faster, more efficient and dare we say - more fun. This repository will hopefully allow our community to share ideas on the best tools and best practices/workflows to make everyones job of building code a little bit easier, a little bit faster and maybe in the process - a litte bit more fun.
+Our goal is to make engineering faster, more efficient and dare we say - more fun. This repository will hopefully allow our community to share ideas on the best tools and best practices/workflows to make everyone's job of building code a little bit easier, a little bit faster and maybe in the process - a little bit more fun.

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -61,7 +61,7 @@ lint:
       commands:
         - output: regex
           parse_regex: ((?P<path>.*):(?P<line>\d+):(?P<col>\d+) - (?P<message>.*))
-          run: cspell ${target}
+          run: cspell --no-progress --no-summary --show-suggestions ${target}
           batch: true
           read_output_from: stdout
           success_codes: [0, 1]

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -55,18 +55,7 @@ lint:
             run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
 
     - name: cspell
-      files:
-        - javascript
-        - typescript
-        - python
-        - php
-        - c#
-        - c++-header
-        - c++-source
-        - latex
-        - go
-        - html
-        - css
+      files: [ALL]
       runtime: node
       package: cspell
       commands:
@@ -76,7 +65,8 @@ lint:
           batch: true
           read_output_from: stdout
           success_codes: [0, 1]
-          cache_results: true
+          cache_results: false
+          run_linter_from: workspace
       direct_configs:
         - .cspell.json
         - cspell.json

--- a/trunk.yaml
+++ b/trunk.yaml
@@ -66,7 +66,6 @@ lint:
           read_output_from: stdout
           success_codes: [0, 1]
           cache_results: false
-          run_linter_from: workspace
       direct_configs:
         - .cspell.json
         - cspell.json


### PR DESCRIPTION
Disable cache for cspell. We don't have an include scanner in the cspell config that would tell us which files (custom dictionaries) need to be symlinked correctly to make caching work.

Fix up all spelling issues in the repo