### PR TITLE
feat(linters): set up nancy, a go security linter

### DIFF
--- a/.trunk/cspell-words.txt
+++ b/.trunk/cspell-words.txt
@@ -15,3 +15,4 @@ protobuf
 runtimes
 indentless
 kwargs
+vuln

--- a/linters/nancy/parse.py
+++ b/linters/nancy/parse.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""
+nancy sleuth --output=json looks like this:
+
+```
+{
+  ...,
+  "vulnerable": [
+    {
+      "Coordinates": "pkg:golang/golang.org/x/text@v0.3.7",
+      "Reference": "https://ossindex.sonatype.org/component/pkg:golang/golang.org/x/text@v0.3.7?utm_source=nancy-client&utm_medium=integration&utm_content=1.0.41",
+      "Vulnerabilities": [
+        {
+          "ID": "CVE-2022-32149",
+          "Title": "[CVE-2022-32149] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "Description": "An attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse.",
+          "CvssScore": "7.5",
+          "CvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "Cve": "CVE-2022-32149",
+          "Reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-32149?component-type=golang&component-name=golang.org%2Fx%2Ftext&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.41",
+          "Excluded": false
+        }
+      ],
+      "InvalidSemVer": false
+    }
+  ]
+}
+```
+"""
+
+import json
+import sys
+
+
+def to_result_sarif(
+    path: str, line_number: int, column_number: int, rule_id: str, message: str
+):
+    return {
+        "level": "error",
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": path,
+                    },
+                    "region": {
+                        "startColumn": column_number,
+                        "startLine": line_number,
+                    },
+                }
+            }
+        ],
+        "message": {
+            "text": message,
+        },
+        "ruleId": rule_id,
+    }
+
+
+def main(argv):
+    results = []
+
+    nancy_output = json.load(sys.stdin)
+
+    for vuln_entry in nancy_output.get("vulnerable", []):
+        for vuln in vuln_entry.get("Vulnerabilities", []):
+            results.append(
+                to_result_sarif(
+                    ".",
+                    0,
+                    0,
+                    vuln["ID"],
+                    f'{vuln_entry["Coordinates"]} is vulnerable: {vuln["Description"]}',
+                )
+            )
+
+    sarif = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{"results": results}],
+    }
+
+    print(json.dumps(sarif, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/linters/nancy/plugin.yaml
+++ b/linters/nancy/plugin.yaml
@@ -1,0 +1,28 @@
+version: 0.1
+lint:
+  downloads:
+    - name: nancy
+      version: 1.0.41
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/sonatype-nexus-community/nancy/releases/download/v${version}/nancy-v${version}-${os}-${cpu}.tar.gz
+  definitions:
+    - name: nancy
+      download: nancy
+      runtime: go
+      commands:
+        - output: sarif
+          run: ${plugin}/linters/nancy/run.sh sleuth
+          success_codes: [0, 1]
+          read_output_from: stdout
+          parser:
+            runtime: python
+            run: ${plugin}/linters/nancy/parse.py
+      environment:
+        - name: PATH
+          list: ["${runtime}", "${linter}", "${env.PATH}"]

--- a/linters/nancy/run.sh
+++ b/linters/nancy/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+go list -json -deps ./... | nancy sleuth --output=json


### PR DESCRIPTION
Nancy checks the Go dependency graph against the Sonatype OSS index.

Nancy comes in two flavors, sleuth and IQ, but only sleuth advertises a JSON output format, so we leave IQ alone for now.

Also, sleuth can run into rate limits that require authz tokens to bypass; see
https://github.com/sonatype-nexus-community/nancy#oss-index-options.