### PR TITLE
Add semgrep known_bad_version 1.5.1

### DIFF
--- a/linters/semgrep/plugin.yaml
+++ b/linters/semgrep/plugin.yaml
@@ -28,6 +28,7 @@ lint:
         - name: PATH
           list: ["${env.PATH}"]
       known_good_version: 0.110.0
+      known_bad_versions: [1.5.1] # Does not work on MacOS
       version_command:
         parse_regex: ${semver}
         run: semgrep --version

--- a/tests/driver/index.ts
+++ b/tests/driver/index.ts
@@ -211,7 +211,7 @@ export class TrunkDriver {
         path.resolve(this.sandboxPath, ".trunk/trunk.yaml"),
         "utf8"
       );
-      const enabledVersionRegex = `(?<linter>${this.linter})@(?<version>.+)\n$`;
+      const enabledVersionRegex = `(?<linter>${this.linter})@(?<version>.+)\n`;
       const foundIn = newTrunkContents.match(enabledVersionRegex);
       if (foundIn && foundIn.groups?.version && foundIn.groups?.version.length > 0) {
         this.enabledVersion = foundIn.groups.version;

--- a/tests/utils/trunk_config.ts
+++ b/tests/utils/trunk_config.ts
@@ -27,7 +27,7 @@ export const getTrunkConfig = (repoRoot: string): any => {
 export const getTrunkVersion = (): string => {
   // trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)
   const repoCliVersion = getTrunkConfig(REPO_ROOT).cli.version as string;
-  return ARGS.cliVersion ?? repoCliVersion ?? "1.2.1";
+  return ARGS.cliVersion ?? repoCliVersion ?? "bad-version";
 };
 
 /**
@@ -40,4 +40,9 @@ plugins:
   sources:
   - id: trunk
     local: ${REPO_ROOT}
-  `;
+lint:
+  ignore:
+    - linters: [ALL]
+      paths:
+        - tmp/**
+`;


### PR DESCRIPTION
This version is improperly built for macOS. Users won't pick this change up until the next plugin release, unfortunately.

Also adds a couple QoL improvements for plugin testing.