### PR TITLE
consolidate sqlfluff definitions

### DIFF
--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -17,7 +17,7 @@ lint:
             runtime: python
             run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
         - name: fix
-          run: sqlfluff fix ${target} --dialect ansi --disable_progress_bar --force
+          run: sqlfluff fix ${target} --dialect ansi --disable-progress-bar --force
           output: rewrite
           formatter: true
           in_place: true

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -16,14 +16,6 @@ lint:
           parser:
             runtime: python
             run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
-
-    - name: sqlfluff-fix
-      files: [sql, sql-j2, dml, ddl]
-      runtime: python
-      package: sqlfluff
-      direct_configs:
-        - .sqlfluff
-      commands:
         - name: fix
           run: sqlfluff fix ${target} --dialect ansi --disable_progress_bar --force
           output: rewrite


### PR DESCRIPTION
It looks like this bug has been fixed since it was filed; we can replace the definition - https://linear.app/trunk/issue/TRUNK-4669/sqlfluff-fix-how-mutliple-commands-are-resolved-for-formatters-and