### PR TITLE
feat: Upgrade required_trunk_version. 

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 version: 0.1
-required_trunk_version: ">0.17.0"
+required_trunk_version: ">1.0.0"
 lint:
   files:
     - name: dml


### PR DESCRIPTION
trunk 1.0.1 has support for the new plugin.yaml recursive layout. Next release of plugins repo will require at least trunk v1.0.1


