### PR TITLE
feat(actions): add `go-mod-tidy` and `go-mod-tidy-vendor` plugins

### DIFF
--- a/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
+++ b/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+go mod tidy && go mod vendor

--- a/actions/go-mod-tidy-vendor/plugin.yaml
+++ b/actions/go-mod-tidy-vendor/plugin.yaml
@@ -4,6 +4,7 @@ actions:
     - id: go-mod-tidy-vendor
       display_name: Go Mod Tidy & Vendor
       description: Runs go mod tidy followed by go mod vendor.
+      runtime: go
       run: ${plugin}/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
       triggers:
         - files: [go.mod]

--- a/actions/go-mod-tidy-vendor/plugin.yaml
+++ b/actions/go-mod-tidy-vendor/plugin.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+actions:
+  definitions:
+    - id: go-mod-tidy-vendor
+      display_name: Go Mod Tidy & Vendor
+      description: Runs go mod tidy followed by go mod vendor.
+      run: ./go-mod-tidy-vendor.sh
+      import_to_global: true
+      triggers:
+        - files: [go.mod]

--- a/actions/go-mod-tidy-vendor/plugin.yaml
+++ b/actions/go-mod-tidy-vendor/plugin.yaml
@@ -4,7 +4,6 @@ actions:
     - id: go-mod-tidy-vendor
       display_name: Go Mod Tidy & Vendor
       description: Runs go mod tidy followed by go mod vendor.
-      run: ./go-mod-tidy-vendor.sh
-      import_to_global: true
+      run: ${plugin}/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
       triggers:
         - files: [go.mod]

--- a/actions/go-mod-tidy/go-mod-tidy.sh
+++ b/actions/go-mod-tidy/go-mod-tidy.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+go mod tidy && go mod vendor

--- a/actions/go-mod-tidy/go-mod-tidy.sh
+++ b/actions/go-mod-tidy/go-mod-tidy.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-go mod tidy && go mod vendor

--- a/actions/go-mod-tidy/plugin.yaml
+++ b/actions/go-mod-tidy/plugin.yaml
@@ -4,7 +4,7 @@ actions:
     - id: go-mod-tidy
       display_name: Go Mod Tidy
       description: Runs go mod tidy when changes are detected to go.mod.
-      run: ./go-mod-tidy-vendor.sh
-      import_to_global: true
+      runtime: go
+      run: mod tidy
       triggers:
         - files: [go.mod]

--- a/actions/go-mod-tidy/plugin.yaml
+++ b/actions/go-mod-tidy/plugin.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+actions:
+  definitions:
+    - id: go-mod-tidy
+      display_name: Go Mod Tidy
+      description: Runs go mod tidy when changes are detected to go.mod.
+      run: ./go-mod-tidy-vendor.sh
+      import_to_global: true
+      triggers:
+        - files: [go.mod]

--- a/actions/go-mod-tidy/plugin.yaml
+++ b/actions/go-mod-tidy/plugin.yaml
@@ -5,6 +5,6 @@ actions:
       display_name: Go Mod Tidy
       description: Runs go mod tidy when changes are detected to go.mod.
       runtime: go
-      run: mod tidy
+      run: ${plugin}/actions/go-mod-tidy/go-mod-tidy.sh
       triggers:
         - files: [go.mod]

--- a/actions/go-mod-tidy/plugin.yaml
+++ b/actions/go-mod-tidy/plugin.yaml
@@ -5,6 +5,6 @@ actions:
       display_name: Go Mod Tidy
       description: Runs go mod tidy when changes are detected to go.mod.
       runtime: go
-      run: ${plugin}/actions/go-mod-tidy/go-mod-tidy.sh
+      run: go mod tidy
       triggers:
         - files: [go.mod]


### PR DESCRIPTION
- `go-mod-tidy` for enabling action on file change for `go.mod`.
- `go-mod-tidy-vendor` for enabling action on file change for `go.mod` that also runs go mod vendor afterward. This helps improve vendoring workflow to consistent and avoid inconsistent vendoring issues by forgetting.

executable bit is set on both scripts.