### PR TITLE
Add binary artifact exemption for gradle-wrapper.jar

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,4 @@
+IgnorePaths:
+  # Checking in gradle-wrapper.jar is standard and the PR that introduced this ignore feature
+  # explicitly called it out. See https://github.com/ossf/allstar/pull/176
+  - linters/detekt/test_data/detekt_gradle/gradle/wrapper/gradle-wrapper.jar

--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,4 +1,4 @@
 IgnorePaths:
   # Checking in gradle-wrapper.jar is standard and the PR that introduced this ignore feature
   # explicitly called it out. See https://github.com/ossf/allstar/pull/176
-  - gradle/wrapper/gradle-wrapper.jar
+  - linters/detekt/test_data/detekt_gradle/gradle/wrapper/gradle-wrapper.jar

--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,4 +1,4 @@
 IgnorePaths:
   # Checking in gradle-wrapper.jar is standard and the PR that introduced this ignore feature
   # explicitly called it out. See https://github.com/ossf/allstar/pull/176
-  - linters/detekt/test_data/detekt_gradle/gradle/wrapper/gradle-wrapper.jar
+  - gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
It's expected to use this exemption with `gradle-wrapper.jar`, see https://github.com/ossf/allstar/pull/176.