### PR TITLE
Fix ruff autofix parsing

### DIFF
--- a/linters/ruff/ruff_to_sarif.py
+++ b/linters/ruff/ruff_to_sarif.py
@@ -9,12 +9,12 @@ results = []
 def get_region(entry):
     location = entry["location"]
     region = {
-        "startColumn": location["column"],
+        "startColumn": location["column"] + 1,
         "startLine": location["row"],
     }
     if "end_location" in entry:
         end_location = entry["end_location"]
-        region["endColumn"] = end_location["column"]
+        region["endColumn"] = end_location["column"] + 1
         region["endLine"] = end_location["row"]
     return region
 
@@ -49,7 +49,7 @@ for result in json.load(sys.stdin):
                 "description": {
                     "text": fix["message"],
                 },
-                "fileChanges": [
+                "artifactChanges": [
                     {
                         "artifactLocation": {
                             "uri": filepath,

--- a/linters/ruff/ruff_to_sarif.py
+++ b/linters/ruff/ruff_to_sarif.py
@@ -6,15 +6,15 @@ import sys
 results = []
 
 
-def get_region(entry):
+def get_region(entry, column_offset=0):
     location = entry["location"]
     region = {
-        "startColumn": location["column"] + 1,
+        "startColumn": location["column"] + column_offset,
         "startLine": location["row"],
     }
     if "end_location" in entry:
         end_location = entry["end_location"]
-        region["endColumn"] = end_location["column"] + 1
+        region["endColumn"] = end_location["column"] + column_offset
         region["endLine"] = end_location["row"]
     return region
 
@@ -56,7 +56,7 @@ for result in json.load(sys.stdin):
                         },
                         "replacements": [
                             {
-                                "deletedRegion": get_region(fix),
+                                "deletedRegion": get_region(fix, 1),
                                 "insertedContent": {
                                     "text": fix["content"],
                                 },

--- a/linters/ruff/ruff_to_sarif.py
+++ b/linters/ruff/ruff_to_sarif.py
@@ -6,6 +6,8 @@ import sys
 results = []
 
 
+# Column offset field required due to indexing bug in Ruff
+# https://github.com/charliermarsh/ruff/issues/3106
 def get_region(entry, column_offset=0):
     location = entry["location"]
     region = {

--- a/linters/ruff/ruff_to_sarif.py
+++ b/linters/ruff/ruff_to_sarif.py
@@ -6,8 +6,6 @@ import sys
 results = []
 
 
-# Column offset field required due to indexing bug in Ruff
-# https://github.com/charliermarsh/ruff/issues/3106
 def get_region(entry, column_offset=0):
     location = entry["location"]
     region = {
@@ -58,6 +56,8 @@ for result in json.load(sys.stdin):
                         },
                         "replacements": [
                             {
+                                # Ruff gives 0-indexed columns, SARIF requires 1-indexed
+                                # https://github.com/charliermarsh/ruff/issues/3106
                                 "deletedRegion": get_region(fix, 1),
                                 "insertedContent": {
                                     "text": fix["content"],

--- a/linters/ruff/test_data/ruff_v0.0.243_basic.check.shot
+++ b/linters/ruff/test_data/ruff_v0.0.243_basic.check.shot
@@ -6,7 +6,7 @@ Object {
     Object {
       "bucket": "ruff",
       "code": "E402",
-      "column": "1",
+      "column": "2",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "7",
@@ -15,9 +15,21 @@ Object {
       "targetType": "python",
     },
     Object {
+      "autofixOptions": Array [
+        Object {
+          "message": "Remove unused import: \`sys\`",
+          "replacements": Array [
+            Object {
+              "filePath": "test_data/basic.in.py",
+              "length": "11",
+              "offset": "83",
+            },
+          ],
+        },
+      ],
       "bucket": "ruff",
       "code": "F401",
-      "column": "8",
+      "column": "9",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "7",
@@ -28,7 +40,7 @@ Object {
     Object {
       "bucket": "ruff",
       "code": "E402",
-      "column": "1",
+      "column": "2",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "9",

--- a/linters/ruff/test_data/ruff_v0.0.243_basic.check.shot
+++ b/linters/ruff/test_data/ruff_v0.0.243_basic.check.shot
@@ -6,7 +6,7 @@ Object {
     Object {
       "bucket": "ruff",
       "code": "E402",
-      "column": "2",
+      "column": "1",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "7",
@@ -29,7 +29,7 @@ Object {
       ],
       "bucket": "ruff",
       "code": "F401",
-      "column": "9",
+      "column": "8",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "7",
@@ -40,7 +40,7 @@ Object {
     Object {
       "bucket": "ruff",
       "code": "E402",
-      "column": "2",
+      "column": "1",
       "file": "test_data/basic.in.py",
       "level": "LEVEL_HIGH",
       "line": "9",


### PR DESCRIPTION
Fixes a typo in the parser script and adds a workaround off-by-one error in ruff's output column locations in `fix` objects.