### PR TITLE
Point tests to new release of cli

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,13 +1,12 @@
 version: 0.1
 
 cli:
-  version: 1.4.2-beta.8
+  version: 1.4.3-beta.2
 
 plugins:
   sources:
     - id: trunk
-      uri: https://github.com/trunk-io/plugins
-      ref: 454583aa8bb4d092db343c7c4a71a72a19938768 # run the plugins repo at its own latest commit
+      local: .
 
 runtimes:
   enabled:
@@ -80,7 +79,6 @@ actions:
     - repo-tests
     - linter-test-helper
     - trunk-announce
-    - toggle-local
     - trunk-cache-prune
     - trunk-upgrade-available
     - trunk-check-pre-push

--- a/contributing.md
+++ b/contributing.md
@@ -31,8 +31,6 @@ plugins:
       local: </path/to/repo/root>
 ```
 
-Run `trunk run toggle-local` to quickly toggle this setting in this repo.
-
 Adding a plugin source lets users run `trunk check enable` or `trunk actions enable` with linters
 and actions defined in that plugin. For more information, see our
 [docs](https://docs.trunk.io/docs/plugins).


### PR DESCRIPTION
This should make things green again, now that the dependency ordering is sorted out. Also points the plugin source to `.`, and we can eventually delete the `toggle-local` action.