### PR TITLE
Fix required_trunk_version

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,5 @@
 version: 0.1
-required_trunk_version: ">=0.18.0-beta"
-
+required_trunk_version: ">0.17.0"
 actions:
   definitions:
     - id: commitlint


### PR DESCRIPTION
Our current semver implementation needs to be more rigorous to different formats. For now, this should unblock people before we put out a v0.0.5 release