### PR TITLE
Use batching for shfmt

### DIFF
--- a/linters/shfmt/plugin.yaml
+++ b/linters/shfmt/plugin.yaml
@@ -6,11 +6,12 @@ lint:
       commands:
         - name: format
           output: shfmt
-          run: shfmt -s -filename ${target} -
+          run: shfmt -ws ${target}
           success_codes: [0, 1]
-          stdin: true
           cache_results: true
           formatter: true
+          batch: true
+          in_place: true
       runtime: go
       package: mvdan.cc/sh/v${major_version}/cmd/shfmt
       good_without_config: true

--- a/linters/shfmt/plugin.yaml
+++ b/linters/shfmt/plugin.yaml
@@ -6,7 +6,7 @@ lint:
       commands:
         - name: format
           output: shfmt
-          run: shfmt -ws ${target}
+          run: shfmt -w -s ${target}
           success_codes: [0, 1]
           cache_results: true
           formatter: true


### PR DESCRIPTION
`shfmt` appears to have a bug reading from stdin on some systems. Format with in_place batching as a work-around. It's faster anyways.