### PR TITLE
`git-lfs`: Unquote hook params in run command

### DIFF
--- a/actions/git/plugin.yaml
+++ b/actions/git/plugin.yaml
@@ -4,6 +4,6 @@ actions:
     - id: git-lfs
       display_name: Git LFS
       description: Git LFS hooks
-      run: git lfs "${hook}" "${@}"
+      run: git lfs "${hook}" ${@}
       triggers:
         - git_hooks: [post-checkout, post-commit, post-merge, pre-push]


### PR DESCRIPTION
`git lfs "<hook>"` expects all hook arguments to follow separately, not as one single command. Note that this bug doesn't appear in our current hooks implementation because `base::ShlexSplit` (I believe) strips the quotation marks from `"${@}"` in our run command, which makes our parser instead insert every argument separately.