### PR TITLE
Use a default config for sqlfluff so users can override the dialect

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 
 cli:
-  version: 1.4.3-beta.2
+  version: 1.5.1
 
 plugins:
   sources:
@@ -16,19 +16,21 @@ runtimes:
 
 lint:
   enabled:
+    - clippy@1.65.0
+    - golangci-lint@1.51.2
     - actionlint@1.6.23
     - black@23.1.0
-    - eslint@8.33.0
+    - eslint@8.34.0
     - flake8@6.0.0:
         packages:
-          - flake8-bugbear@23.1.20
+          - flake8-bugbear@23.2.13
     - git-diff-check
     - gitleaks@8.15.3
     - isort@5.12.0
     - markdownlint@0.33.0
-    - prettier@2.8.3
-    - renovate@34.125.1
-    - semgrep@1.9.0
+    - prettier@2.8.4
+    - renovate@34.152.1
+    - semgrep@1.12.1
     - shellcheck@0.9.0
     - shfmt@3.5.0
     - sqlfluff@1.4.5

--- a/linters/sqlfluff/.sqlfluff
+++ b/linters/sqlfluff/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = ansi

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -10,7 +10,7 @@ lint:
         - .sqlfluff
       commands:
         - name: lint
-          run: sqlfluff lint ${target} --format json --dialect ansi --nofail
+          run: sqlfluff lint ${target} --format json --nofail
           output: sarif
           success_codes: [0]
           read_output_from: stdout
@@ -18,7 +18,7 @@ lint:
             runtime: python
             run: ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
         - name: fix
-          run: sqlfluff fix ${target} --dialect ansi --disable-progress-bar --force
+          run: sqlfluff fix ${target} --disable-progress-bar --force
           output: rewrite
           formatter: true
           in_place: true

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -8,6 +8,7 @@ lint:
       known_good_version: 1.4.5
       direct_configs:
         - .sqlfluff
+      is_recommended: false
       commands:
         - name: lint
           run: sqlfluff lint ${target} --format json --nofail


### PR DESCRIPTION
When we hard-code it on the command-line, the config file has no affect on the dialect.
Add a default config file as without a config file specifying a dialect the linter will fail.

Upgrade everything too, thanks LUV.