### PR TITLE
Add instructions for multiple subcommands where only one is recommended

### DIFF
--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -22,6 +22,7 @@ lint:
           formatter: true
           in_place: true
           success_codes: [0]
+          enabled: false
 
     - name: sqlfluff-fix
       files: [sql, sql-j2, dml, ddl]

--- a/readme.md
+++ b/readme.md
@@ -57,3 +57,41 @@ Read more about how to use plugins [here](https://docs.trunk.io/docs/plugins).
 ### Mission
 
 Our goal is to make engineering faster, more efficient and dare we say - more fun. This repository will hopefully allow our community to share ideas on the best tools and best practices/workflows to make everyone's job of building code a little bit easier, a little bit faster and maybe in the process - a little bit more fun.
+
+### Additional Reference
+
+Some linters provide built-in formatters or autofix options that don't always produce ideal outputs, especially in conjunction with other formatters. Trunk supports defining autofix options for these linters, but has their formatting turned off by default. An example of this is [sqlfluff](./linters/sqlfluff/plugin.yaml):
+
+```yaml
+- name: sqlfluff
+  files: [sql, sql-j2, dml, ddl]
+  runtime: python
+  package: sqlfluff
+  direct_configs:
+    - .sqlfluff
+  commands:
+    - name: lint
+      run: sqlfluff lint ${target} --format json --dialect ansi --nofail
+      output: sarif
+      success_codes: [0]
+      read_output_from: stdout
+      parser:
+        runtime: python
+        run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
+    - name: fix
+      run: sqlfluff fix ${target} --dialect ansi --disable-progress-bar --force
+      output: rewrite
+      formatter: true
+      in_place: true
+      success_codes: [0]
+      enabled: false
+```
+
+The `fix` subcommand has `enabled: false`, so when you run `trunk check enable sqlfluff`, only the `lint` subcommand is enabled. To override this behavior in your trunk.yaml, specify commands:
+
+```yaml
+lint:
+  enabled:
+    - sqlfluff:
+        commands: [lint, fix]
+```


### PR DESCRIPTION
Turns off sqlfluff's `fix` subcommand by default, and provides instructions to turn it on.