### PR TITLE
Try to fix configuration key for allstar ignore

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,4 +1,4 @@
-IgnorePaths:
+ignorePaths:
   # Checking in gradle-wrapper.jar is standard and the PR that introduced this ignore feature
   # explicitly called it out. See https://github.com/ossf/allstar/pull/176
   - linters/detekt/test_data/detekt_gradle/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
Seems it needs to be lowercase `i` from https://github.com/jeffmendoza/allstar/blob/2a079b8006615ae0ec125da15599513f79fa8776/pkg/policies/binary/binary.go#L64