### PR TITLE
Disable cspell

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,7 +15,6 @@ lint:
   enabled:
     - actionlint@1.6.15
     - black@22.8.0
-    - cspell@6.8.2
     - flake8@5.0.4:
         packages:
           - flake8-bugbear@22.9.11
@@ -28,6 +27,8 @@ lint:
     - shellcheck@0.8.0
     - shfmt@3.5.0
     - yamllint@1.28.0
+  disabled:
+    - cspell
 actions:
   enabled:
     - trunk-check-pre-push


### PR DESCRIPTION
We have not yet fully audited cspell for use in this particular repo. In order to unblock other PRs, I'm disabling it here.

Future work should include doing a more comprehensive audit to create a configuration/ruleset that would be more appropriate for cspell in this repo.