### PR TITLE
Add missing ktlint download and repo test

### DIFF
--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -1,5 +1,12 @@
 version: 0.1
 lint:
+  downloads:
+    - name: ktlint
+      version: 0.43.2
+      executable: true
+      downloads:
+        # Cross-platform download
+        - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
   definitions:
     - name: ktlint
       files: [kotlin]

--- a/linters/ktlint/test_data/complex.in.kt
+++ b/linters/ktlint/test_data/complex.in.kt
@@ -1,0 +1,3 @@
+class TestBaselineExtraErrorFile {
+  { }}
+}

--- a/linters/ktlint/test_data/ktlint_v0.43.2_complex.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v0.43.2_complex.fmt.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter ktlint test complex 1`] = `
+"class TestBaselineExtraErrorFile {
+  { }}
+}
+"
+`;

--- a/linters/ktlint/test_data/ktlint_v0.48.0_complex.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v0.48.0_complex.fmt.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter ktlint test complex 1`] = `
+"class TestBaselineExtraErrorFile {
+  { }}
+}
+"
+`;

--- a/tests/repo_tests/no_missing_download.test.ts
+++ b/tests/repo_tests/no_missing_download.test.ts
@@ -21,6 +21,7 @@ describe("All linters that use downloads must define them", () => {
       // trunk-ignore(eslint/jest/valid-title)
       it(linter, () => {
         // trunk-ignore-begin(eslint): Expected any accesses
+        // Ignoring no-unsafe-member-access, no-unsafe-assignment, no-unsafe-call, no-unsafe-return, and conditional jest expect
         const yamlContents = parseYaml(path.resolve(linterDir, linter, "plugin.yaml"));
 
         yamlContents.lint?.definitions?.forEach((definition: any) => {

--- a/tests/repo_tests/no_missing_download.test.ts
+++ b/tests/repo_tests/no_missing_download.test.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+import { REPO_ROOT } from "tests/utils";
+import { parseYaml } from "tests/utils/trunk_config";
+
+// These linters use go or rust downloads.
+const excludedLinters: string[] = ["clippy", "gofmt", "rustfmt"];
+
+// This test asserts that all linters that have a `download` specified (as opposed to custom run command or package)
+// Must also define that download in its same file. Otherwise, this would be a runtime error.
+describe("All linters that use downloads must define them", () => {
+  // Find all linter subdirectories
+  const linterDir = path.resolve(REPO_ROOT, "linters");
+  const linters = fs
+    .readdirSync(linterDir)
+    .filter((file) => fs.lstatSync(path.resolve(linterDir, file)).isDirectory());
+
+  linters
+    .filter((linter) => !excludedLinters.includes(linter))
+    .forEach((linter) => {
+      // trunk-ignore(eslint/jest/valid-title)
+      it(linter, () => {
+        // trunk-ignore-begin(eslint): Expected any accesses
+        const yamlContents = parseYaml(path.resolve(linterDir, linter, "plugin.yaml"));
+
+        yamlContents.lint?.definitions?.forEach((definition: any) => {
+          if (definition.download) {
+            const downloads = (yamlContents.lint?.downloads ?? []).map(
+              (download: any) => download?.name
+            );
+            expect(downloads).toContain(definition.download);
+            // trunk-ignore-end(eslint)
+          }
+        });
+      });
+    });
+});


### PR DESCRIPTION
Added ktlint download that I missed when I originally ported definitions over and another of its tests. I also added a repo test to make sure this doesn't happen again.