### PR TITLE
Add sort-package-json

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,6 +53,5 @@ jobs:
         run: npm ci
 
       - name: Run plugin tests
-        run:
-          PATH=$(npm bin):$PATH PLUGINS_TEST_LINTER_VERSION=${{ matrix.linter-version }} npm test
-          --ci
+        run: |
+          PATH=$(npm bin):$PATH PLUGINS_TEST_LINTER_VERSION=${{ matrix.linter-version }} npm test --ci

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,21 +14,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node
+      - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 18
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
 
   plugins_test:
-    name: Plugins Test Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
+    name: Plugin Tests
+    # trunk-ignore(actionlint/runner-label)
+    runs-on: [ubuntu-latest-8-cores]
+    timeout-minutes: 60
     strategy:
       matrix:
         linter-version: [KnownGoodVersion, Latest]
@@ -44,13 +45,15 @@ jobs:
           # No need to key on trunk version unless we change how we store downloads.
           key: trunk-${{ runner.os }}
 
-      - name: Setup Node
+      - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 18
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Run Plugin Tests
-        run: PATH=$(npm bin):$PATH PLUGINS_TEST_LINTER_VERSION=${{ matrix.linter-version }} npm test
+      - name: Run plugin tests
+        run:
+          PATH=$(npm bin):$PATH PLUGINS_TEST_LINTER_VERSION=${{ matrix.linter-version }} npm test
+          --ci

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,9 +27,7 @@ jobs:
 
   plugins_test:
     name: Plugin Tests
-    runs-on:
-      # trunk-ignore(actionlint/syntax-check)
-      labels: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,8 +27,9 @@ jobs:
 
   plugins_test:
     name: Plugin Tests
-    # trunk-ignore(actionlint/runner-label)
-    runs-on: [ubuntu-latest-8-cores]
+    runs-on:
+      # trunk-ignore(actionlint/syntax-check)
+      labels: ubuntu-latest-8-cores
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.3.0
+  version: 1.3.1
 
 plugins:
   sources:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.2.1
+  version: 1.3.0
 
 plugins:
   sources:
@@ -19,7 +19,7 @@ lint:
   enabled:
     - actionlint@1.6.22
     - black@22.12.0
-    - eslint@8.30.0
+    - eslint@8.31.0
     - flake8@6.0.0:
         packages:
           - flake8-bugbear@22.12.6

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -32,6 +32,7 @@ lint:
     - shellcheck@0.9.0
     - shfmt@3.5.0
     - sqlfluff@1.4.5
+    - taplo@0.7.0
     - yamllint@1.28.0
 
   ignore:

--- a/linters/sort-package-json/plugin.yaml
+++ b/linters/sort-package-json/plugin.yaml
@@ -1,0 +1,20 @@
+version: 0.1
+lint:
+  files:
+    - name: package-json
+      filenames: [package.json]
+
+  definitions:
+    - name: sort-package-json
+      files: [package-json]
+      commands:
+        - name: format
+          output: rewrite
+          run: sort-package-json ${target}
+          success_codes: [0]
+          in_place: true
+          formatter: true
+      runtime: node
+      package: sort-package-json
+      # good_without_config: true # decide whether this is something we want on by default
+      known_good_version: 2.1.0

--- a/tests/test_coverage.test.ts
+++ b/tests/test_coverage.test.ts
@@ -10,6 +10,7 @@ const excludedLinters: string[] = [
   "cspell",
   "nancy",
   "oxipng",
+  "sort-package-json",
   "sqlfmt",
   "trivy",
 ];


### PR DESCRIPTION
- Tested locally
- We need to upgrade the testing code to support "in" files for formatting that have a specific name, not a prefix (package.json must be named package.json for the tool to accept it)
- This tool has no --version command, or any cmd line args really 😆 

I think I'd like to mark this `good_without_config`, but need to make sure _most_ people will actually want their package.json sorted in this way first.