### PR TITLE
Support interactive hooks for trunk-fmt-pre-commit

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.4.0
+  version: 1.4.1-beta.2
 
 plugins:
   sources:
@@ -19,16 +19,16 @@ lint:
   enabled:
     - actionlint@1.6.23
     - black@22.12.0
-    - eslint@8.32.0
+    - eslint@8.33.0
     - flake8@6.0.0:
         packages:
           - flake8-bugbear@23.1.20
     - git-diff-check
     - gitleaks@8.15.3
-    - isort@5.11.4
+    - isort@5.12.0
     - markdownlint@0.33.0
     - prettier@2.8.3
-    - semgrep@1.5.1
+    - semgrep@1.6.0
     - shellcheck@0.9.0
     - shfmt@3.5.0
     - sqlfluff@1.4.5

--- a/actions/trunk/plugin.yaml
+++ b/actions/trunk/plugin.yaml
@@ -21,7 +21,7 @@ actions:
       description: Run 'trunk fmt' whenever you run 'git commit'
       display_name: Trunk Fmt Pre-Commit Hook
       run: trunk fmt -t "git-commit" --index-file '${env.GIT_INDEX_FILE}' --upstream=HEAD
-      interactive: true
+      interactive: auto
       triggers:
         - git_hooks: [pre-commit]
       notify_on_error: false

--- a/actions/trunk/plugin.yaml
+++ b/actions/trunk/plugin.yaml
@@ -21,7 +21,7 @@ actions:
       description: Run 'trunk fmt' whenever you run 'git commit'
       display_name: Trunk Fmt Pre-Commit Hook
       run: trunk fmt -t "git-commit" --index-file '${env.GIT_INDEX_FILE}' --upstream=HEAD
-      interactive: auto
+      interactive: optional
       triggers:
         - git_hooks: [pre-commit]
       notify_on_error: false

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 version: 0.1
-required_trunk_version: ">1.3.2-beta.7"
+required_trunk_version: ">=1.4.0"
 lint:
   files:
     - name: dml

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 version: 0.1
-required_trunk_version: ">=1.4.0"
+required_trunk_version: ">1.4.0"
 lint:
   files:
     - name: dml


### PR DESCRIPTION
Migrates this fix from the binary. This should enable users to run trunk-fmt-pre-commit from invocations such as VSCode's built-in SCM.