### PR TITLE
Reenable tests for remark-lint and renovate on Mac

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.4.2-beta.6
+  version: 1.4.2-beta.8
 
 # TODO(Tyler): This is set temporarily in order to test uploading validated versions
 api:

--- a/linters/remark-lint/remark_lint.test.ts
+++ b/linters/remark-lint/remark_lint.test.ts
@@ -1,12 +1,5 @@
-import path from "path";
-import { customLinterCheckTest, linterFmtTest } from "tests";
-import { skipOS, TEST_DATA } from "tests/utils";
+import { linterCheckTest, linterFmtTest } from "tests";
 
 linterFmtTest({ linterName: "remark-lint" });
 
-// TODO(Tyler): Fix custom parsers sometimes breaking on Mac
-customLinterCheckTest({
-  linterName: "remark-lint",
-  args: path.join(TEST_DATA, "basic.in.md"),
-  skipTestIf: skipOS(["darwin"]),
-});
+linterCheckTest({ linterName: "remark-lint" });

--- a/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
+++ b/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing linter remark-lint test CUSTOM 1`] = `
+exports[`Testing linter remark-lint test basic 1`] = `
 Object {
   "issues": Array [
     Object {
@@ -8,7 +8,6 @@ Object {
       "code": "list-item-indent",
       "column": "4",
       "file": "test_data/basic.in.md",
-      "issueClass": "ISSUE_CLASS_EXISTING",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "remark-lint",
@@ -33,16 +32,6 @@ Object {
       "paths": Array [
         "test_data/basic.in.md",
       ],
-      "verb": "TRUNK_VERB_CHECK",
-    },
-    Object {
-      "command": "lint",
-      "fileGroupName": "markdown",
-      "linter": "remark-lint",
-      "paths": Array [
-        "test_data/basic.in.md",
-      ],
-      "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],

--- a/linters/renovate/renovate.test.ts
+++ b/linters/renovate/renovate.test.ts
@@ -1,10 +1,6 @@
 import { customLinterCheckTest } from "tests";
-import { skipOS } from "tests/utils";
 
-// TODO(Tyler): Fix custom parsers sometimes breaking on Mac
-// python missing on mac
 customLinterCheckTest({
   linterName: "renovate",
   args: "-a",
-  skipTestIf: skipOS(["darwin"]),
 });


### PR DESCRIPTION
The custom parser fix is in. Not sure if we want to do a required_cli_version update, but I think probably not.