### PR TITLE
Cache downloads on PR runs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
   plugins_test:
     name: Plugins Test Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     strategy:
       matrix:
         linter-version: [KnownGoodVersion, Latest]
@@ -34,12 +34,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache test downloads
+      - name: Cache tool downloads
         uses: actions/cache@v3
         with:
           path: /tmp/plugins_testing_download_cache
-          # key on .trunk/trunk.yaml since tests are dependent on trunk cli versionß
-          key: trunk-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
+          # No need to key on trunk version unless we change how we store downloads.
+          key: trunk-${{ runner.os }}
 
       - name: Locate trunk
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache test downloads
+        uses: actions/cache@v3
+        with:
+          path: /tmp/plugins_testing_download_cache
+          # key on .trunk/trunk.yaml since tests are dependent on trunk cli versionß
+          key: trunk-${{ runner.os }}-${{ hashFiles('.trunk/trunk.yaml') }}
+
       - name: Locate trunk
         shell: bash
         run: ./locate_trunk.sh

--- a/setup.ts
+++ b/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(60000); // milliseconds
+jest.setTimeout(120000); // milliseconds

--- a/tests/driver/index.ts
+++ b/tests/driver/index.ts
@@ -327,7 +327,7 @@ export class TrunkDriver {
     targetAbsPath?: string;
     resultJsonPath?: string;
   }) {
-    const fullArgs = `check -n --output-file=${resultJsonPath} --no-progress ${args}`;
+    const fullArgs = `check -n --output-file=${resultJsonPath} --no-progress --ignore-git-state ${args}`;
     try {
       const { stdout, stderr } = await this.run(fullArgs);
       return this.parseRunResult(
@@ -384,7 +384,7 @@ export class TrunkDriver {
     const targetAbsPath = path.resolve(this.sandboxPath ?? "", targetRelativePath);
     const resultJsonPath = `${targetAbsPath}.json`;
 
-    const args = `fmt --output-file=${resultJsonPath} --no-progress --filter=${linter} ${targetAbsPath}`;
+    const args = `fmt --output-file=${resultJsonPath} --no-progress --ignore-git-state --filter=${linter} ${targetAbsPath}`;
 
     try {
       this.debug("Running `trunk fmt` on %s", targetRelativePath);


### PR DESCRIPTION
Accomplishes two things:
1. Cache linter downloads across PR runs
2. Fixes a small bug with how preCheck and postCheck callbacks are invoked (this is an important fix for getting git-diff-check working).

When running 20+ tests, this brought the PR time from 10+ minutes down to 4 minutes. I still have some timeouts to investigate on large numbers of tests in CI.

I don't think there's a real need to flush/reset these downloads, but when we add nightly workflows we can implement that.