### PR TITLE
Fix the plugin version used in the upload

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -61,6 +61,9 @@ jobs:
       matrix:
         linter-version: [Snapshots, Latest]
         os: [ubuntu-latest, macos-latest]
+    outputs:
+      plugin-version: ${{ steps.get-release.outputs.tag }}
+
     steps:
       - name: Retrieve git history
         uses: actions/checkout@v3
@@ -162,6 +165,8 @@ jobs:
 
       - name: Parse Test Results
         run: npm run parse
+        env:
+          PLUGIN_VERSION: ${{needs.linter_tests_release.outputs.plugin-version}}
 
       - name: Upload Test Results
         env:

--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -11,6 +11,10 @@ import { REPO_ROOT } from "tests/utils";
 import { getTrunkVersion } from "tests/utils/trunk_config";
 
 const RESULTS_FILE = path.resolve(REPO_ROOT, "results.json");
+const PLUGIN_VERSION = process.env.PLUGIN_VERSION ?? "v0.0.10";
+if (!process.env.PLUGIN_VERSION) {
+  console.log("Environment var `PLUGIN_VERSION` is not set, using fallback `v0.0.10`");
+}
 
 /**
  * Convert an OS into the expected file path.
@@ -148,7 +152,7 @@ const mergeTestResultSummaries = (testResults: TestResultSummary[]): TestResultS
  */
 const writeTestResults = (testResults: TestResultSummary) => {
   const cliVersion = getTrunkVersion();
-  const pluginVersion = "v0.0.10"; // TODO(Tyler): Iron out ref for nightly runs.
+  const pluginVersion = PLUGIN_VERSION;
   const validatedVersions = Array.from(testResults.linters).reduce(
     (accumulator: ValidatedVersion[], [linter, { version, testResultStatus }]) => {
       if (testResultStatus === "passed" && version) {


### PR DESCRIPTION
Previously, this was hard-coded. Now, use the version that the tests actually run against. Thanks to the checkout dance, this will take effect on the next nightly, even if we don't make a release.

Remaining work includes potential slack notifications, which would probably require the use of a separate failure.json file (this could include information, such as `MISMATCHED`).