### PR TITLE
Testing improvements to support more linters

### DIFF
--- a/linters/buf/buf.test.ts
+++ b/linters/buf/buf.test.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import * as path from "path";
 import { linterCheckTest, linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
@@ -6,12 +5,9 @@ import { TEST_DATA } from "tests/utils";
 
 // buf-breaking detects breaking changes to proto files by using git-awareness
 const preCheck = async (driver: TrunkDriver) => {
-  if (driver.sandboxPath && driver.gitDriver) {
-    // trunk-ignore-begin(semgrep): driver.sandboxPath is generated deterministically and is safe
-    const testPath = path.resolve(driver.sandboxPath, TEST_DATA);
+  if (driver.gitDriver) {
     const inputName = "buf_breaking.in.proto";
-    const inputPath = path.resolve(testPath, inputName);
-    // trunk-ignore-end(semgrep)
+    const inputPath = path.join(TEST_DATA, inputName);
 
     const newContents = `
     syntax = "proto3";
@@ -26,7 +22,7 @@ const preCheck = async (driver: TrunkDriver) => {
     `;
 
     await driver.gitDriver.add(inputPath).commit("Committed original version");
-    fs.writeFileSync(inputPath, newContents);
+    driver.writeFile(inputPath, newContents);
   }
 };
 

--- a/linters/detekt/detekt.test.ts
+++ b/linters/detekt/detekt.test.ts
@@ -1,14 +1,9 @@
-import * as fs from "fs";
-import * as path from "path";
 import { linterCheckTest } from "tests";
 import { TrunkDriver } from "tests/driver";
 
 // Running check on the input manually requires the existence of a top level .detekt.yaml
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath) {
-    // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-    fs.writeFileSync(path.resolve(driver.sandboxPath, ".detekt.yaml"), "");
-  }
+  driver.writeFile(".detekt.yaml", "");
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving failure modes.

--- a/linters/git-diff-check/git_diff_check.test.ts
+++ b/linters/git-diff-check/git_diff_check.test.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import * as path from "path";
 import { linterCheckTest } from "tests";
 import { TrunkDriver } from "tests/driver";
@@ -6,19 +5,16 @@ import { TEST_DATA } from "tests/utils";
 
 // Simulate the creation of a merge conflict
 const preCheck = async (driver: TrunkDriver) => {
-  if (driver.sandboxPath && driver.gitDriver) {
-    // trunk-ignore-begin(semgrep): driver.sandboxPath is generated deterministically and is safe
-    const testPath = path.resolve(driver.sandboxPath, TEST_DATA);
+  if (driver.gitDriver) {
     const inputName = "basic.in.txt";
-    const inputPath = path.resolve(testPath, inputName);
-    // trunk-ignore-end(semgrep)
+    const inputPath = path.join(TEST_DATA, inputName);
 
     await driver.gitDriver.checkoutLocalBranch("branchA");
-    fs.writeFileSync(inputPath, "Branch A contents");
+    driver.writeFile(inputPath, "Branch A contents");
     await driver.gitDriver.add(inputPath).commit("Branch A changes");
 
     await driver.gitDriver.checkoutBranch("branchB", "main");
-    fs.writeFileSync(inputPath, "Branch B contents");
+    driver.writeFile(inputPath, "Branch B contents");
     await driver.gitDriver.add(inputPath).commit("Branch B changes");
 
     try {

--- a/linters/ktlint/ktlint.test.ts
+++ b/linters/ktlint/ktlint.test.ts
@@ -1,19 +1,9 @@
-import fs from "fs";
-import path from "path";
 import { linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
-import { REPO_ROOT } from "tests/utils";
 
 // Grab the root .editorconfig
-// TODO(Tyler): This is something we should automatically do by default in the TrunkDriver
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath) {
-    fs.copyFileSync(
-      path.resolve(REPO_ROOT, ".editorconfig"),
-      // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-      path.resolve(driver.sandboxPath, ".editorconfig")
-    );
-  }
+  driver.copyFileFromRoot(".editorconfig");
 };
 
 linterFmtTest({ linterName: "ktlint", preCheck });

--- a/linters/prettier/prettier.test.ts
+++ b/linters/prettier/prettier.test.ts
@@ -1,19 +1,9 @@
-import fs from "fs";
-import path from "path";
 import { linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
-import { REPO_ROOT } from "tests/utils";
 
 // Grab the root .prettierrc.yaml
-// TODO(Tyler): This is something we should automatically do by default in the TrunkDriver
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath) {
-    fs.copyFileSync(
-      path.resolve(REPO_ROOT, ".trunk/configs/.prettierrc.yaml"),
-      // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-      path.resolve(driver.sandboxPath, ".prettierrc.yaml")
-    );
-  }
+  driver.copyFileFromRoot(".trunk/configs/.prettierrc.yaml");
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving other file types.

--- a/linters/scalafmt/scalafmt.test.ts
+++ b/linters/scalafmt/scalafmt.test.ts
@@ -1,18 +1,10 @@
-import fs from "fs";
-import path from "path";
 import { linterCheckTest, linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
 
 // Add a .scalafmt.confg (required to run)
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath) {
-    fs.writeFileSync(
-      // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-      path.resolve(driver.sandboxPath, ".scalafmt.conf"),
-      // version in .scalafmt.conf must match the enabled version
-      `version = ${driver.enabledVersion ?? "3.4.3"}\nrunner.dialect = scala3`
-    );
-  }
+  const contents = `version = ${driver.enabledVersion ?? "3.4.3"}\nrunner.dialect = scala3`;
+  driver.writeFile(".scalafmt.conf", contents);
 };
 
 // scalafmt succeeds on empty files

--- a/linters/shfmt/shfmt.test.ts
+++ b/linters/shfmt/shfmt.test.ts
@@ -1,19 +1,9 @@
-import fs from "fs";
-import path from "path";
 import { linterCheckTest, linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
-import { REPO_ROOT } from "tests/utils";
 
 // Grab the root .editorconfig
-// TODO(Tyler): This is something we should automatically do by default in the TrunkDriver
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath) {
-    fs.copyFileSync(
-      path.resolve(REPO_ROOT, ".editorconfig"),
-      // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-      path.resolve(driver.sandboxPath, ".editorconfig")
-    );
-  }
+  driver.copyFileFromRoot(".editorconfig");
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving formatting behavior.

--- a/linters/sort-package-json/sort_package_json.test.ts
+++ b/linters/sort-package-json/sort_package_json.test.ts
@@ -1,0 +1,17 @@
+import path from "path";
+import { customLinterCheckTest, customLinterFmtTest } from "tests";
+import { TrunkDriver } from "tests/driver";
+import { TEST_DATA } from "tests/utils";
+
+const preCheck = (driver: TrunkDriver) => {
+  driver.moveFile(path.join(TEST_DATA, "bad_package.json"), path.join(TEST_DATA, "package.json"));
+};
+
+customLinterFmtTest({
+  linterName: "sort-package-json",
+  args: "--all",
+  pathsToSnapshot: [path.join(TEST_DATA, "package.json")],
+});
+
+// Run with check to assert error behavior when malformed json
+customLinterCheckTest({ linterName: "sort-package-json", args: "--all", preCheck });

--- a/linters/sort-package-json/sort_package_json.test.ts
+++ b/linters/sort-package-json/sort_package_json.test.ts
@@ -3,6 +3,7 @@ import { customLinterCheckTest, customLinterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
 import { TEST_DATA } from "tests/utils";
 
+// Use file with malformed json
 const preCheck = (driver: TrunkDriver) => {
   driver.moveFile(path.join(TEST_DATA, "bad_package.json"), path.join(TEST_DATA, "package.json"));
 };

--- a/linters/sort-package-json/sort_package_json.test.ts
+++ b/linters/sort-package-json/sort_package_json.test.ts
@@ -3,16 +3,16 @@ import { customLinterCheckTest, customLinterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
 import { TEST_DATA } from "tests/utils";
 
-// Use file with malformed json
-const preCheck = (driver: TrunkDriver) => {
-  driver.moveFile(path.join(TEST_DATA, "bad_package.json"), path.join(TEST_DATA, "package.json"));
-};
-
 customLinterFmtTest({
   linterName: "sort-package-json",
   args: "--all",
   pathsToSnapshot: [path.join(TEST_DATA, "package.json")],
 });
+
+// Use file with malformed json
+const preCheck = (driver: TrunkDriver) => {
+  driver.moveFile(path.join(TEST_DATA, "bad_package.json"), path.join(TEST_DATA, "package.json"));
+};
 
 // Run with check to assert error behavior when malformed json
 customLinterCheckTest({ linterName: "sort-package-json", args: "--all", preCheck });

--- a/linters/sort-package-json/test_data/bad_package.json
+++ b/linters/sort-package-json/test_data/bad_package.json
@@ -1,0 +1,42 @@
+{
+  "private": true,
+  "devDependencies": {
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-node": "^11.1.0"
+    "eslint-plugin-jest": "^27.1.7",
+    "eslint-plugin-prefer-arrow-functions": "^3.1.4",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
+    "@types/jest": "^29.2.4",
+    "@types/debug": "^4.1.7",
+    "@types/caller": "^1.0.0",
+    "@trunkio/launcher": "^1.2.3"
+    "@types/jest-specific-snapshot": "^0.5.6",
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
+    "debug": "^4.3.4",
+    "caller": "^1.1.0",
+    "eslint": "^8.30.0",
+    "jest": "^29.3.1",
+    "fast-sort": "^3.2.0",
+    "jest-specific-snapshot": "^7.0.0",
+    "semver": "^7.3.8",
+    "ts-jest": "^29.0.3",
+    "simple-git": "^3.15.1",
+    "ts-node": "^10.9.1",
+    "yaml": "^2.2.0",
+    "typescript": "^4.9.4",
+  },
+  "scripts": {
+    "trunk": "trunk",
+    "test": "jest"
+  },
+  "engines": {
+    "node": ">=16",
+  },
+  "bundleDependencies": [
+    "tests"
+  ]
+}

--- a/linters/sort-package-json/test_data/package.json
+++ b/linters/sort-package-json/test_data/package.json
@@ -1,0 +1,42 @@
+{
+  "private": true,
+  "devDependencies": {
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-jest": "^27.1.7",
+    "eslint-plugin-prefer-arrow-functions": "^3.1.4",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
+    "@types/jest": "^29.2.4",
+    "@types/debug": "^4.1.7",
+    "@types/caller": "^1.0.0",
+    "@trunkio/launcher": "^1.2.3",
+    "@types/jest-specific-snapshot": "^0.5.6",
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
+    "debug": "^4.3.4",
+    "caller": "^1.1.0",
+    "eslint": "^8.30.0",
+    "jest": "^29.3.1",
+    "fast-sort": "^3.2.0",
+    "jest-specific-snapshot": "^7.0.0",
+    "semver": "^7.3.8",
+    "ts-jest": "^29.0.3",
+    "simple-git": "^3.15.1",
+    "ts-node": "^10.9.1",
+    "yaml": "^2.2.0",
+    "typescript": "^4.9.4"
+  },
+  "scripts": {
+    "trunk": "trunk",
+    "test": "jest"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "bundleDependencies": [
+    "tests"
+  ]
+}

--- a/linters/sort-package-json/test_data/sort_package-json_v2.1.0_CUSTOM.check.shot
+++ b/linters/sort-package-json/test_data/sort_package-json_v2.1.0_CUSTOM.check.shot
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter sort-package-json test CUSTOM 1`] = `
+Object {
+  "issues": Array [],
+  "lintActions": Array [],
+  "taskFailures": Array [
+    Object {
+      "message": "test_data/package.json",
+      "name": "sort-package-json",
+    },
+  ],
+  "unformattedFiles": Array [],
+}
+`;

--- a/linters/sort-package-json/test_data/sort_package-json_v2.1.0_test_data.package.json.fmt.shot
+++ b/linters/sort-package-json/test_data/sort_package-json_v2.1.0_test_data.package.json.fmt.shot
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter sort-package-json test CUSTOM 1`] = `
+"{
+  \\"private\\": true,
+  \\"scripts\\": {
+    \\"test\\": \\"jest\\",
+    \\"trunk\\": \\"trunk\\"
+  },
+  \\"devDependencies\\": {
+    \\"@trunkio/launcher\\": \\"^1.2.3\\",
+    \\"@types/caller\\": \\"^1.0.0\\",
+    \\"@types/debug\\": \\"^4.1.7\\",
+    \\"@types/jest\\": \\"^29.2.4\\",
+    \\"@types/jest-specific-snapshot\\": \\"^0.5.6\\",
+    \\"@types/node\\": \\"^18.11.18\\",
+    \\"@typescript-eslint/eslint-plugin\\": \\"^5.47.1\\",
+    \\"caller\\": \\"^1.1.0\\",
+    \\"debug\\": \\"^4.3.4\\",
+    \\"eslint\\": \\"^8.30.0\\",
+    \\"eslint-config-prettier\\": \\"^8.5.0\\",
+    \\"eslint-import-resolver-typescript\\": \\"^3.5.2\\",
+    \\"eslint-plugin-import\\": \\"^2.26.0\\",
+    \\"eslint-plugin-jest\\": \\"^27.1.7\\",
+    \\"eslint-plugin-node\\": \\"^11.1.0\\",
+    \\"eslint-plugin-prefer-arrow-functions\\": \\"^3.1.4\\",
+    \\"eslint-plugin-prettier\\": \\"^4.2.1\\",
+    \\"eslint-plugin-simple-import-sort\\": \\"^8.0.0\\",
+    \\"fast-sort\\": \\"^3.2.0\\",
+    \\"jest\\": \\"^29.3.1\\",
+    \\"jest-specific-snapshot\\": \\"^7.0.0\\",
+    \\"semver\\": \\"^7.3.8\\",
+    \\"simple-git\\": \\"^3.15.1\\",
+    \\"ts-jest\\": \\"^29.0.3\\",
+    \\"ts-node\\": \\"^10.9.1\\",
+    \\"typescript\\": \\"^4.9.4\\",
+    \\"yaml\\": \\"^2.2.0\\"
+  },
+  \\"bundleDependencies\\": [
+    \\"tests\\"
+  ],
+  \\"engines\\": {
+    \\"node\\": \\">=16\\"
+  }
+}
+"
+`;

--- a/linters/sqlfluff/sqlfluff.test.ts
+++ b/linters/sqlfluff/sqlfluff.test.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-import path from "path";
 import { linterCheckTest, linterFmtTest, TestCallback } from "tests";
 
 // basic_check.out.json is the result of running:
@@ -9,15 +7,14 @@ linterCheckTest({ linterName: "sqlfluff", namedTestPrefixes: ["basic_check"] });
 // Due to sqlfluff's fix subcommand being disabled by default, we need to manually enable it in our test's
 // trunk.yaml.
 const fmtCallbacks: TestCallback = (driver) => {
-  // trunk-ignore(semgrep): driver.sandboxPath is generated deterministically and is safe
-  const trunkYamlPath = path.resolve(driver.sandboxPath ?? "", ".trunk/trunk.yaml");
-  const currentContents = fs.readFileSync(trunkYamlPath, "utf8");
+  const trunkYamlPath = ".trunk/trunk.yaml";
+  const currentContents = driver.readFile(trunkYamlPath);
   const sqlfluffRegex = /- sqlfluff@((\d.?)+)\n/;
   const newContents = currentContents.replace(
     sqlfluffRegex,
     "- sqlfluff@$1:\n        commands: [lint, fix]\n"
   );
-  fs.writeFileSync(trunkYamlPath, newContents);
+  driver.writeFile(trunkYamlPath, newContents);
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving failure modes.

--- a/linters/stylelint/stylelint.test.ts
+++ b/linters/stylelint/stylelint.test.ts
@@ -1,18 +1,10 @@
 import { execSync } from "child_process";
-import * as fs from "fs";
-import * as path from "path";
 import { linterCheckTest, linterFmtTest } from "tests";
 import { TrunkDriver } from "tests/driver";
 
 // stylelint requires additional install steps
 const preCheck = (driver: TrunkDriver) => {
-  if (driver.sandboxPath && driver.gitDriver) {
-    // trunk-ignore-begin(semgrep): driver.sandboxPath is generated deterministically and is safe
-    const packageJsonPath = path.resolve(driver.sandboxPath, "package.json");
-    const configDir = path.resolve(driver.sandboxPath, ".trunk/configs");
-    const configPath = path.resolve(configDir, ".stylelintrc");
-    // trunk-ignore-end(semgrep)
-
+  if (driver.gitDriver) {
     const packageJsonContents = `
 {
   "private": true,
@@ -28,10 +20,9 @@ const preCheck = (driver: TrunkDriver) => {
 }
     `;
 
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.writeFileSync(packageJsonPath, packageJsonContents);
-    fs.writeFileSync(configPath, stylelintContents);
-    execSync("npm install", { cwd: driver.sandboxPath });
+    driver.writeFile("package.json", packageJsonContents);
+    driver.writeFile(".trunk/configs/.stylelintrc", stylelintContents);
+    execSync("npm install", { cwd: driver.getSandbox() });
   }
 };
 

--- a/tests/driver/index.ts
+++ b/tests/driver/index.ts
@@ -373,7 +373,7 @@ export class TrunkDriver {
    */
   async run(args: string, execOptions?: ExecOptions) {
     const trunkPath = ARGS.cliPath ?? "trunk";
-    return await execFilePromise(trunkPath, args.split(" "), {
+    return await execFilePromise(trunkPath, args.split(" ").filter(Boolean), {
       cwd: this.sandboxPath,
       env: executionEnv(this.sandboxPath ?? ""),
       ...execOptions,

--- a/tests/driver/index.ts
+++ b/tests/driver/index.ts
@@ -236,11 +236,23 @@ export class TrunkDriver {
 
   /**** Repository file manipulation ****/
 
+  /**
+   * Returns the generated sandboxPath for this test. Throws if setup has not yet been called.
+   */
   getSandbox(): string {
     if (!this.sandboxPath) {
       throw new Error(UNINITIALIZED_ERROR);
     }
     return this.sandboxPath;
+  }
+
+  /**
+   * Reads the contents of the file at `relPath`, relative to the sandbox root.
+   */
+  readFile(relPath: string): string {
+    const sandboxPath = this.getSandbox();
+    const targetPath = path.resolve(sandboxPath, relPath);
+    return fs.readFileSync(targetPath, "utf8");
   }
 
   /**

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -11,6 +11,8 @@ const toMatchSpecificSnapshot = specific_snapshot.toMatchSpecificSnapshot;
 
 const baseDebug = Debug("Tests");
 
+const CUSTOM_SNAPSHOT_PREFIX = "CUSTOM";
+
 export type TestCallback = (driver: TrunkDriver) => unknown;
 
 /**
@@ -79,11 +81,168 @@ export const setupDriver = (
 };
 
 /**
+ * Test that running a linter filtered by `linterName` with any custom `args` produces the desired output
+ * json. Optionally specify additional file paths to snapshot.
+ * Prefer using `linterCheckTest` unless additional specification is needed.
+ * @param dirname absolute path to the linter subdirectory.
+ * @param linterName linter to enable and filter on.
+ * @param args args to append to the `trunk check` call (e.g. file paths, flags, etc.)
+ * @param pathsToSnapshot file paths that should be used to generate snapshots, such as for when passing `-y` as an arg.
+ *                        Paths should be relative to the specific linter subdirectory (or relative to the sandbox root).
+ * @param preCheck callback to run during setup
+ * @param postCheck callback to run for additional assertions from the base snapshot
+ */
+export const customLinterCheckTest = ({
+  linterName,
+  dirname = path.dirname(caller()),
+  args = "",
+  pathsToSnapshot = [],
+  preCheck,
+  postCheck,
+}: {
+  linterName: string;
+  dirname?: string;
+  args?: string;
+  pathsToSnapshot?: string[];
+  preCheck?: TestCallback;
+  postCheck?: TestCallback;
+}) => {
+  describe(`Testing linter ${linterName}`, () => {
+    // Step 1: Detect versions to test against if PLUGINS_TEST_LINTER_VERSION=Snapshots
+    const linterVersions = getVersionsForTest(dirname, linterName, CUSTOM_SNAPSHOT_PREFIX, "check");
+    linterVersions.forEach((linterVersion) => {
+      // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
+      describe("test", () => {
+        // Step 2: Define test setup and teardown
+        const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+
+        // Step 3: Run the test
+        it(CUSTOM_SNAPSHOT_PREFIX, async () => {
+          const debug = baseDebug.extend(driver.debugNamespace);
+
+          const testRunResult = await driver.runCheck({ args, linter: linterName });
+          expect(testRunResult).toMatchObject({
+            success: true,
+          });
+
+          // Step 4a: Verify that the output matches expected snapshots for that linter version.
+          // See `getSnapshotPathForAssert` and `linterCheckTest` for explanation of snapshot logic.
+          const snapshotDir = path.resolve(dirname, TEST_DATA);
+          const primarySnapshotPath = getSnapshotPathForAssert(
+            snapshotDir,
+            linterName,
+            CUSTOM_SNAPSHOT_PREFIX,
+            "check",
+            driver.enabledVersion
+          );
+          debug("Using snapshot %s", path.basename(primarySnapshotPath));
+          expect(testRunResult.landingState).toMatchSpecificSnapshot(primarySnapshotPath);
+
+          // Step 4b: Verify that any specified files match their expected snapshots for that linter version.
+          pathsToSnapshot.forEach((pathToSnapshot) => {
+            const normalizedName = pathToSnapshot.replace("/", ".");
+            const snapshotPath = getSnapshotPathForAssert(
+              snapshotDir,
+              linterName,
+              normalizedName,
+              "check",
+              driver.enabledVersion
+            );
+            debug("Using snapshot %s", path.basename(snapshotPath));
+            expect(driver.readFile(pathToSnapshot)).toMatchSpecificSnapshot(snapshotPath);
+          });
+        });
+
+        if (postCheck) {
+          postCheck(driver);
+          driver.debug("Finished running custom postCheck hook");
+        }
+      });
+    });
+  });
+};
+
+/**
+ * Test that running a linter filtered by `linterName` with any custom `args` produces the desired output
+ * json. Optionally specify additional file paths to snapshot.
+ * Prefer using `linterFmtTest` unless additional specification is needed.
+ * @param dirname absolute path to the linter subdirectory.
+ * @param linterName linter to enable and filter on.
+ * @param args args to append to the `trunk fmt` call (e.g. file paths, flags, etc.)
+ * @param pathsToSnapshot file paths that should be used to generate snapshots, such as for when passing `-y` as an arg.
+ *                        Paths should be relative to the specific linter subdirectory (or relative to the sandbox root).
+ * @param preCheck callback to run during setup
+ * @param postCheck callback to run for additional assertions from the base snapshot
+ */
+export const customLinterFmtTest = ({
+  linterName,
+  dirname = path.dirname(caller()),
+  args = "",
+  pathsToSnapshot = [],
+  preCheck,
+  postCheck,
+}: {
+  linterName: string;
+  dirname?: string;
+  args?: string;
+  pathsToSnapshot?: string[];
+  preCheck?: TestCallback;
+  postCheck?: TestCallback;
+}) => {
+  describe(`Testing linter ${linterName}`, () => {
+    // Step 1: Detect versions to test against if PLUGINS_TEST_LINTER_VERSION=Snapshots
+    const linterVersions = getVersionsForTest(dirname, linterName, CUSTOM_SNAPSHOT_PREFIX, "fmt");
+    linterVersions.forEach((linterVersion) => {
+      // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
+      describe("test", () => {
+        // Step 2: Define test setup and teardown
+        const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+
+        // Step 3: Run the test
+        it(CUSTOM_SNAPSHOT_PREFIX, async () => {
+          const debug = baseDebug.extend(driver.debugNamespace);
+
+          const testRunResult = await driver.runFmt({ args, linter: linterName });
+          expect(testRunResult).toMatchObject({
+            success: true,
+            landingState: {
+              taskFailures: [],
+            },
+          });
+
+          // Step 4: Verify that any specified files match their expected snapshots for that linter version.
+          const snapshotDir = path.resolve(dirname, TEST_DATA);
+          pathsToSnapshot.forEach((pathToSnapshot) => {
+            const normalizedName = pathToSnapshot.replace("/", ".");
+            const snapshotPath = getSnapshotPathForAssert(
+              snapshotDir,
+              linterName,
+              normalizedName,
+              "fmt",
+              driver.enabledVersion
+            );
+            debug("Using snapshot %s", path.basename(snapshotPath));
+            expect(driver.readFile(pathToSnapshot)).toMatchSpecificSnapshot(snapshotPath);
+          });
+        });
+
+        if (postCheck) {
+          postCheck(driver);
+          driver.debug("Finished running custom postCheck hook");
+        }
+      });
+    });
+  });
+};
+
+/**
  * Test that running a linter filtered by `linterName` on the test files in test_data in `dirname` produces the desired output
  * json. Either detect input files automatically, or specify their prefixes as `namedTestPrefixes`.
  * @param dirname absolute path to the linter subdirectory.
  * @param linterName linter to enable and filter on.
  * @param namedTestPrefixes for input `test_data/basic.in.py`, prefix is `basic`
+ * @param preCheck callback to run during setup
+ * @param postCheck callback to run for additional assertions from the base snapshot
  */
 export const linterCheckTest = ({
   linterName,
@@ -106,7 +265,7 @@ export const linterCheckTest = ({
       // Step 1b: Detect versions to test against if PLUGINS_TEST_LINTER_VERSION=Snapshots
       const linterVersions = getVersionsForTest(dirname, linterName, prefix, "check");
       linterVersions.forEach((linterVersion) => {
-        // TODO(Tyler): Find a reliable way to replace the name "test" that doesn't violate snapshot export names.
+        // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
           const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
@@ -119,6 +278,7 @@ export const linterCheckTest = ({
               success: true,
             });
 
+            // Step 4: Verify that the output matches expected snapshots for that linter version.
             // If the linter being tested is versioned, the latest matching snapshot version will be asserted against.
             // If args.PLUGINS_TEST_UPDATE_SNAPSHOTS is passed, a new snapshot will be created for the currently tested version.
             // If the linter is not versioned, the same snapshot will be used every time.
@@ -155,17 +315,15 @@ export const linterCheckTest = ({
  * @param dirname absolute path to the linter subdir.
  * @param linterName linter to enable and filter on.
  * @param namedTestPrefixes for input pair `test_data/basic.in.py`, prefix is `basic`
+ * @param preCheck callback to run during setup
+ * @param postCheck callback to run for additional assertions from the base snapshot
  */
 export const linterFmtTest = ({
   linterName,
   dirname = path.dirname(caller()),
   namedTestPrefixes = [],
-  preCheck = () => {
-    // noop
-  },
-  postCheck = () => {
-    // noop
-  },
+  preCheck,
+  postCheck,
 }: {
   linterName: string;
   dirname?: string;
@@ -181,7 +339,7 @@ export const linterFmtTest = ({
       // Step 1b: Detect versions to test against if PLUGINS_TEST_LINTER_VERSION=Snapshots
       const linterVersions = getVersionsForTest(dirname, linterName, prefix, "fmt");
       linterVersions.forEach((linterVersion) => {
-        // TODO(Tyler): Find a reliable way to replace the name "test" that doesn't violate snapshot export names.
+        // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
           const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
@@ -197,6 +355,8 @@ export const linterFmtTest = ({
               },
             });
 
+            // Step 4: Verify that the output matches expected snapshots for that linter version.
+            // See `getSnapshotPathForAssert` and `linterCheckTest` for explanation of snapshot logic.
             const snapshotDir = path.resolve(dirname, TEST_DATA);
             const snapshotPath = getSnapshotPathForAssert(
               snapshotDir,
@@ -211,7 +371,10 @@ export const linterFmtTest = ({
               snapshotPath
             );
           });
-          postCheck(driver);
+          if (postCheck) {
+            postCheck(driver);
+            driver.debug("Finished running custom postCheck hook");
+          }
         });
       });
     });

--- a/tests/jest_setup.ts
+++ b/tests/jest_setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(180000); // 180s
+jest.setTimeout(150000); // 150s

--- a/tests/test_coverage.test.ts
+++ b/tests/test_coverage.test.ts
@@ -10,7 +10,6 @@ const excludedLinters: string[] = [
   "cspell",
   "nancy",
   "oxipng",
-  "sort-package-json",
   "sqlfmt",
   "trivy",
 ];


### PR DESCRIPTION
Accomplishes the following:
- Streamlines preCheck hooks by exposing more helper methods in the TrunkDriver for file manipulation.
- Adds more custom helper methods for running `check` and `fmt` without specifying specific targets. This should enable most of the remaining linters. The thinking behind this setup is as follows:
  - Most simple use cases should use `linterCheckTest` or `linterFmtTest`, which should supply a decent amount of isolation and clarity on test inputs and outputs.
  - For most other use cases, such as when targets != inputs (e.g. clippy, or trigger-based linters), or when specific functionality is being tested, arguments can be specified at will using `customLinterCheckTest` or `customLinterFmtTest`.
- Fixes a small bug where multiple launchers invocations could collide over non-atomic operations. This helps with the flakiness, but I still haven't tracked down the root cause.
- Adds a test for sort-package-json, demonstrating these custom helper methods (note that a custom test is necessary in this case since `package.json` can never be `package.in.json`.

I will follow this up with additional linter migrations. And also fix the flaky test timeout.