### PR TITLE
Don't run latest tests on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linter-version: [KnownGoodVersion]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
@@ -51,7 +50,7 @@ jobs:
       - name: Linter Tests
         uses: ./.github/actions/linter_tests
         with:
-          linter-version: ${{ matrix.linter-version }}
+          linter-version: KnownGoodVersion
 
   # Run repo healthcheck tests
   repo_tests:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linter-version: [KnownGoodVersion, Latest]
+        linter-version: [KnownGoodVersion]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout


### PR DESCRIPTION
After this:
- PRs will only run on KnownGoodVersion (quick)
- Nightlies will run on Snapshots (slower) and Latest (non-idempotent due to releases)

This should make it so people don't become blocked by new releases. We can follow-up about where more coverage might be needed.