### PR TITLE
Fix remark-lint tests

### DIFF
--- a/linters/remark-lint/plugin.yaml
+++ b/linters/remark-lint/plugin.yaml
@@ -28,7 +28,7 @@ lint:
           success_codes: [0]
           in_place: true
           cache_results: true
-        - name: check
+        - name: lint
           output: sarif
           run: remark ${target} --frail --output --report=vfile-reporter-json
           success_codes: [0, 1]

--- a/linters/remark-lint/remark_lint.test.ts
+++ b/linters/remark-lint/remark_lint.test.ts
@@ -1,5 +1,12 @@
-import { linterCheckTest, linterFmtTest } from "tests";
+import path from "path";
+import { customLinterCheckTest, linterFmtTest } from "tests";
+import { skipOS, TEST_DATA } from "tests/utils";
 
 linterFmtTest({ linterName: "remark-lint" });
 
-linterCheckTest({ linterName: "remark-lint" });
+// TODO(Tyler): Fix custom parsers sometimes breaking on Mac
+customLinterCheckTest({
+  linterName: "remark-lint",
+  args: path.join(TEST_DATA, "basic.in.md"),
+  skipTestIf: skipOS(["darwin"]),
+});

--- a/linters/remark-lint/test_data/basic.in.md
+++ b/linters/remark-lint/test_data/basic.in.md
@@ -1,21 +1,21 @@
-*   this is a list item
-    indented with tabs
+* 	this is a list item
+		indented with tabs
 
 *   this is a list item
     indented with spaces
 
 Code:
 
-    this code block is indented by one tab
+	this code block is indented by one tab
 
 And:
 
-    	this code block is indented by two tabs
+		this code block is indented by two tabs
 
 And:
 
-    +	this is an example list item
-    	indented with tabs
+		+ this is an example list item
+			indented with tabs
 
     +   this is an example list item
         indented with spaces

--- a/linters/remark-lint/test_data/remark_lint_v11.0.0_CUSTOM.check.shot
+++ b/linters/remark-lint/test_data/remark_lint_v11.0.0_CUSTOM.check.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing linter remark-lint test basic 1`] = `
+exports[`Testing linter remark-lint test CUSTOM 1`] = `
 Object {
   "issues": Array [
     Object {
@@ -8,6 +8,7 @@ Object {
       "code": "list-item-indent",
       "column": "4",
       "file": "test_data/basic.in.md",
+      "issueClass": "ISSUE_CLASS_EXISTING",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "remark-lint",
@@ -32,6 +33,16 @@ Object {
       "paths": Array [
         "test_data/basic.in.md",
       ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    Object {
+      "command": "lint",
+      "fileGroupName": "markdown",
+      "linter": "remark-lint",
+      "paths": Array [
+        "test_data/basic.in.md",
+      ],
+      "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],

--- a/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
+++ b/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
@@ -5,50 +5,19 @@ Object {
   "issues": Array [
     Object {
       "bucket": "remark-lint",
-      "code": "no-tabs",
-      "column": "5",
+      "code": "list-item-indent",
+      "column": "4",
       "file": "test_data/basic.in.md",
       "level": "LEVEL_HIGH",
-      "line": "13",
+      "line": "1",
       "linter": "remark-lint",
-      "message": "Use spaces instead of tabs",
-      "targetType": "markdown",
-    },
-    Object {
-      "bucket": "remark-lint",
-      "code": "no-tabs",
-      "column": "6",
-      "file": "test_data/basic.in.md",
-      "level": "LEVEL_HIGH",
-      "line": "17",
-      "linter": "remark-lint",
-      "message": "Use spaces instead of tabs",
-      "targetType": "markdown",
-    },
-    Object {
-      "bucket": "remark-lint",
-      "code": "no-tabs",
-      "column": "5",
-      "file": "test_data/basic.in.md",
-      "level": "LEVEL_HIGH",
-      "line": "18",
-      "linter": "remark-lint",
-      "message": "Use spaces instead of tabs",
+      "message": "Incorrect list-item indent: add 1 space",
       "targetType": "markdown",
     },
   ],
   "lintActions": Array [
     Object {
-      "command": "check",
-      "fileGroupName": "markdown",
-      "linter": "remark-lint",
-      "paths": Array [
-        "test_data/basic.in.md",
-      ],
-      "verb": "TRUNK_VERB_CHECK",
-    },
-    Object {
-      "command": "format",
+      "command": "fmt",
       "fileGroupName": "markdown",
       "linter": "remark-lint",
       "paths": Array [
@@ -56,8 +25,27 @@ Object {
       ],
       "verb": "TRUNK_VERB_FMT",
     },
+    Object {
+      "command": "lint",
+      "fileGroupName": "markdown",
+      "linter": "remark-lint",
+      "paths": Array [
+        "test_data/basic.in.md",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
   ],
   "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "unformattedFiles": Array [
+    Object {
+      "column": "1",
+      "file": "test_data/basic.in.md",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "remark-lint",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
 }
 `;

--- a/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.fmt.shot
+++ b/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.fmt.shot
@@ -17,8 +17,8 @@ And:
 
 And:
 
-    +	this is an example list item
-    	indented with tabs
+    	+ this is an example list item
+    		indented with tabs
 
     +   this is an example list item
         indented with spaces

--- a/linters/renovate/renovate.test.ts
+++ b/linters/renovate/renovate.test.ts
@@ -1,6 +1,7 @@
 import { customLinterCheckTest } from "tests";
 import { skipOS } from "tests/utils";
 
+// TODO(Tyler): Fix custom parsers sometimes breaking on Mac
 // python missing on mac
 customLinterCheckTest({
   linterName: "renovate",


### PR DESCRIPTION
The last commit broke some of the tests. Namely, the no-tabs plugin was removed, the subcommands were renamed, and I believe the original file was saved with spaces.