### PR TITLE
Update linters list in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,9 @@ make the discovery, management and integration of new tools as straight-forward 
 | Go              | [gofmt], [golangci-lint], [semgrep], [goimports]                                |
 | HAML            | [haml-lint]                                                                     |
 | Java            | [semgrep]                                                                       |
-| Javascript      | [eslint], [prettier], [semgrep]                                                 |
+| Javascript      | [eslint], [prettier], [rome], [semgrep]                                         |
 | JSON            | [eslint], [prettier], [semgrep]                                                 |
-| Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>                                 |
+| Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>, [ktlint]                       |
 | Kubernetes      | [kube-linter]                                                                   |
 | Markdown        | [markdownlint]                                                                  |
 | package.json    | [sort-package-json]                                                             |
@@ -62,7 +62,7 @@ make the discovery, management and integration of new tools as straight-forward 
 | SQL             | [sqlfluff], [sqlfmt], [sql-formatter]                                           |
 | SVG             | [svgo]                                                                          |
 | Terraform       | [terraform] (validate and fmt), [tflint]<sup><a href="#note-tflint">2</a></sup> |
-| Typescript      | [eslint], [prettier], [semgrep]                                                 |
+| Typescript      | [eslint], [prettier], [rome], [semgrep]                                         |
 | YAML            | [prettier], [semgrep], [yamllint]                                               |
 
 [actionlint]: https://github.com/rhysd/actionlint#readme
@@ -93,6 +93,7 @@ make the discovery, management and integration of new tools as straight-forward 
 [hadolint]: https://github.com/hadolint/hadolint#readme
 [haml-lint]: https://github.com/sds/haml-lint#readme
 [isort]: https://github.com/PyCQA/isort#readme
+[ktlint]: https://github.com/pinterest/ktlint#readme
 [kube-linter]: https://github.com/stackrox/kube-linter#readme
 [markdownlint]: https://github.com/DavidAnson/markdownlint#readme
 [nancy]: https://github.com/sonatype-nexus-community/nancy#readme
@@ -100,6 +101,7 @@ make the discovery, management and integration of new tools as straight-forward 
 [pragma-once]: linters/pragma-once/readme.md
 [prettier]: https://github.com/prettier/prettier#readme
 [pylint]: https://github.com/PyCQA/pylint#readme
+[rome]: https://github.com/rome/tools#readme
 [rubocop]: https://github.com/rubocop/rubocop#readme
 [rufo]: https://github.com/ruby-formatter/rufo#readme
 [rustfmt]: https://github.com/rust-lang/rustfmt#readme

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,111 @@ make the discovery, management and integration of new tools as straight-forward 
 
 ### Enabling a supported linter
 
