### PR TITLE
add `@typescript-eslint/parser` to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/jest-specific-snapshot": "^0.5.6",
         "@types/node": "^18.11.18",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
+        "@typescript-eslint/parser": "^5.50.0",
         "caller": "^1.1.0",
         "debug": "^4.3.4",
         "eslint": "^8.30.0",
@@ -1484,15 +1485,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.1.tgz",
-      "integrity": "sha512-9Vb+KIv29r6GPu4EboWOnQM7T+UjpjXvjCPhNORlgm40a9Ia9bvaPJswvtae1gip2QEeVeGh6YquqAzEgoRAlw==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.50.0.tgz",
+      "integrity": "sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.50.0",
+        "@typescript-eslint/types": "5.50.0",
+        "@typescript-eslint/typescript-estree": "5.50.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1509,6 +1509,80 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz",
+      "integrity": "sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.50.0",
+        "@typescript-eslint/visitor-keys": "5.50.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.50.0.tgz",
+      "integrity": "sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz",
+      "integrity": "sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.50.0",
+        "@typescript-eslint/visitor-keys": "5.50.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz",
+      "integrity": "sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.50.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -7285,16 +7359,58 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.1.tgz",
-      "integrity": "sha512-9Vb+KIv29r6GPu4EboWOnQM7T+UjpjXvjCPhNORlgm40a9Ia9bvaPJswvtae1gip2QEeVeGh6YquqAzEgoRAlw==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.50.0.tgz",
+      "integrity": "sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.50.0",
+        "@typescript-eslint/types": "5.50.0",
+        "@typescript-eslint/typescript-estree": "5.50.0",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.50.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz",
+          "integrity": "sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.50.0",
+            "@typescript-eslint/visitor-keys": "5.50.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.50.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.50.0.tgz",
+          "integrity": "sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.50.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz",
+          "integrity": "sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.50.0",
+            "@typescript-eslint/visitor-keys": "5.50.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.50.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz",
+          "integrity": "sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.50.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/jest-specific-snapshot": "^0.5.6",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
+    "@typescript-eslint/parser": "^5.50.0",
     "caller": "^1.1.0",
     "debug": "^4.3.4",
     "eslint": "^8.30.0",


### PR DESCRIPTION
Currently, `trunk check` doesn't work on freshly cloned and `yarn install`ed repos due to eslint not being able to find the package:

```
Error: Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc.yaml » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base': Cannot find module '@typescript-eslint/parser'
```

This fixes that.