### PR TITLE
chore: trunk.yaml -> plugin.yaml

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -5,7 +5,7 @@ plugins:
       ref: v0.0.4
       uri: https://github.com/trunk-io/plugins
 cli:
-  version: 0.17.0-beta
+  version: 0.17.0-beta.7
 lint:
   enabled:
     - cspell@6.8.1

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 version: 0.1
-required_trunk_version: ">0.16.1"
+required_trunk_version: ">=0.17.0-beta.7"
 actions:
   definitions:
     - id: commitlint


### PR DESCRIPTION
Plugin configurations are now shared using plugin.yaml, not trunk.yaml