### PR TITLE
trunk upgrade - (version, tooling)

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,5 +28,6 @@ lint:
     - shfmt@3.5.0
 actions:
   enabled:
+    - trunk-check-pre-push
     - trunk-fmt-pre-commit
     - git-lfs

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,26 +1,32 @@
 version: 0.1
+cli:
+  version: 0.17.0-beta.7
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
+    - python@3.10.3
 plugins:
   sources:
     - id: trunk
       ref: v0.0.4
       uri: https://github.com/trunk-io/plugins
-cli:
-  version: 0.17.0-beta.7
 lint:
   enabled:
-    - cspell@6.8.1
+    - cspell@6.8.2
     - actionlint@1.6.15
-    - black@22.6.0
-    - flake8@4.0.1:
+    - black@22.8.0
+    - flake8@5.0.4:
         packages:
-          - flake8-bugbear@21.9.2
+          - flake8-bugbear@22.9.11
     - git-diff-check@SYSTEM
     - gitleaks@8.8.12
     - isort@5.10.1
-    - markdownlint@0.32.0
+    - markdownlint@0.32.2
     - prettier@2.7.1
     - shellcheck@0.8.0
     - shfmt@3.5.0
 actions:
   enabled:
+    - trunk-fmt-pre-commit
     - git-lfs

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 cli:
-  version: 0.17.0-beta.7
+  version: 0.17.0-beta.8
 runtimes:
   enabled:
     - go@1.18.3


### PR DESCRIPTION
1) Upgrade trunk to latest bleeding edge
2) Upgrade tooling versions
3) Enable trunk fmt on pre-commit hook 