### PR TITLE
fix(actions): disable commitlint

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -47,7 +47,6 @@ actions:
             - lint/**
           run: tools/toggle-local/toggle notify ${workspace}
   enabled:
-    - commitlint
     - toggle-local
     - trunk-cache-prune
     - trunk-upgrade-available


### PR DESCRIPTION
commitlint is consistently broken for me and just screws up my commits every single time i make one

plus it doesn't make sense as a commit hook for anyone using squash-and-merge workflows: in that scenario the thing that actually matters is the merge description.