### PR TITLE
chore: bump cli.version to new staging release

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.3.2-beta.4
+  version: 1.3.2-beta.7
 
 plugins:
   sources:


### PR DESCRIPTION
Allows running tests of google-java-format