-| technology      | linters                                                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| All             | [cspell](https://github.com/streetsidesoftware/cspell), [codespell](https://github.com/codespell-project/codespell) |
-| C++             | [pragma-once](linters/pragma-once/readme.md)                                                                        |
-| PNG             | [oxipng](https://github.com/shssoichiro/oxipng)                                                                     |
-| SQL             | [sqlfluff](https://github.com/sqlfluff/sqlfluff), [sqlfmt](https://github.com/tconbeer/sqlfmt)                      |
-| Security        | [nancy](https://github.com/sonatype-nexus-community/nancy), [trivy](https://github.com/aquasecurity/trivy)          |
-| CircleCI Config | [circleci](https://github.com/CircleCI-Public/circleci-cli#readme)                                                  |
+| Technology      | Linters                                                                         |
+| --------------- | ------------------------------------------------------------------------------- |
+| All             | [codespell], [cspell], [gitleaks], [git-diff-check]                             |
+| Ansible         | [ansible-lint]                                                                  |
+| Bash            | [shellcheck], [shfmt]                                                           |
+| Bazel, Starlark | [buildifier]                                                                    |
+| C++             | [clang-format], [clang-tidy], [pragma-once]                                     |
+| CircleCI Config | [circleci]                                                                      |
+| Cloudformation  | [cfnlint]                                                                       |
+| CSS, SCSS       | [stylelint]                                                                     |
+| Cue             | [cue-fmt]                                                                       |
+| Docker          | [hadolint]                                                                      |
+| Dotenv          | [dotenv-linter]                                                                 |
+| GitHub          | [actionlint]                                                                    |
+| Go              | [gofmt], [golangci-lint], [semgrep], [goimports]                                |
+| HAML            | [haml-lint]                                                                     |
+| Java            | [semgrep]                                                                       |
+| Javascript      | [eslint], [prettier], [semgrep]                                                 |
+| JSON            | [eslint], [prettier], [semgrep]                                                 |
+| Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>                                 |
+| Kubernetes      | [kube-linter]                                                                   |
+| Markdown        | [markdownlint]                                                                  |
+| package.json    | [sort-package-json]                                                             |
+| PNG             | [oxipng]                                                                        |
+| Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                |
+| Python          | [autopep8], [bandit], [black], [flake8], [isort], [pylint], [semgrep], [yapf]   |
+| Ruby            | [brakeman], [rubocop], [rufo], [semgrep], [standardrb]                          |
+| Rust            | [clippy], [rustfmt]                                                             |
+| Scala           | [scalafmt]                                                                      |
+| Security        | [nancy], [trivy]                                                                |
+| SQL             | [sqlfluff], [sqlfmt], [sql-formatter]                                           |
+| SVG             | [svgo]                                                                          |
+| Terraform       | [terraform] (validate and fmt), [tflint]<sup><a href="#note-tflint">2</a></sup> |
+| Typescript      | [eslint], [prettier], [semgrep]                                                 |
+| YAML            | [prettier], [semgrep], [yamllint]                                               |
+
+[actionlint]: https://github.com/rhysd/actionlint#readme
+[ansible-lint]: https://github.com/ansible/ansible-lint#readme
+[autopep8]: https://github.com/hhatto/autopep8#readme
+[bandit]: https://github.com/PyCQA/bandit#readme
+[black]: https://github.com/psf/black#readme
+[brakeman]: https://github.com/presidentbeef/brakeman#readme
+[buf]: https://github.com/bufbuild/buf#readme
+[buildifier]: https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
+[circleci]: https://github.com/CircleCI-Public/circleci-cli#readme
+[cfnlint]: https://github.com/aws-cloudformation/cfn-lint#readme
+[clang-format]: https://clang.llvm.org/docs/ClangFormat.html
+[clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
+[clippy]: https://github.com/rust-lang/rust-clippy#readme
+[codespell]: https://github.com/codespell-project/codespell#readme
+[cspell]: https://github.com/streetsidesoftware/cspell#readme
+[cue-fmt]: https://cuelang.org/
+[detekt]: https://github.com/detekt/detekt#readme
+[dotenv-linter]: https://github.com/dotenv-linter/dotenv-linter#readme
+[eslint]: https://github.com/eslint/eslint#readme
+[flake8]: https://github.com/PyCQA/flake8#readme
+[gitleaks]: https://github.com/zricethezav/gitleaks#readme
+[git-diff-check]: https://git-scm.com/docs/git-diff
+[gofmt]: https://pkg.go.dev/cmd/gofmt
+[goimports]: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+[golangci-lint]: https://github.com/golangci/golangci-lint#readme
+[hadolint]: https://github.com/hadolint/hadolint#readme
+[haml-lint]: https://github.com/sds/haml-lint#readme
+[isort]: https://github.com/PyCQA/isort#readme
+[kube-linter]: https://github.com/stackrox/kube-linter#readme
+[markdownlint]: https://github.com/DavidAnson/markdownlint#readme
+[nancy]: https://github.com/sonatype-nexus-community/nancy#readme
+[oxipng]: https://github.com/shssoichiro/oxipng#readme
+[pragma-once]: linters/pragma-once/readme.md
+[prettier]: https://github.com/prettier/prettier#readme
+[pylint]: https://github.com/PyCQA/pylint#readme
+[rubocop]: https://github.com/rubocop/rubocop#readme
+[rufo]: https://github.com/ruby-formatter/rufo#readme
+[rustfmt]: https://github.com/rust-lang/rustfmt#readme
+[scalafmt]: https://github.com/scalameta/scalafmt#readme
+[semgrep]: https://github.com/returntocorp/semgrep#readme
+[shellcheck]: https://github.com/koalaman/shellcheck#readme
+[shfmt]: https://github.com/mvdan/sh#readme
+[sort-package-json]: https://github.com/keithamus/sort-package-json#readme
+[sql-formatter]: https://github.com/sql-formatter-org/sql-formatter#readme
+[sqlfluff]: https://github.com/sqlfluff/sqlfluff#readme
+[sqlfmt]: https://github.com/tconbeer/sqlfmt#readme
+[standardrb]: https://github.com/testdouble/standard#readme
+[stylelint]: https://github.com/stylelint/stylelint#readme
+[svgo]: https://github.com/svg/svgo#readme
+[terraform]: https://developer.hashicorp.com/terraform/cli/code
+[tflint]: https://github.com/terraform-linters/tflint#readme
+[trivy]: https://github.com/aquasecurity/trivy#readme
+[yamllint]: https://github.com/adrienverge/yamllint#readme
+[yapf]: https://github.com/google/yapf#readme
+
+<sup><ol>
+
+<li><a aria-hidden="true" tabindex="-1" class="customAnchor" id="note-detekt"></a>
+Support for Detekt is under active development; see our <a href="https://docs.trunk.io/docs/check-supported-linters#detekt">docs</a> for more
+details.
+</li>
+
+<li><a aria-hidden="true" tabindex="-1" class="customAnchor" id="note-tflint"></a>
+<a href="https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/module-inspection.md">Module inspection</a>, <a href="https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/docs/deep_checking.md">deep checking</a>, and setting variables are not currently supported.
+</li>
+
+</ol></sup>
+
+<br/>
 
 ```bash
 trunk check enable {linter}

--- a/tests/readme_inclusion.test.ts
+++ b/tests/readme_inclusion.test.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+import { REPO_ROOT } from "tests/utils";
+
+const excludedLinters: string[] = [];
+const abbreviationMapping = new Map<string, string>([["iwyu", "include-what-you-use"]]);
+
+const readmeContents = fs.readFileSync(path.resolve(REPO_ROOT, "readme.md"), { encoding: "utf-8" });
+const readmeTableContents = readmeContents.substring(
+  readmeContents.indexOf("### Enabling a supported linter"),
+  readmeContents.indexOf("### Enabling a supported action")
+);
+
+// This test asserts that all linters are included in the root readme.md. This does not cover subcommands, and it assumes one
+// directory per linter. Name mapping can be achieved through `abbreviationMapping`.
+describe("All linters must be included in readme.md", () => {
+  // Find all linter subdirectories
+  const linterDir = path.resolve(REPO_ROOT, "linters");
+  const linters = fs
+    .readdirSync(linterDir)
+    .filter((file) => fs.lstatSync(path.resolve(linterDir, file)).isDirectory());
+
+  // Assert that each linter subdirectory is included in the repo's readme.md
+  linters
+    .filter((linter) => !excludedLinters.includes(linter))
+    .forEach((linter) => {
+      // trunk-ignore(eslint/jest/valid-title)
+      it(linter, () => {
+        const fullName = abbreviationMapping.get(linter) ?? linter;
+        expect(readmeTableContents).toContain(fullName);
+      });
+    });
+});


### PR DESCRIPTION
Bring the root readme.md up to date with the migrated linters. I split out some of the previously combined fields (e.g. typescript+javascript) for clarity. I also added a test that requires every linter to be named in the readme table.

The only remaining linters to port and add to this list are taplo and mypy, once non-semver testing support has been added, and stringslint/swiftlint/swiftformat, once MacOS tests have been ironed out.