### PR TITLE
Support latest jest-specific-snapshot

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -8,6 +8,7 @@ all-linters:
   - tests/utils/**
   - tests/index.ts
   - .trunk/trunk.yaml
+  - package.json
 
 # Run tests against specific linters if existing linters have been modified or updated.
 # These test will be run with KnownGoodVersion and Latest to verify linter integrity at the latest and fallback version.
@@ -25,5 +26,6 @@ repo-tests:
   - actions/**
   - readme.md
   - .trunk/trunk.yaml
+  - package.json
 # Nightly jobs will run on all linters with Snapshots and Latest.
 # e.g. `PLUGINS_TEST_LINTER_VERSION=[Snapshots,Latest] npm test linters`

--- a/linters/actionlint/test_data/actionlint_v1.6.21_CUSTOM.check.shot
+++ b/linters/actionlint/test_data/actionlint_v1.6.21_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter actionlint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "actionlint",
       "code": "events",
       "column": "13",
@@ -13,10 +13,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "4",
       "linter": "actionlint",
-      "message": "invalid CRON format \\"0 */3 * *\\" in schedule event: Expected exactly 5 fields, found 4: 0 */3 * *",
+      "message": "invalid CRON format "0 */3 * *" in schedule event: Expected exactly 5 fields, found 4: 0 */3 * *",
       "targetType": "github-workflow",
     },
-    Object {
+    {
       "bucket": "actionlint",
       "code": "events",
       "column": "13",
@@ -29,7 +29,7 @@ Object {
       "message": "scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes",
       "targetType": "github-workflow",
     },
-    Object {
+    {
       "bucket": "actionlint",
       "code": "syntax-check",
       "column": "1",
@@ -43,27 +43,27 @@ Object {
       "targetType": "github-workflow",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "github-workflow",
       "linter": "actionlint",
-      "paths": Array [
+      "paths": [
         ".github/workflows/bad.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "github-workflow",
       "linter": "actionlint",
-      "paths": Array [
+      "paths": [
         ".github/workflows/empty.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/actionlint/test_data/actionlint_v1.6.9_CUSTOM.check.shot
+++ b/linters/actionlint/test_data/actionlint_v1.6.9_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter actionlint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "actionlint",
       "code": "events",
       "column": "13",
@@ -13,10 +13,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "4",
       "linter": "actionlint",
-      "message": "invalid CRON format \\"0 */3 * *\\" in schedule event: Expected exactly 5 fields, found 4: 0 */3 * *",
+      "message": "invalid CRON format "0 */3 * *" in schedule event: Expected exactly 5 fields, found 4: 0 */3 * *",
       "targetType": "github-workflow",
     },
-    Object {
+    {
       "bucket": "actionlint",
       "code": "events",
       "column": "13",
@@ -29,7 +29,7 @@ Object {
       "message": "scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes",
       "targetType": "github-workflow",
     },
-    Object {
+    {
       "bucket": "actionlint",
       "code": "syntax-check",
       "file": ".github/workflows/empty.in.yaml",
@@ -37,31 +37,31 @@ Object {
       "issueUrl": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
       "level": "LEVEL_HIGH",
       "linter": "actionlint",
-      "message": "\\"jobs\\" section is missing in workflow",
+      "message": ""jobs" section is missing in workflow",
       "targetType": "github-workflow",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "github-workflow",
       "linter": "actionlint",
-      "paths": Array [
+      "paths": [
         ".github/workflows/bad.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "github-workflow",
       "linter": "actionlint",
-      "paths": Array [
+      "paths": [
         ".github/workflows/empty.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v5.4.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v5.4.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]+$\`\` pattern",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]+$\`\` pattern",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -121,28 +121,28 @@ Object {
       "targetType": "ansible",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v5.4.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v5.4.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]+$\`\` pattern",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]+$\`\` pattern",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "File permissions unset or incorrect",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing",
       "targetType": "ansible",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -121,28 +121,28 @@ Object {
       "targetType": "ansible",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.1.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.1.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -234,10 +234,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -247,10 +247,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -459,28 +459,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.1.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.1.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -234,10 +234,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -247,10 +247,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -459,28 +459,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.12.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.12.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Use FQCN for builtin module actions (wait_for).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[play]",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "All plays should be named.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use FQCN for builtin module actions (get_url).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Use FQCN for builtin module actions (unarchive).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "Use FQCN for builtin module actions (command).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use FQCN for builtin module actions (group).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Use FQCN for builtin module actions (user).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use FQCN for builtin module actions (file).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Use FQCN for builtin module actions (shell).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": "Use FQCN for module actions, such \`ansible.posix.firewalld\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -549,7 +549,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -562,7 +562,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -575,7 +575,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[play]",
       "column": "1",
@@ -589,28 +589,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.12.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.12.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "syntax-check[specific]",
       "column": "7",
@@ -17,28 +17,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.13.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.13.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Use FQCN for builtin module actions (wait_for).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[play]",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "All plays should be named.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use FQCN for builtin module actions (get_url).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Use FQCN for builtin module actions (unarchive).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "Use FQCN for builtin module actions (command).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use FQCN for builtin module actions (group).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Use FQCN for builtin module actions (user).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use FQCN for builtin module actions (file).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[octal-values]",
       "column": "1",
@@ -377,10 +377,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "59",
       "linter": "ansible-lint",
-      "message": "Forbidden implicit octal value \\"0755\\"",
+      "message": "Forbidden implicit octal value "0755"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Use FQCN for builtin module actions (shell).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -549,7 +549,7 @@ Object {
       "message": "Use FQCN for module actions, such \`ansible.posix.firewalld\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -562,7 +562,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -575,7 +575,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -588,7 +588,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[play]",
       "column": "1",
@@ -602,28 +602,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.13.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.13.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "syntax-check[specific]",
       "column": "7",
@@ -17,28 +17,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.5.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.5.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -260,10 +260,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -273,10 +273,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -511,28 +511,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.5.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.5.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -260,10 +260,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -273,10 +273,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -511,28 +511,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.6.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.6.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "schema",
       "column": "1",
@@ -171,7 +171,7 @@ If incorrect schema was picked, you might want to either:
 ",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -184,7 +184,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -197,7 +197,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -210,7 +210,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -223,7 +223,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -236,7 +236,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -249,7 +249,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -262,7 +262,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -275,7 +275,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -285,10 +285,10 @@ If incorrect schema was picked, you might want to either:
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -298,10 +298,10 @@ If incorrect schema was picked, you might want to either:
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -314,7 +314,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -327,7 +327,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -340,7 +340,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -353,7 +353,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -366,7 +366,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -379,7 +379,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -392,7 +392,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -405,7 +405,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -418,7 +418,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -431,7 +431,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -444,7 +444,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -457,7 +457,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -470,7 +470,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -483,7 +483,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -496,7 +496,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -509,7 +509,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -522,7 +522,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -536,28 +536,28 @@ If incorrect schema was picked, you might want to either:
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.6.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.6.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "schema",
       "column": "1",
@@ -171,7 +171,7 @@ If incorrect schema was picked, you might want to either:
 ",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -184,7 +184,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -197,7 +197,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -210,7 +210,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -223,7 +223,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -236,7 +236,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -249,7 +249,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -262,7 +262,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -275,7 +275,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -285,10 +285,10 @@ If incorrect schema was picked, you might want to either:
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -298,10 +298,10 @@ If incorrect schema was picked, you might want to either:
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -314,7 +314,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -327,7 +327,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -340,7 +340,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -353,7 +353,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -366,7 +366,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -379,7 +379,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -392,7 +392,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -405,7 +405,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -418,7 +418,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -431,7 +431,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -444,7 +444,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -457,7 +457,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -470,7 +470,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -483,7 +483,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -496,7 +496,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -509,7 +509,7 @@ If incorrect schema was picked, you might want to either:
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -522,7 +522,7 @@ If incorrect schema was picked, you might want to either:
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -536,28 +536,28 @@ If incorrect schema was picked, you might want to either:
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.6.1_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.6.1_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -260,10 +260,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -273,10 +273,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -511,28 +511,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.6.1_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.6.1_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Task/Handler: Extract archive",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Install Java 1.7 and some basic dependencies",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Task/Handler: Rename install directory",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -260,10 +260,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "37",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add group \\"jboss\\"",
+      "message": "Task/Handler: Add group "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -273,10 +273,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "41",
       "linter": "ansible-lint",
-      "message": "Task/Handler: Add user \\"jboss\\"",
+      "message": "Task/Handler: Add user "jboss"",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Task/Handler: Change ownership of JBoss installation",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Task/Handler: Copy the init script",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Enable JBoss to be started at boot",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is installed",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn-builtins",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: Ensure that firewalld is started",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -511,28 +511,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.8.0_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.8.0_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Action \`jboss\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Action \`jboss\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use \`ansible.builtin.get_url\` or \`ansible.legacy.get_url\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use \`ansible.builtin.unarchive\` or \`ansible.legacy.unarchive\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Use \`ansible.builtin.yum\` or \`ansible.legacy.yum\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use \`ansible.builtin.command\` or \`ansible.legacy.command\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Use \`ansible.builtin.template\` or \`ansible.legacy.template\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use \`ansible.builtin.group\` or \`ansible.legacy.group\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Use \`ansible.builtin.user\` or \`ansible.legacy.user\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use \`ansible.builtin.file\` or \`ansible.legacy.file\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use \`ansible.builtin.shell\` or \`ansible.legacy.shell\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Use \`ansible.builtin.template\` or \`ansible.legacy.template\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Use \`ansible.builtin.yum\` or \`ansible.legacy.yum\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "Action \`firewalld\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -550,28 +550,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.8.0_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.8.0_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Action \`jboss\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "Task/Handler: Copy application WAR file to host",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Action \`jboss\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "Task/Handler: restart jboss",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "Task/Handler: restart iptables",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use \`ansible.builtin.get_url\` or \`ansible.legacy.get_url\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "Task/Handler: Download JBoss from jboss.org",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use \`ansible.builtin.unarchive\` or \`ansible.legacy.unarchive\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Use \`ansible.builtin.yum\` or \`ansible.legacy.yum\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use \`ansible.builtin.command\` or \`ansible.legacy.command\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Use \`ansible.builtin.template\` or \`ansible.legacy.template\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "Task/Handler: Copying standalone.xml configuration file",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use \`ansible.builtin.group\` or \`ansible.legacy.group\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Use \`ansible.builtin.user\` or \`ansible.legacy.user\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use \`ansible.builtin.file\` or \`ansible.legacy.file\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use \`ansible.builtin.copy\` or \`ansible.legacy.copy\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use \`ansible.builtin.shell\` or \`ansible.legacy.shell\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Task/Handler: Workaround for systemd bug",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Use \`ansible.builtin.template\` or \`ansible.legacy.template\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "Task/Handler: deploy iptables rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Use \`ansible.builtin.yum\` or \`ansible.legacy.yum\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "Use \`ansible.builtin.service\` or \`ansible.legacy.service\` instead.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "Action \`firewalld\` is not FQCN.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "Task/Handler: deploy firewalld rules",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": undefined,
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml",
       "column": "1",
@@ -550,28 +550,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.8.7_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.8.7_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use FQCN for builtin module actions (get_url).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use FQCN for builtin module actions (unarchive).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use FQCN for builtin module actions (command).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use FQCN for builtin module actions (group).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Use FQCN for builtin module actions (user).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use FQCN for builtin module actions (file).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use FQCN for builtin module actions (shell).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "Use FQCN for module actions, such \`ansible.posix.firewalld\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -550,28 +550,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ansible-lint/test_data/ansible_lint_v6.8.7_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.8.7_non_FQCN.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -29,7 +29,7 @@ Object {
       "message": "Role name java-app does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -42,7 +42,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -55,7 +55,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -68,7 +68,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -81,7 +81,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -94,7 +94,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -107,7 +107,7 @@ Object {
       "message": "Use FQCN for module actions, such \`community.general.jboss\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "role-name",
       "column": "1",
@@ -120,7 +120,7 @@ Object {
       "message": "Role name jboss-standalone does not match \`\`^[a-z][a-z0-9_]*$\`\` pattern.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -133,7 +133,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -146,7 +146,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -172,7 +172,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -185,7 +185,7 @@ Object {
       "message": "Use FQCN for builtin module actions (get_url).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -198,7 +198,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -211,7 +211,7 @@ Object {
       "message": "Use FQCN for builtin module actions (unarchive).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -224,7 +224,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -237,7 +237,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -250,7 +250,7 @@ Object {
       "message": "Use FQCN for builtin module actions (command).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -263,7 +263,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -276,7 +276,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -289,7 +289,7 @@ Object {
       "message": "Use FQCN for builtin module actions (group).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -302,7 +302,7 @@ Object {
       "message": "Use FQCN for builtin module actions (user).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -315,7 +315,7 @@ Object {
       "message": "Use FQCN for builtin module actions (file).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -328,7 +328,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -341,7 +341,7 @@ Object {
       "message": "Use FQCN for builtin module actions (copy).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "command-instead-of-module",
       "column": "1",
@@ -354,7 +354,7 @@ Object {
       "message": "service used in place of service module",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -367,7 +367,7 @@ Object {
       "message": "Use FQCN for builtin module actions (shell).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "ignore-errors",
       "column": "1",
@@ -380,7 +380,7 @@ Object {
       "message": "Use failed_when and specify error conditions instead of using ignore_errors.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "no-changed-when",
       "column": "1",
@@ -393,7 +393,7 @@ Object {
       "message": "Commands should not change things if nothing needs doing.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -406,7 +406,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -419,7 +419,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -432,7 +432,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -445,7 +445,7 @@ Object {
       "message": "Use FQCN for builtin module actions (template).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -458,7 +458,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "risky-file-permissions",
       "column": "1",
@@ -471,7 +471,7 @@ Object {
       "message": "File permissions unset or incorrect.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -484,7 +484,7 @@ Object {
       "message": "Use FQCN for builtin module actions (yum).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action-core]",
       "column": "1",
@@ -497,7 +497,7 @@ Object {
       "message": "Use FQCN for builtin module actions (service).",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "fqcn[action]",
       "column": "1",
@@ -510,7 +510,7 @@ Object {
       "message": "Use FQCN for module actions, such \`ansible.posix.firewalld\`.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "name[casing]",
       "column": "1",
@@ -523,7 +523,7 @@ Object {
       "message": "All names should start with an uppercase letter.",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -536,7 +536,7 @@ Object {
       "message": "Truthy value should be one of [false, true]",
       "targetType": "custom",
     },
-    Object {
+    {
       "bucket": "ansible-lint",
       "code": "yaml[truthy]",
       "column": "1",
@@ -550,28 +550,28 @@ Object {
       "targetType": "custom",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "custom",
       "linter": "ansible-lint",
-      "paths": Array [
+      "paths": [
         "jboss-standalone",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/autopep8/test_data/autopep8_v1.5.7_basic.fmt.shot
+++ b/linters/autopep8/test_data/autopep8_v1.5.7_basic.fmt.shot
@@ -28,10 +28,10 @@ class Example3(object):
             bar = bar * bar
             return bar
         else:
-            some_string = \\"\\"\\"
+            some_string = """
                        Indentation in multiline strings should not be touched.
 Only actual code should be reindented.
-\\"\\"\\"
+"""
             return (sys.path, some_string)
 "
 `;

--- a/linters/bandit/test_data/bandit_v1.7.3_basic.check.shot
+++ b/linters/bandit/test_data/bandit_v1.7.3_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter bandit test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "bandit",
       "code": "B403",
       "file": "test_data/basic.in.py",
@@ -14,7 +14,7 @@ Object {
       "message": "Consider possible security implications associated with dill module.",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "bandit",
       "code": "B301",
       "file": "test_data/basic.in.py",
@@ -26,18 +26,18 @@ Object {
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "bandit",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/black/test_data/black_py_v22.3.0_basic.fmt.shot
+++ b/linters/black/test_data/black_py_v22.3.0_basic.fmt.shot
@@ -4,7 +4,7 @@ exports[`Testing formatter black-py test basic 1`] = `
 "# whitespace below vvv
 
 # A malindented comment
-if __name__ == \\"__main__\\":
+if __name__ == "__main__":
     a = 4 + 1
     b = 2 * 7
     c = [1, 2, 3]

--- a/linters/black/test_data/black_v22.3.0_basic.fmt.shot
+++ b/linters/black/test_data/black_v22.3.0_basic.fmt.shot
@@ -4,7 +4,7 @@ exports[`Testing formatter black test basic 1`] = `
 "# whitespace below vvv
 
 # A malindented comment
-if __name__ == \\"__main__\\":
+if __name__ == "__main__":
     a = 4 + 1
     b = 2 * 7
     c = [1, 2, 3]

--- a/linters/black/test_data/black_v22.3.0_basic_nb.fmt.shot
+++ b/linters/black/test_data/black_v22.3.0_basic_nb.fmt.shot
@@ -2,41 +2,41 @@
 
 exports[`Testing formatter black test basic_nb 1`] = `
 "{
- \\"nbformat\\": 4,
- \\"nbformat_minor\\": 0,
- \\"metadata\\": {
-  \\"colab\\": {
-   \\"provenance\\": []
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "provenance": []
   },
-  \\"kernelspec\\": {
-   \\"name\\": \\"python3\\",
-   \\"display_name\\": \\"Python 3\\"
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
   },
-  \\"language_info\\": {
-   \\"name\\": \\"python\\"
+  "language_info": {
+   "name": "python"
   }
  },
- \\"cells\\": [
+ "cells": [
   {
-   \\"cell_type\\": \\"markdown\\",
-   \\"source\\": [
-    \\"# Test Notebook\\"
+   "cell_type": "markdown",
+   "source": [
+    "# Test Notebook"
    ],
-   \\"metadata\\": {
-    \\"id\\": \\"LbWsYSsF_n0F\\"
+   "metadata": {
+    "id": "LbWsYSsF_n0F"
    }
   },
   {
-   \\"cell_type\\": \\"code\\",
-   \\"execution_count\\": null,
-   \\"metadata\\": {
-    \\"id\\": \\"LhkRbbgv_QeE\\"
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LhkRbbgv_QeE"
    },
-   \\"outputs\\": [],
-   \\"source\\": [
-    \\"# A malindented comment\\\\n\\",
-    \\"\\\\n\\",
-    \\"print(\\\\\\"Hello World!\\\\\\")\\"
+   "outputs": [],
+   "source": [
+    "# A malindented comment\\n",
+    "\\n",
+    "print(\\"Hello World!\\")"
    ]
   }
  ]

--- a/linters/brakeman/test_data/brakeman_v5.4.0_CUSTOM.check.shot
+++ b/linters/brakeman/test_data/brakeman_v5.4.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter brakeman test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "brakeman",
       "code": "EOLRails",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
       "message": "Support for Rails 5.2.8.1 ended on 2022-06-01",
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "brakeman",
       "code": "Evaluation",
       "column": "1",
@@ -30,28 +30,28 @@ Object {
       "targetType": "ruby",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ruby",
       "linter": "brakeman",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ruby",
       "linter": "brakeman",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/buf/test_data/buf_format_v1.2.0_buf_lint.fmt.shot
+++ b/linters/buf/test_data/buf_format_v1.2.0_buf_lint.fmt.shot
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing formatter buf-format test buf_lint 1`] = `
-"syntax = \\"proto3\\";
+"syntax = "proto3";
 
 package trunk;
 

--- a/linters/buf/test_data/buf_lint_v1.1.0_buf_lint.check.shot
+++ b/linters/buf/test_data/buf_lint_v1.1.0_buf_lint.check.shot
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter buf-lint test buf_lint 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "buf-lint",
       "code": "FILE_LOWER_SNAKE_CASE",
       "file": "test_data/buf_lint.in.proto",
       "issueUrl": "https://docs.buf.build/lint/rules#file_lower_snake_case",
       "level": "LEVEL_HIGH",
       "linter": "buf-lint",
-      "message": "Filename \\"buf_lint.in.proto\\" should be lower_snake_case.proto, such as \\"buf_lint_in.proto\\".",
+      "message": "Filename "buf_lint.in.proto" should be lower_snake_case.proto, such as "buf_lint_in.proto".",
       "targetType": "proto",
     },
-    Object {
+    {
       "bucket": "buf-lint",
       "code": "PACKAGE_DIRECTORY_MATCH",
       "column": "1",
@@ -22,10 +22,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "4",
       "linter": "buf-lint",
-      "message": "Files with package \\"trunk\\" must be within a directory \\"trunk\\" relative to root but were in directory \\"test_data\\".",
+      "message": "Files with package "trunk" must be within a directory "trunk" relative to root but were in directory "test_data".",
       "targetType": "proto",
     },
-    Object {
+    {
       "bucket": "buf-lint",
       "code": "PACKAGE_VERSION_SUFFIX",
       "column": "1",
@@ -34,10 +34,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "4",
       "linter": "buf-lint",
-      "message": "Package name \\"trunk\\" should be suffixed with a correctly formed version, such as \\"trunk.v1\\".",
+      "message": "Package name "trunk" should be suffixed with a correctly formed version, such as "trunk.v1".",
       "targetType": "proto",
     },
-    Object {
+    {
       "bucket": "buf-lint",
       "code": "ENUM_VALUE_PREFIX",
       "column": "3",
@@ -46,10 +46,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "7",
       "linter": "buf-lint",
-      "message": "Enum value name \\"lower_case_UNSPECIFIED\\" should be prefixed with \\"GOOD_ENUM_\\".",
+      "message": "Enum value name "lower_case_UNSPECIFIED" should be prefixed with "GOOD_ENUM_".",
       "targetType": "proto",
     },
-    Object {
+    {
       "bucket": "buf-lint",
       "code": "ENUM_VALUE_UPPER_SNAKE_CASE",
       "column": "3",
@@ -58,22 +58,22 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "7",
       "linter": "buf-lint",
-      "message": "Enum value name \\"lower_case_UNSPECIFIED\\" should be UPPER_SNAKE_CASE, such as \\"LOWER_CASE_UNSPECIFIED\\".",
+      "message": "Enum value name "lower_case_UNSPECIFIED" should be UPPER_SNAKE_CASE, such as "LOWER_CASE_UNSPECIFIED".",
       "targetType": "proto",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "proto",
       "linter": "buf-lint",
-      "paths": Array [
+      "paths": [
         "test_data/buf_lint.in.proto",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/buildifier/test_data/buildifier_v4.0.1_basic.check.shot
+++ b/linters/buildifier/test_data/buildifier_v4.0.1_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter buildifier test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "buildifier",
       "code": "module-docstring",
       "column": "1",
@@ -16,7 +16,7 @@ Object {
 A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines).",
       "targetType": "starlark",
     },
-    Object {
+    {
       "bucket": "buildifier",
       "code": "load",
       "column": "26",
@@ -25,16 +25,16 @@ A module docstring is a string literal (not a comment) which should be the first
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "buildifier",
-      "message": "Loaded symbol \\"a\\" is unused. Please remove it.
+      "message": "Loaded symbol "a" is unused. Please remove it.
 To disable the warning, add '@unused' in a comment.
 If you want to re-export a symbol, use the following pattern:
 
-    load(..., _a = \\"a\\", ...)
+    load(..., _a = "a", ...)
     a = _a
 ",
       "targetType": "starlark",
     },
-    Object {
+    {
       "bucket": "buildifier",
       "code": "out-of-order-load",
       "column": "1",
@@ -46,7 +46,7 @@ If you want to re-export a symbol, use the following pattern:
       "message": "Load statement is out of its lexicographical order.",
       "targetType": "starlark",
     },
-    Object {
+    {
       "bucket": "buildifier",
       "code": "load",
       "column": "26",
@@ -55,39 +55,39 @@ If you want to re-export a symbol, use the following pattern:
       "level": "LEVEL_HIGH",
       "line": "2",
       "linter": "buildifier",
-      "message": "Loaded symbol \\"b\\" is unused. Please remove it.
+      "message": "Loaded symbol "b" is unused. Please remove it.
 To disable the warning, add '@unused' in a comment.
 If you want to re-export a symbol, use the following pattern:
 
-    load(..., _b = \\"b\\", ...)
+    load(..., _b = "b", ...)
     b = _b
 ",
       "targetType": "starlark",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fix",
       "fileGroupName": "starlark",
       "linter": "buildifier",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.bzl",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "warn",
       "fileGroupName": "starlark",
       "linter": "buildifier",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.bzl",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic.in.bzl",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/buildifier/test_data/buildifier_v4.0.1_basic.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v4.0.1_basic.fmt.shot
@@ -5,6 +5,6 @@ exports[`Testing formatter buildifier test basic 1`] = `
 def eponymous_name():
     name = native.package_name()
 
-    return name[name.rfind(\\"/\\") + 1:]
+    return name[name.rfind("/") + 1:]
 "
 `;

--- a/linters/cfnlint/test_data/cfnlint_v0.58.2_basic.check.shot
+++ b/linters/cfnlint/test_data/cfnlint_v0.58.2_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter cfnlint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "cfnlint",
       "code": "E3030",
       "column": "7",
@@ -12,10 +12,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "19",
       "linter": "cfnlint",
-      "message": "You must specify a valid value for ValidationMethod (DNSS). Valid values are [\\"DNS\\", \\"EMAIL\\"]",
+      "message": "You must specify a valid value for ValidationMethod (DNSS). Valid values are ["DNS", "EMAIL"]",
       "targetType": "cloudformation",
     },
-    Object {
+    {
       "bucket": "cfnlint",
       "code": "E3002",
       "column": "7",
@@ -28,18 +28,18 @@ Object {
       "targetType": "cloudformation",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "cloudformation",
       "linter": "cfnlint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clang-format/test_data/clang_format_v14.0.0_proto.fmt.shot
+++ b/linters/clang-format/test_data/clang_format_v14.0.0_proto.fmt.shot
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing formatter clang-format test proto 1`] = `
-"syntax = \\"proto3\\";
+"syntax = "proto3";
 
 message MyMessage {
   int32 a = 1;

--- a/linters/clang-tidy/test_data/clang_tidy_v15.0.6_default_config.check.shot
+++ b/linters/clang-tidy/test_data/clang_tidy_v15.0.6_default_config.check.shot
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clang-tidy test default_config 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test.hh",
               "offset": "14",
               "replacementText": "static ",
@@ -27,45 +27,45 @@ Object {
       "targetType": "c++-source",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "a_includes.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "b_includes.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "basic.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "test.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clang-tidy/test_data/clang_tidy_v15.0.6_test_config.check.shot
+++ b/linters/clang-tidy/test_data/clang_tidy_v15.0.6_test_config.check.shot
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clang-tidy test test_config 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "basic.cc",
               "length": "6",
               "offset": "29",
@@ -27,11 +27,11 @@ Object {
       "message": "invalid case style for constexpr variable 'unused'",
       "targetType": "c++-source",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test.hh",
               "offset": "14",
               "replacementText": "static ",
@@ -51,45 +51,45 @@ Object {
       "targetType": "c++-source",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "a_includes.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "b_includes.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "basic.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "clang-tidy",
-      "paths": Array [
+      "paths": [
         "test.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_basic.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "clippy",
       "code": "needless_range_loop",
       "column": "14",
@@ -14,8 +14,8 @@ Object {
       "line": "21",
       "linter": "clippy",
       "message": "the loop variable \`i\` is only used to index \`vec\`",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "src/main.rs",
           "length": "12",
           "offset": "542",
@@ -23,7 +23,7 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
+    {
       "bucket": "clippy",
       "code": "manual_non_exhaustive",
       "column": "1",
@@ -34,8 +34,8 @@ Object {
       "line": "4",
       "linter": "clippy",
       "message": "this seems like a manual implementation of the non-exhaustive pattern",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "src/main.rs",
           "length": "79",
           "offset": "230",
@@ -44,18 +44,18 @@ Object {
       "targetType": "rust",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "rust",
       "linter": "clippy",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_complex.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_complex.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test complex 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "clippy",
       "code": "dead_code",
       "column": "4",
@@ -14,8 +14,8 @@ Object {
       "line": "1",
       "linter": "clippy",
       "message": "function \`do_bad_math\` is never used",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "src/high.rs",
           "length": "11",
           "offset": "3",
@@ -23,7 +23,7 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
+    {
       "bucket": "clippy",
       "code": "arithmetic_overflow",
       "column": "13",
@@ -34,8 +34,8 @@ Object {
       "line": "2",
       "linter": "clippy",
       "message": "this arithmetic operation will overflow",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "src/high.rs",
           "length": "11",
           "offset": "31",
@@ -44,18 +44,18 @@ Object {
       "targetType": "rust",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "rust",
       "linter": "clippy",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_complex_subdir.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_complex_subdir.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test complex_subdir 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "clippy",
       "code": "dead_code",
       "column": "4",
@@ -14,8 +14,8 @@ Object {
       "line": "1",
       "linter": "clippy",
       "message": "function \`do_bad_math\` is never used",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/complex_subdir/src/high.rs",
           "length": "11",
           "offset": "3",
@@ -23,7 +23,7 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
+    {
       "bucket": "clippy",
       "code": "arithmetic_overflow",
       "column": "5",
@@ -34,8 +34,8 @@ Object {
       "line": "2",
       "linter": "clippy",
       "message": "this arithmetic operation will overflow",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/complex_subdir/src/high.rs",
           "length": "11",
           "offset": "23",
@@ -43,7 +43,7 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
+    {
       "bucket": "clippy",
       "code": "no_effect",
       "column": "5",
@@ -54,8 +54,8 @@ Object {
       "line": "2",
       "linter": "clippy",
       "message": "statement with no effect",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/complex_subdir/src/high.rs",
           "length": "12",
           "offset": "23",
@@ -63,11 +63,11 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/complex_subdir/src/high.rs",
               "offset": "23",
               "replacementText": "let _ = ",
@@ -85,8 +85,8 @@ Object {
       "line": "2",
       "linter": "clippy",
       "message": "unused bitwise operation that must be used",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/complex_subdir/src/high.rs",
           "length": "11",
           "offset": "23",
@@ -94,11 +94,11 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/complex_subdir/src/main.rs",
               "length": "15",
               "offset": "60",
@@ -117,8 +117,8 @@ Object {
       "line": "6",
       "linter": "clippy",
       "message": "this binary expression can be simplified",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/complex_subdir/src/main.rs",
           "length": "15",
           "offset": "60",
@@ -127,18 +127,18 @@ Object {
       "targetType": "rust",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "rust",
       "linter": "clippy",
-      "paths": Array [
+      "paths": [
         "test_data/complex_subdir",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_malformed.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_malformed.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test malformed 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "clippy",
       "code": "E0583",
       "column": "1",
@@ -14,8 +14,8 @@ Object {
       "line": "3",
       "linter": "clippy",
       "message": "file not found for module \`high\`",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "src/main.rs",
           "length": "9",
           "offset": "118",
@@ -24,18 +24,18 @@ Object {
       "targetType": "rust",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "rust",
       "linter": "clippy",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_malformed_subdir.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_malformed_subdir.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test malformed_subdir 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "clippy",
       "code": "compiler",
       "column": "1",
@@ -14,8 +14,8 @@ Object {
       "line": "10",
       "linter": "clippy",
       "message": "expected item, found \`<eof>\`",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/malformed_subdir/src/main.rs",
           "length": "1",
           "offset": "225",
@@ -23,11 +23,11 @@ Object {
       ],
       "targetType": "rust",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/malformed_subdir/src/main.rs",
               "offset": "126",
               "replacementText": ";",
@@ -45,13 +45,13 @@ Object {
       "line": "5",
       "linter": "clippy",
       "message": "expected \`;\`, found keyword \`fn\`",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/malformed_subdir/src/main.rs",
           "length": "2",
           "offset": "128",
         },
-        Object {
+        {
           "filePath": "test_data/malformed_subdir/src/main.rs",
           "offset": "126",
         },
@@ -59,18 +59,18 @@ Object {
       "targetType": "rust",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "rust",
       "linter": "clippy",
-      "paths": Array [
+      "paths": [
         "test_data/malformed_subdir",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/clippy/test_data/clippy_v1.65.0_src.main.rs.check.shot
+++ b/linters/clippy/test_data/clippy_v1.65.0_src.main.rs.check.shot
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter clippy test basic 1`] = `
-"// clippy/manual_non_exhaustive has {\\"suggested_replacement\\": null} in its JSON, so we want to
+"// clippy/manual_non_exhaustive has {"suggested_replacement": null} in its JSON, so we want to
 // explicitly test that. Note that a match {} block against this enum in the callgraph needs to
 // be compiled to actually trigger it.
 pub enum Gibberish {
@@ -14,21 +14,21 @@ fn main() {
     let x = 1;
     let y = 2;
     if x <= y {}
-    println!(\\"Hello World\\");
+    println!("Hello World");
 
     // empty format literal
-    println!(\\"empty format literal\\");
+    println!("empty format literal");
 
     // needless range loop
     let vec = vec!['a', 'b', 'c'];
     for i in 0..vec.len() {
-        println!(\\"{}\\", vec[i]);
+        println!("{}", vec[i]);
 
     }
     // manual nonexhaustive
-    let z = Gibberish::Foo(\\"fizz\\".to_string());
-    println!(\\"gibberish is {}\\", match z {
-        Gibberish::Foo(_) => \\"buzz\\",
+    let z = Gibberish::Foo("fizz".to_string());
+    println!("gibberish is {}", match z {
+        Gibberish::Foo(_) => "buzz",
         Gibberish::__Nonexhaustive => unreachable!(),
     });
 }
@@ -42,7 +42,7 @@ fn main() {
     let x = 1;
     let y = 2;
     if x <= y {}
-    println!(\\"Hello World\\");
+    println!("Hello World");
 }
 "
 `;
@@ -56,7 +56,7 @@ fn main() {
     let x = 1;
     let y = 2;
     if x == y || x < y {}
-    println!(\\"Hello World\\");
+    println!("Hello World");
 }
 "
 `;

--- a/linters/cue-fmt/test_data/cue_fmt_v0.4.3_basic.fmt.shot
+++ b/linters/cue-fmt/test_data/cue_fmt_v0.4.3_basic.fmt.shot
@@ -6,6 +6,6 @@ exports[`Testing formatter cue-fmt test basic 1`] = `
 	b?: int // a useful comment
 }
 foo: #Bar
-foo: {a: \\"a\\"}
+foo: {a: "a"}
 "
 `;

--- a/linters/detekt/test_data/detekt_explicit_v1.19.0_basic_explicit.check.shot
+++ b/linters/detekt/test_data/detekt_explicit_v1.19.0_basic_explicit.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter detekt-explicit test basic_explicit 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "kotlin",
       "linter": "detekt-explicit",
-      "paths": Array [
+      "paths": [
         "test_data/basic_explicit.in.kt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/detekt/test_data/detekt_explicit_v1.21.0_basic_explicit.check.shot
+++ b/linters/detekt/test_data/detekt_explicit_v1.21.0_basic_explicit.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter detekt-explicit test basic_explicit 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "kotlin",
       "linter": "detekt-explicit",
-      "paths": Array [
+      "paths": [
         "test_data/basic_explicit.in.kt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/detekt/test_data/detekt_gradle_CUSTOM.check.shot
+++ b/linters/detekt/test_data/detekt_gradle_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter detekt-gradle test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "detekt-gradle",
       "code": "detekt.potential-bugs.EqualsWithHashCodeExist",
       "column": "12",
@@ -15,18 +15,18 @@ Object {
       "targetType": "kotlin",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "kotlin",
       "linter": "detekt-gradle",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/detekt/test_data/detekt_v1.19.0_basic_detekt.check.shot
+++ b/linters/detekt/test_data/detekt_v1.19.0_basic_detekt.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter detekt test basic_detekt 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "detekt",
       "code": "detekt.style.MagicNumber",
       "column": "15",
@@ -14,7 +14,7 @@ Object {
       "message": "This expression contains a magic number. Consider defining it to a well named constant.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.style.MagicNumber",
       "column": "3",
@@ -25,7 +25,7 @@ Object {
       "message": "This expression contains a magic number. Consider defining it to a well named constant.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.style.FunctionOnlyReturningConstant",
       "column": "5",
@@ -36,7 +36,7 @@ Object {
       "message": "constantInt is returning a constant. Prefer declaring a constant instead.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.potential-bugs.EqualsWithHashCodeExist",
       "column": "12",
@@ -48,18 +48,18 @@ Object {
       "targetType": "kotlin",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "kotlin",
       "linter": "detekt",
-      "paths": Array [
+      "paths": [
         "test_data/basic_detekt.in.kt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/detekt/test_data/detekt_v1.21.0_basic_detekt.check.shot
+++ b/linters/detekt/test_data/detekt_v1.21.0_basic_detekt.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter detekt test basic_detekt 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "detekt",
       "code": "detekt.style.MagicNumber",
       "column": "15",
@@ -14,7 +14,7 @@ Object {
       "message": "This expression contains a magic number. Consider defining it to a well named constant.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.style.MagicNumber",
       "column": "3",
@@ -25,7 +25,7 @@ Object {
       "message": "This expression contains a magic number. Consider defining it to a well named constant.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.naming.InvalidPackageDeclaration",
       "column": "1",
@@ -36,7 +36,7 @@ Object {
       "message": "The package declaration does not match the actual file location.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.style.FunctionOnlyReturningConstant",
       "column": "5",
@@ -47,7 +47,7 @@ Object {
       "message": "constantInt is returning a constant. Prefer declaring a constant instead.",
       "targetType": "kotlin",
     },
-    Object {
+    {
       "bucket": "detekt",
       "code": "detekt.potential-bugs.EqualsWithHashCodeExist",
       "column": "12",
@@ -59,18 +59,18 @@ Object {
       "targetType": "kotlin",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "kotlin",
       "linter": "detekt",
-      "paths": Array [
+      "paths": [
         "test_data/basic_detekt.in.kt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/eslint/test_data/eslint_v8.10.0_CUSTOM.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter eslint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "1",
@@ -15,7 +15,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-unused-vars",
       "column": "10",
@@ -27,7 +27,7 @@ Object {
       "message": "'zaphod' is defined but never used.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "import/no-unresolved",
       "column": "24",
@@ -39,7 +39,7 @@ Object {
       "message": "Unable to resolve path to module 'beetlebrox'.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-missing-import",
       "column": "24",
@@ -48,10 +48,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "2",
       "linter": "eslint",
-      "message": "\\"beetlebrox\\" is not found.",
+      "message": ""beetlebrox" is not found.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "1",
@@ -63,7 +63,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-unused-vars",
       "column": "10",
@@ -75,7 +75,7 @@ Object {
       "message": "'arthur' is defined but never used.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "import/no-unresolved",
       "column": "24",
@@ -87,7 +87,7 @@ Object {
       "message": "Unable to resolve path to module 'dent'.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-missing-import",
       "column": "24",
@@ -96,10 +96,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "3",
       "linter": "eslint",
-      "message": "\\"dent\\" is not found.",
+      "message": ""dent" is not found.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "1",
@@ -111,7 +111,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-unused-vars",
       "column": "10",
@@ -123,7 +123,7 @@ Object {
       "message": "'ford' is defined but never used.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "import/no-unresolved",
       "column": "22",
@@ -135,7 +135,7 @@ Object {
       "message": "Unable to resolve path to module 'prefect'.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-missing-import",
       "column": "22",
@@ -144,10 +144,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "4",
       "linter": "eslint",
-      "message": "\\"prefect\\" is not found.",
+      "message": ""prefect" is not found.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "1",
@@ -159,7 +159,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "3",
@@ -171,7 +171,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "36",
@@ -183,7 +183,7 @@ Object {
       "message": "Unexpected any. Specify a different type.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "53",
@@ -195,7 +195,7 @@ Object {
       "message": "Unexpected any. Specify a different type.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "60",
@@ -207,7 +207,7 @@ Object {
       "message": "Unexpected any. Specify a different type.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "3",
@@ -219,7 +219,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "54",
@@ -231,7 +231,7 @@ Object {
       "message": "Unexpected any. Specify a different type.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "node/no-unsupported-features/es-syntax",
       "column": "3",
@@ -243,7 +243,7 @@ Object {
       "message": "Import and export declarations are not supported yet.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "42",
@@ -255,7 +255,7 @@ Object {
       "message": "Unexpected any. Specify a different type.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "eslint",
       "code": "@typescript-eslint/no-explicit-any",
       "column": "49",
@@ -268,36 +268,36 @@ Object {
       "targetType": "typescript",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "typescript",
       "linter": "eslint",
-      "paths": Array [
+      "paths": [
         "test_data/eof_autofix.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "typescript",
       "linter": "eslint",
-      "paths": Array [
+      "paths": [
         "test_data/format_imports.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "typescript",
       "linter": "eslint",
-      "paths": Array [
+      "paths": [
         "test_data/non_ascii.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter eslint test bad_install 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [],
-  "taskFailures": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [],
+  "taskFailures": [
+    {
       "details": StringMatching /\\.\\*\\$/m,
       "message": "test_data/eof_autofix.ts... (4 files)",
       "name": "eslint",
     },
-    Object {
+    {
       "details": StringMatching /\\.\\*\\$/m,
       "message": "test_data/eof_autofix.ts... (4 files)",
       "name": "eslint",
     },
   ],
-  "unformattedFiles": Array [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/eslint/test_data/eslint_v8.10.0_test_data.eof_autofix.ts.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_test_data.eof_autofix.ts.check.shot
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter eslint test CUSTOM 1`] = `
-"/* eslint \\"eol-last\\": \\"error\\" */
-\\"perfectly normal ascii string\\";
+"/* eslint "eol-last": "error" */
+"perfectly normal ascii string";
 "
 `;

--- a/linters/eslint/test_data/eslint_v8.10.0_test_data.format_imports.ts.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_test_data.format_imports.ts.check.shot
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter eslint test CUSTOM 1`] = `
-"/* eslint \\"import/first\\": \\"error\\" */
-import { zaphod } from \\"beetlebrox\\";
-import { arthur } from \\"dent\\";
-import { ford } from \\"prefect\\";
+"/* eslint "import/first": "error" */
+import { zaphod } from "beetlebrox";
+import { arthur } from "dent";
+import { ford } from "prefect";
 
 export interface Marvin {
   paranoid: boolean;

--- a/linters/flake8/test_data/flake8_v4.0.1_basic.check.shot
+++ b/linters/flake8/test_data/flake8_v4.0.1_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter flake8 test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "flake8",
       "code": "E402",
       "column": "1",
@@ -15,7 +15,7 @@ Object {
       "message": "module level import not at top of file",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "flake8",
       "code": "F401",
       "column": "1",
@@ -27,7 +27,7 @@ Object {
       "message": "'sys' imported but unused",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "trunk",
       "code": "ignore-does-nothing",
       "column": "3",
@@ -39,18 +39,18 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "flake8",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/git-diff-check/test_data/git_diff_check_basic.check.shot
+++ b/linters/git-diff-check/test_data/git_diff_check_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter git-diff-check test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "git-diff-check",
       "code": "error",
       "column": "1",
@@ -14,7 +14,7 @@ Object {
       "message": " leftover conflict marker",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "git-diff-check",
       "code": "error",
       "column": "1",
@@ -25,7 +25,7 @@ Object {
       "message": " leftover conflict marker",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "git-diff-check",
       "code": "error",
       "column": "1",
@@ -37,18 +37,18 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "git-diff-check",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.txt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/git-diff-check/test_data/git_diff_check_conflict.check.shot
+++ b/linters/git-diff-check/test_data/git_diff_check_conflict.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter git-diff-check test conflict 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "git-diff-check",
-      "paths": Array [
+      "paths": [
         "test_data/conflict.in.txt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gitleaks/test_data/gitleaks_v7.0.0_basic.check.shot
+++ b/linters/gitleaks/test_data/gitleaks_v7.0.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gitleaks test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "gitleaks",
       "column": "1",
       "file": "test_data/basic.py",
@@ -14,7 +14,7 @@ Object {
       "message": "AWS Access Key secret detected",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "gitleaks",
       "column": "1",
       "file": "test_data/basic.py",
@@ -26,28 +26,28 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gitleaks/test_data/gitleaks_v8.0.5_basic.check.shot
+++ b/linters/gitleaks/test_data/gitleaks_v8.0.5_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gitleaks test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "23",
@@ -16,28 +16,28 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gitleaks/test_data/gitleaks_v8.1.2_basic.check.shot
+++ b/linters/gitleaks/test_data/gitleaks_v8.1.2_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gitleaks test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "22",
@@ -14,7 +14,7 @@ Object {
       "message": "aws-access-token has detected secret for file test_data/basic.py.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "23",
@@ -27,28 +27,28 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gitleaks/test_data/gitleaks_v8.1.3_basic.check.shot
+++ b/linters/gitleaks/test_data/gitleaks_v8.1.3_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gitleaks test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "22",
@@ -15,7 +15,7 @@ Object {
       "message": "aws-access-token has detected secret for file test_data/basic.py.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "23",
@@ -28,28 +28,28 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gitleaks/test_data/gitleaks_v8.8.7_basic.check.shot
+++ b/linters/gitleaks/test_data/gitleaks_v8.8.7_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gitleaks test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "22",
@@ -15,7 +15,7 @@ Object {
       "message": "aws-access-token has detected secret for file test_data/basic.py.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "gitleaks",
       "code": "aws-access-token",
       "column": "23",
@@ -28,28 +28,28 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ALL",
       "linter": "gitleaks",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/gofmt/test_data/gofmt_v1.19.3_empty.check.shot
+++ b/linters/gofmt/test_data/gofmt_v1.19.3_empty.check.shot
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter gofmt test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [],
-  "taskFailures": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [],
+  "taskFailures": [
+    {
       "details": StringMatching /\\.\\*\\$/m,
       "message": "test_data/empty.in.go",
       "name": "gofmt",
     },
   ],
-  "unformattedFiles": Array [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/goimports/test_data/goimports_v0.1.10_basic.fmt.shot
+++ b/linters/goimports/test_data/goimports_v0.1.10_basic.fmt.shot
@@ -3,11 +3,11 @@
 exports[`Testing formatter goimports test basic 1`] = `
 "package main
 
-import \\"fmt\\"
+import "fmt"
 
 // 🧗.
 func main() {
-	fmt.Println(\\"Hello world\\")
+	fmt.Println("Hello world")
 
 }
 "

--- a/linters/goimports/test_data/goimports_v0.1.10_empty.check.shot
+++ b/linters/goimports/test_data/goimports_v0.1.10_empty.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter goimports test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "go",
       "linter": "goimports",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.go",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.46.2_CUSTOM.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.46.2_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter golangci-lint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "golangci-lint",
       "code": "deadcode",
       "column": "6",
@@ -15,7 +15,7 @@ Object {
       "message": "\`helper\` is unused",
       "targetType": "go",
     },
-    Object {
+    {
       "bucket": "golangci-lint",
       "code": "typecheck",
       "column": "23",
@@ -28,18 +28,18 @@ Object {
       "targetType": "go",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.46.2_empty.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.46.2_empty.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter golangci-lint test empty 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "golangci-lint",
       "code": "typecheck",
       "column": "1",
@@ -15,7 +15,7 @@ Object {
       "message": "expected 'package', found 'EOF'",
       "targetType": "go",
     },
-    Object {
+    {
       "bucket": "golangci-lint",
       "code": "deadcode",
       "column": "6",
@@ -27,7 +27,7 @@ Object {
       "message": "\`helper\` is unused",
       "targetType": "go",
     },
-    Object {
+    {
       "bucket": "golangci-lint",
       "code": "typecheck",
       "column": "23",
@@ -40,36 +40,36 @@ Object {
       "targetType": "go",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         "test_data/wrapper",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.46.2_unbuildable.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.46.2_unbuildable.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter golangci-lint test unbuildable 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "golangci-lint",
       "code": "error",
       "file": ".",
@@ -13,18 +13,18 @@ Object {
       "targetType": "go",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.49.0_empty.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.49.0_empty.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter golangci-lint test empty 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "golangci-lint",
       "code": "typecheck",
       "column": "1",
@@ -15,7 +15,7 @@ Object {
       "message": "expected 'package', found 'EOF'",
       "targetType": "go",
     },
-    Object {
+    {
       "bucket": "golangci-lint",
       "code": "unused",
       "column": "6",
@@ -27,7 +27,7 @@ Object {
       "message": "func \`helper\` is unused",
       "targetType": "go",
     },
-    Object {
+    {
       "bucket": "golangci-lint",
       "code": "typecheck",
       "column": "23",
@@ -40,36 +40,36 @@ Object {
       "targetType": "go",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         ".",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "go",
       "linter": "golangci-lint",
-      "paths": Array [
+      "paths": [
         "test_data/wrapper",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/hadolint/test_data/hadolint_v2.8.0_CUSTOM.check.shot
+++ b/linters/hadolint/test_data/hadolint_v2.8.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter hadolint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "hadolint",
       "code": "DL3059",
       "column": "1",
@@ -17,142 +17,142 @@ Object {
       "targetType": "docker",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/Dockerfile.empty",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/empty.Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/Dockerfile.debug",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/prefix.Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/Dockerfile",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/Dockerfile.empty",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/empty.Dockerfile",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/Dockerfile.debug",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/dockerfile",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "docker",
       "linter": "hadolint",
-      "paths": Array [
+      "paths": [
         "test_data/nested/prefix.Dockerfile",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/haml-lint/test_data/haml_lint_v0.40.0_CUSTOM.check.shot
+++ b/linters/haml-lint/test_data/haml_lint_v0.40.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter haml-lint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "haml-lint",
       "code": "IdNames",
       "file": "test_data/basic.haml",
@@ -13,7 +13,7 @@ Object {
       "message": "\`id\` attribute must be in lisp-case",
       "targetType": "haml",
     },
-    Object {
+    {
       "bucket": "haml-lint",
       "code": "EmptyScript",
       "file": "test_data/basic.haml",
@@ -23,7 +23,7 @@ Object {
       "message": "Empty script should be removed",
       "targetType": "haml",
     },
-    Object {
+    {
       "bucket": "haml-lint",
       "code": "SpaceBeforeScript",
       "file": "test_data/basic.haml",
@@ -34,27 +34,27 @@ Object {
       "targetType": "haml",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "haml",
       "linter": "haml-lint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.haml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "haml",
       "linter": "haml-lint",
-      "paths": Array [
+      "paths": [
         "test_data/empty.haml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/isort/test_data/isort_v5.9.3_basic.fmt.shot
+++ b/linters/isort/test_data/isort_v5.9.3_basic.fmt.shot
@@ -26,7 +26,7 @@ from third_party import (
     lib15,
 )
 
-print(\\"Hey\\")
-print(\\"yo\\")
+print("Hey")
+print("yo")
 "
 `;

--- a/linters/iwyu/test_data/include_what_you_use_v0.19_CUSTOM.check.shot
+++ b/linters/iwyu/test_data/include_what_you_use_v0.19_CUSTOM.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter include-what-you-use test CUSTOM 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "c++-source",
       "linter": "include-what-you-use",
-      "paths": Array [
+      "paths": [
         "test.cc",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/iwyu/test_data/include_what_you_use_v0.19_test.cc.check.shot
+++ b/linters/iwyu/test_data/include_what_you_use_v0.19_test.cc.check.shot
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter include-what-you-use test CUSTOM 1`] = `
-"#include \\"a.hh\\"
-#include \\"c.hh\\"
+"#include "a.hh"
+#include "c.hh"
 
 inline void F() {
   A();

--- a/linters/ktlint/test_data/ktlint_v0.43.2_utf8.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v0.43.2_utf8.fmt.shot
@@ -5,14 +5,14 @@ exports[`Testing formatter ktlint test utf8 1`] = `
 
 fun main(args: Array<String>) {
   println(
-    \\"\\"\\"
+    """
         ┌───────────┬───────────┬────────────┐
         │   BLOCK   │   FORM    │ ADDED_DATE │
         ├───────────┼───────────┼────────────┤
         │ 1.1.1.1/1 │ trunca…   │ 1111-01-01 │
         │ 2.2.2.2/2 │ OtherForm │ 1212-12-12 │
         └───────────┴───────────┴────────────┘
-    \\"\\"\\".trimIndent()
+    """.trimIndent()
   )
 }
 "

--- a/linters/ktlint/test_data/ktlint_v0.48.0_utf8.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v0.48.0_utf8.fmt.shot
@@ -5,14 +5,14 @@ exports[`Testing formatter ktlint test utf8 1`] = `
 
 fun main(args: Array<String>) {
   println(
-    \\"\\"\\"
+    """
         ┌───────────┬───────────┬────────────┐
         │   BLOCK   │   FORM    │ ADDED_DATE │
         ├───────────┼───────────┼────────────┤
         │ 1.1.1.1/1 │ trunca…   │ 1111-01-01 │
         │ 2.2.2.2/2 │ OtherForm │ 1212-12-12 │
         └───────────┴───────────┴────────────┘
-    \\"\\"\\".trimIndent(),
+    """.trimIndent(),
   )
 }
 "

--- a/linters/kube-linter/test_data/kube_linter_v0.5.0_basic.check.shot
+++ b/linters/kube-linter/test_data/kube_linter_v0.5.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter kube-linter test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "kube-linter",
       "code": "latest-tag",
       "column": "1",
@@ -11,11 +11,11 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "kube-linter",
-      "message": "The container \\"sec-ctx-demo\\" is using an invalid container image, \\"busybox\\". Please use images that are not blocked by the \`BlockList\` criteria : [\\".*:(latest)$\\" \\"^[^:]*$\\" \\"(.*/[^:]+)$\\"]
+      "message": "The container "sec-ctx-demo" is using an invalid container image, "busybox". Please use images that are not blocked by the \`BlockList\` criteria : [".*:(latest)$" "^[^:]*$" "(.*/[^:]+)$"]
 object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "targetType": "yaml",
     },
-    Object {
+    {
       "bucket": "kube-linter",
       "code": "no-read-only-root-fs",
       "column": "1",
@@ -23,11 +23,11 @@ object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "kube-linter",
-      "message": "container \\"sec-ctx-demo\\" does not have a read-only root file system
+      "message": "container "sec-ctx-demo" does not have a read-only root file system
 object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "targetType": "yaml",
     },
-    Object {
+    {
       "bucket": "kube-linter",
       "code": "unset-cpu-requirements",
       "column": "1",
@@ -35,11 +35,11 @@ object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "kube-linter",
-      "message": "container \\"sec-ctx-demo\\" has cpu limit 0
+      "message": "container "sec-ctx-demo" has cpu limit 0
 object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "targetType": "yaml",
     },
-    Object {
+    {
       "bucket": "kube-linter",
       "code": "unset-memory-requirements",
       "column": "1",
@@ -47,23 +47,23 @@ object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "kube-linter",
-      "message": "container \\"sec-ctx-demo\\" has memory limit 0
+      "message": "container "sec-ctx-demo" has memory limit 0
 object: <no namespace>/security-context-demo /v1, Kind=Pod",
       "targetType": "yaml",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "yaml",
       "linter": "kube-linter",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/markdownlint/test_data/markdownlint_v0.31.1_basic.check.shot
+++ b/linters/markdownlint/test_data/markdownlint_v0.31.1_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter markdownlint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "markdownlint",
       "code": "MD025",
       "file": "test_data/basic.in.md",
@@ -15,18 +15,18 @@ Object {
       "targetType": "markdown",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "markdown",
       "linter": "markdownlint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.md",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/mypy/test_data/mypy_v0.931_CUSTOM.check.shot
+++ b/linters/mypy/test_data/mypy_v0.931_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter mypy test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "mypy",
       "code": "import",
       "column": "1",
@@ -12,10 +12,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Library stubs not installed for \\"google.protobuf\\" (or incompatible with Python 3.10)",
+      "message": "Library stubs not installed for "google.protobuf" (or incompatible with Python 3.10)",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "import",
       "column": "1",
@@ -24,10 +24,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Library stubs not installed for \\"google.protobuf.descriptor_pb2\\" (or incompatible with Python 3.10)",
+      "message": "Library stubs not installed for "google.protobuf.descriptor_pb2" (or incompatible with Python 3.10)",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "note",
       "column": "1",
@@ -36,10 +36,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Hint: \\"python3 -m pip install types-protobuf\\". (or run \\"mypy --install-types\\" to install all missing stub packages). See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports",
+      "message": "Hint: "python3 -m pip install types-protobuf". (or run "mypy --install-types" to install all missing stub packages). See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "arg-type",
       "column": "10",
@@ -48,10 +48,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "13",
       "linter": "mypy",
-      "message": "Argument 1 to \\"greeting\\" has incompatible type \\"int\\"; expected \\"str\\"",
+      "message": "Argument 1 to "greeting" has incompatible type "int"; expected "str"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "arg-type",
       "column": "10",
@@ -60,10 +60,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "14",
       "linter": "mypy",
-      "message": "Argument 1 to \\"greeting\\" has incompatible type \\"bytes\\"; expected \\"str\\"",
+      "message": "Argument 1 to "greeting" has incompatible type "bytes"; expected "str"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "func-returns-value",
       "column": "5",
@@ -72,10 +72,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "15",
       "linter": "mypy",
-      "message": "\\"printer\\" does not return a value",
+      "message": ""printer" does not return a value",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "assignment",
       "column": "10",
@@ -84,10 +84,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "16",
       "linter": "mypy",
-      "message": "Incompatible types in assignment (expression has type \\"int\\", variable has type \\"str\\")",
+      "message": "Incompatible types in assignment (expression has type "int", variable has type "str")",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "attr-defined",
       "column": "1",
@@ -96,10 +96,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "3",
       "linter": "mypy",
-      "message": "Module \\"test_data\\" has no attribute \\"mypy_import2\\"",
+      "message": "Module "test_data" has no attribute "mypy_import2"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "return",
       "column": "1",
@@ -112,36 +112,36 @@ Object {
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/__init__.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/source.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/mypy/test_data/mypy_v0.990_CUSTOM.check.shot
+++ b/linters/mypy/test_data/mypy_v0.990_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter mypy test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "mypy",
       "code": "import",
       "column": "1",
@@ -12,10 +12,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Library stubs not installed for \\"google.protobuf\\"",
+      "message": "Library stubs not installed for "google.protobuf"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "import",
       "column": "1",
@@ -24,10 +24,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Library stubs not installed for \\"google.protobuf.descriptor_pb2\\"",
+      "message": "Library stubs not installed for "google.protobuf.descriptor_pb2"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "note",
       "column": "1",
@@ -36,10 +36,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "mypy",
-      "message": "Hint: \\"python3 -m pip install types-protobuf\\". (or run \\"mypy --install-types\\" to install all missing stub packages). See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports",
+      "message": "Hint: "python3 -m pip install types-protobuf". (or run "mypy --install-types" to install all missing stub packages). See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "arg-type",
       "column": "10",
@@ -48,10 +48,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "13",
       "linter": "mypy",
-      "message": "Argument 1 to \\"greeting\\" has incompatible type \\"int\\"; expected \\"str\\"",
+      "message": "Argument 1 to "greeting" has incompatible type "int"; expected "str"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "arg-type",
       "column": "10",
@@ -60,10 +60,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "14",
       "linter": "mypy",
-      "message": "Argument 1 to \\"greeting\\" has incompatible type \\"bytes\\"; expected \\"str\\"",
+      "message": "Argument 1 to "greeting" has incompatible type "bytes"; expected "str"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "func-returns-value",
       "column": "5",
@@ -72,10 +72,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "15",
       "linter": "mypy",
-      "message": "\\"printer\\" does not return a value",
+      "message": ""printer" does not return a value",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "assignment",
       "column": "10",
@@ -84,10 +84,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "16",
       "linter": "mypy",
-      "message": "Incompatible types in assignment (expression has type \\"int\\", variable has type \\"str\\")",
+      "message": "Incompatible types in assignment (expression has type "int", variable has type "str")",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "attr-defined",
       "column": "1",
@@ -96,10 +96,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "3",
       "linter": "mypy",
-      "message": "Module \\"test_data\\" has no attribute \\"mypy_import2\\"",
+      "message": "Module "test_data" has no attribute "mypy_import2"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "mypy",
       "code": "return",
       "column": "1",
@@ -112,36 +112,36 @@ Object {
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/__init__.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/basic.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "mypy",
-      "paths": Array [
+      "paths": [
         "test_data/source.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/pylint/test_data/pylint_v2.11.1_basic.check.shot
+++ b/linters/pylint/test_data/pylint_v2.11.1_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter pylint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "pylint",
       "code": "C0114",
       "file": "test_data/basic.in.py",
@@ -14,7 +14,7 @@ Object {
       "message": "Missing module docstring",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -22,10 +22,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "3",
       "linter": "pylint",
-      "message": "Constant name \\"shift\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "shift" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "E0602",
       "column": "9",
@@ -37,7 +37,7 @@ Object {
       "message": "Undefined variable 'raw_input'",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "E0602",
       "column": "7",
@@ -49,7 +49,7 @@ Object {
       "message": "Undefined variable 'raw_input'",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -57,10 +57,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "6",
       "linter": "pylint",
-      "message": "Constant name \\"letters\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "letters" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -68,22 +68,22 @@ Object {
       "level": "LEVEL_LOW",
       "line": "7",
       "linter": "pylint",
-      "message": "Constant name \\"encoded\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "encoded" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "pylint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/pylint/test_data/pylint_v2.11.1_config.check.shot
+++ b/linters/pylint/test_data/pylint_v2.11.1_config.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter pylint test config 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "pylint",
       "code": "C0114",
       "file": "test_data/basic.in.py",
@@ -14,7 +14,7 @@ Object {
       "message": "Missing module docstring",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -22,10 +22,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "3",
       "linter": "pylint",
-      "message": "Constant name \\"shift\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "shift" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "E0602",
       "column": "9",
@@ -37,7 +37,7 @@ Object {
       "message": "Undefined variable 'raw_input'",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "E0602",
       "column": "7",
@@ -49,7 +49,7 @@ Object {
       "message": "Undefined variable 'raw_input'",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -57,10 +57,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "6",
       "linter": "pylint",
-      "message": "Constant name \\"letters\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "letters" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0103",
       "file": "test_data/basic.in.py",
@@ -68,10 +68,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "7",
       "linter": "pylint",
-      "message": "Constant name \\"encoded\\" doesn't conform to UPPER_CASE naming style",
+      "message": "Constant name "encoded" doesn't conform to UPPER_CASE naming style",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0114",
       "file": "test_data/severity.py",
@@ -82,7 +82,7 @@ Object {
       "message": "Missing module docstring",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "I0010",
       "file": "test_data/severity.py",
@@ -93,7 +93,7 @@ Object {
       "message": "Unable to consider inline option 'disable'",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0104",
       "file": "test_data/severity.py",
@@ -101,10 +101,10 @@ Object {
       "level": "LEVEL_LOW",
       "line": "7",
       "linter": "pylint",
-      "message": "Disallowed name \\"foo\\"",
+      "message": "Disallowed name "foo"",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "pylint",
       "code": "C0116",
       "file": "test_data/severity.py",
@@ -116,36 +116,36 @@ Object {
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "pylint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "pylint",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "pylint",
-      "paths": Array [
+      "paths": [
         "test_data/severity.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/pylint/test_data/pylint_v2.11.1_empty.check.shot
+++ b/linters/pylint/test_data/pylint_v2.11.1_empty.check.shot
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter pylint test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "pylint",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
+++ b/linters/remark-lint/test_data/remark_lint_v11.0.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter remark-lint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "remark-lint",
       "code": "list-item-indent",
       "column": "4",
@@ -15,29 +15,29 @@ Object {
       "targetType": "markdown",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fmt",
       "fileGroupName": "markdown",
       "linter": "remark-lint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.md",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "markdown",
       "linter": "remark-lint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.md",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic.in.md",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/renovate/test_data/renovate_v34.122.0_CUSTOM.check.shot
+++ b/linters/renovate/test_data/renovate_v34.122.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter renovate test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "renovate",
       "code": "Configuration-Error",
       "file": "test_data/renovate.json",
@@ -12,7 +12,7 @@ Object {
       "message": "Invalid configuration option: packageRules[0].matchUpdateTyped_badInfo",
       "targetType": "renovate-config",
     },
-    Object {
+    {
       "bucket": "renovate",
       "code": "JSON",
       "column": "1",
@@ -24,36 +24,36 @@ Object {
       "targetType": "renovate-config",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "validate",
       "fileGroupName": "renovate-config",
       "linter": "renovate",
-      "paths": Array [
+      "paths": [
         "test_data/.renovaterc.json",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "validate",
       "fileGroupName": "renovate-config",
       "linter": "renovate",
-      "paths": Array [
+      "paths": [
         "test_data/renovate.json",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "validate",
       "fileGroupName": "renovate-config",
       "linter": "renovate",
-      "paths": Array [
+      "paths": [
         "test_data/renovate.json5",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/rome/test_data/rome_v10.0.1_basic_check.check.shot
+++ b/linters/rome/test_data/rome_v10.0.1_basic_check.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter rome test basic_check 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "rome",
       "code": "lint/style/noNegationElse",
       "column": "5",
@@ -14,7 +14,7 @@ Object {
       "message": "Invert blocks when performing a negation test.",
       "targetType": "typescript",
     },
-    Object {
+    {
       "bucket": "rome",
       "code": "lint/correctness/useSingleCaseStatement",
       "column": "7",
@@ -26,29 +26,29 @@ Object {
       "targetType": "typescript",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "check",
       "fileGroupName": "typescript",
       "linter": "rome",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "fmt",
       "fileGroupName": "typescript",
       "linter": "rome",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.ts",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic_check.in.ts",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/rome/test_data/rome_v11.0.0_basic_check.check.shot
+++ b/linters/rome/test_data/rome_v11.0.0_basic_check.check.shot
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter rome test basic_check 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "check",
       "fileGroupName": "typescript",
       "linter": "rome",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "fmt",
       "fileGroupName": "typescript",
       "linter": "rome",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.ts",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic_check.in.ts",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/rubocop/test_data/rubocop_v1.39.0_basic.check.shot
+++ b/linters/rubocop/test_data/rubocop_v1.39.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter rubocop test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "rubocop",
       "code": "Style/Documentation",
       "column": "1",
@@ -13,15 +13,15 @@ Object {
       "line": "1",
       "linter": "rubocop",
       "message": "Missing top-level documentation comment for \`class Plumbus\`.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "20",
         },
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Style/FrozenStringLiteralComment",
       "column": "1",
@@ -31,15 +31,15 @@ Object {
       "line": "1",
       "linter": "rubocop",
       "message": "Missing frozen string literal comment.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
         },
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/ExtraSpacing",
       "column": "6",
@@ -49,8 +49,8 @@ Object {
       "line": "1",
       "linter": "rubocop",
       "message": "Unnecessary spacing detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "7",
           "offset": "5",
@@ -58,7 +58,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Style/LambdaCall",
       "column": "1",
@@ -72,8 +72,8 @@ Object {
   key_1: 'hello',
   key_2: 'world'
 )\`.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "44",
           "offset": "59",
@@ -81,7 +81,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Naming/VariableNumber",
       "column": "3",
@@ -91,8 +91,8 @@ Object {
       "line": "13",
       "linter": "rubocop",
       "message": "Use normalcase for symbol numbers.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "5",
           "offset": "69",
@@ -100,7 +100,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Naming/VariableNumber",
       "column": "3",
@@ -110,8 +110,8 @@ Object {
       "line": "14",
       "linter": "rubocop",
       "message": "Use normalcase for symbol numbers.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "5",
           "offset": "87",
@@ -119,7 +119,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -129,8 +129,8 @@ Object {
       "line": "4",
       "linter": "rubocop",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "32",
@@ -138,7 +138,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -148,8 +148,8 @@ Object {
       "line": "5",
       "linter": "rubocop",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "33",
@@ -157,7 +157,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -167,8 +167,8 @@ Object {
       "line": "6",
       "linter": "rubocop",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "34",
@@ -176,7 +176,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -186,8 +186,8 @@ Object {
       "line": "7",
       "linter": "rubocop",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "35",
@@ -195,7 +195,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -205,8 +205,8 @@ Object {
       "line": "8",
       "linter": "rubocop",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "36",
@@ -214,7 +214,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/IndentationWidth",
       "column": "1",
@@ -224,8 +224,8 @@ Object {
       "line": "9",
       "linter": "rubocop",
       "message": "Use 2 (not 1) spaces for indentation.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "37",
@@ -233,7 +233,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "rubocop",
       "code": "Layout/IndentationConsistency",
       "column": "2",
@@ -243,8 +243,8 @@ Object {
       "line": "9",
       "linter": "rubocop",
       "message": "Inconsistent indentation detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "15",
           "offset": "38",
@@ -253,29 +253,29 @@ Object {
       "targetType": "ruby",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fix-layout",
       "fileGroupName": "ruby",
       "linter": "rubocop",
-      "paths": Array [
+      "paths": [
         "test_data/basic.rb",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "ruby",
       "linter": "rubocop",
-      "paths": Array [
+      "paths": [
         "test_data/basic.rb",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic.rb",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/ruff/test_data/ruff_nbqa_v0.0.250_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.0.250_basic_nb.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ruff-nbqa",
       "code": "error",
       "file": "test_data/basic_nb.in.ipynb",
@@ -15,18 +15,18 @@ Found 1 error.
       "targetType": "jupyter",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "jupyter",
       "linter": "ruff-nbqa",
-      "paths": Array [
+      "paths": [
         "test_data/basic_nb.in.ipynb",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/ruff/test_data/ruff_v0.0.250_basic.check.shot
+++ b/linters/ruff/test_data/ruff_v0.0.250_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter ruff test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "ruff",
       "code": "E402",
       "column": "1",
@@ -14,12 +14,12 @@ Object {
       "message": "Module level import not at top of file",
       "targetType": "python",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
+    {
+      "autofixOptions": [
+        {
           "message": "Remove unused import: \`sys\`",
-          "replacements": Array [
-            Object {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.py",
               "length": "11",
               "offset": "83",
@@ -37,7 +37,7 @@ Object {
       "message": "\`sys\` imported but unused",
       "targetType": "python",
     },
-    Object {
+    {
       "bucket": "ruff",
       "code": "E402",
       "column": "1",
@@ -49,18 +49,18 @@ Object {
       "targetType": "python",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "python",
       "linter": "ruff",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/rufo/test_data/rufo_v0.13.0_empty.check.shot
+++ b/linters/rufo/test_data/rufo_v0.13.0_empty.check.shot
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter rufo test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "ruby",
       "linter": "rufo",
-      "paths": Array [
+      "paths": [
         "test_data/basic.rb",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "format",
       "fileGroupName": "ruby",
       "linter": "rufo",
-      "paths": Array [
+      "paths": [
         "test_data/empty.rb",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic.rb",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",
@@ -34,7 +34,7 @@ Object {
       "linter": "rufo",
       "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
     },
-    Object {
+    {
       "column": "1",
       "file": "test_data/empty.rb",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/rustfmt/test_data/rustfmt_v1.65.0_basic.fmt.shot
+++ b/linters/rustfmt/test_data/rustfmt_v1.65.0_basic.fmt.shot
@@ -2,15 +2,15 @@
 
 exports[`Testing formatter rustfmt test basic 1`] = `
 "fn hey_now() {
-    return \\"you're an all star\\";
+    return "you're an all star";
 }
 
 fn get_your_game_on() {
-    return \\"go play\\";
+    return "go play";
 }
 
 fn main() {
-    println!(\\"Hey now, you're a rock star, get the show on, get paid\\");
+    println!("Hey now, you're a rock star, get the show on, get paid");
 }
 "
 `;

--- a/linters/rustfmt/test_data/rustfmt_v1.65.0_empty.check.shot
+++ b/linters/rustfmt/test_data/rustfmt_v1.65.0_empty.check.shot
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter rustfmt test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "rust",
       "linter": "rustfmt",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.rs",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/empty.in.rs",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/scalafmt/test_data/scalafmt_v3.4.3_empty.check.shot
+++ b/linters/scalafmt/test_data/scalafmt_v3.4.3_empty.check.shot
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter scalafmt test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "scala",
       "linter": "scalafmt",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.scala",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/empty.in.scala",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/semgrep/test_data/semgrep_v0.110.0_CUSTOM.check.shot
+++ b/linters/semgrep/test_data/semgrep_v0.110.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter semgrep test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "semgrep",
       "code": "go.lang.security.audit.crypto.bad_imports.insecure-module-used",
       "column": "12",
@@ -15,7 +15,7 @@ Object {
       "message": "Detected use of an insecure cryptographic hashing method. This method is known to be broken and easily compromised. Use SHA256 or SHA3 instead.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "semgrep",
       "code": "go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5",
       "column": "12",
@@ -27,7 +27,7 @@ Object {
       "message": "Detected MD5 hash algorithm which is considered insecure. MD5 is not collision resistant and is therefore not suitable as a cryptographic signature. Use SHA256 or SHA3 instead.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "semgrep",
       "code": "python.django.security.injection.code.globals-misuse-code-execution.globals-misuse-code-execution",
       "column": "5",
@@ -39,7 +39,7 @@ Object {
       "message": "Found request data as an index to 'globals()'. This is extremely dangerous because it allows an attacker to execute arbitrary code on the system. Refactor your code not to use 'globals()'.",
       "targetType": "ALL",
     },
-    Object {
+    {
       "bucket": "semgrep",
       "code": "python.lang.security.dangerous-globals-use.dangerous-globals-use",
       "column": "16",
@@ -52,123 +52,123 @@ Object {
       "targetType": "ALL",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/basic.go",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/element.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_go.go",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_js.js",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_py.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/request.py",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/basic.go",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/element.ts",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_go.go",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_js.js",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/empty_py.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "check",
       "fileGroupName": "ALL",
       "linter": "semgrep",
-      "paths": Array [
+      "paths": [
         "test_data/request.py",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.8.0_basic.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.8.0_basic.check.shot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "185",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "194",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -29,8 +29,8 @@ Object {
       "line": "11",
       "linter": "shellcheck",
       "message": "Prefer double quoting even when variables don't contain special characters.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "9",
           "offset": "185",
@@ -38,17 +38,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "length": "1",
               "offset": "185",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "194",
               "replacementText": "}",
@@ -65,8 +65,8 @@ Object {
       "line": "11",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "9",
           "offset": "185",
@@ -74,19 +74,19 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "201",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "208",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -100,8 +100,8 @@ Object {
       "line": "12",
       "linter": "shellcheck",
       "message": "Double quote to prevent globbing and word splitting.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "7",
           "offset": "201",
@@ -109,17 +109,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "length": "1",
               "offset": "201",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "208",
               "replacementText": "}",
@@ -136,8 +136,8 @@ Object {
       "line": "12",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "7",
           "offset": "201",
@@ -145,16 +145,16 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "35",
               "replacementText": "[",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "61",
               "replacementText": "]",
@@ -171,8 +171,8 @@ Object {
       "line": "5",
       "linter": "shellcheck",
       "message": "Prefer [[ ]] over [ ] for tests in Bash/Ksh.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "26",
           "offset": "35",
@@ -180,7 +180,7 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
+    {
       "bucket": "shellcheck",
       "code": "SC2312",
       "column": "9",
@@ -190,8 +190,8 @@ Object {
       "line": "5",
       "linter": "shellcheck",
       "message": "Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "5",
           "offset": "40",
@@ -199,7 +199,7 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
+    {
       "bucket": "shellcheck",
       "code": "SC2312",
       "column": "11",
@@ -209,8 +209,8 @@ Object {
       "line": "7",
       "linter": "shellcheck",
       "message": "Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "5",
           "offset": "97",
@@ -218,16 +218,16 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "92",
               "replacementText": "[",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "117",
               "replacementText": "]",
@@ -244,8 +244,8 @@ Object {
       "line": "7",
       "linter": "shellcheck",
       "message": "Prefer [[ ]] over [ ] for tests in Bash/Ksh.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "25",
           "offset": "92",
@@ -254,18 +254,18 @@ Object {
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.8.0_empty.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.8.0_empty.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test empty 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "shellcheck",
       "code": "SC2148",
       "column": "1",
@@ -13,26 +13,26 @@ Object {
       "line": "1",
       "linter": "shellcheck",
       "message": "Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/empty.in.sh",
         },
       ],
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.8.0_unicode.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.8.0_unicode.check.shot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test unicode 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "66",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "75",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -29,8 +29,8 @@ Object {
       "line": "6",
       "linter": "shellcheck",
       "message": "Double quote to prevent globbing and word splitting.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/unicode.in.sh",
           "length": "9",
           "offset": "66",
@@ -38,17 +38,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/unicode.in.sh",
               "length": "1",
               "offset": "66",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "75",
               "replacementText": "}",
@@ -65,8 +65,8 @@ Object {
       "line": "6",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/unicode.in.sh",
           "length": "9",
           "offset": "66",
@@ -75,18 +75,18 @@ Object {
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/unicode.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.9.0_basic.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.9.0_basic.check.shot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "185",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "194",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -29,8 +29,8 @@ Object {
       "line": "11",
       "linter": "shellcheck",
       "message": "Double quote to prevent globbing and word splitting.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "9",
           "offset": "185",
@@ -38,17 +38,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "length": "1",
               "offset": "185",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "194",
               "replacementText": "}",
@@ -65,8 +65,8 @@ Object {
       "line": "11",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "9",
           "offset": "185",
@@ -74,19 +74,19 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "201",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "208",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -100,8 +100,8 @@ Object {
       "line": "12",
       "linter": "shellcheck",
       "message": "Double quote to prevent globbing and word splitting.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "7",
           "offset": "201",
@@ -109,17 +109,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "length": "1",
               "offset": "201",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "208",
               "replacementText": "}",
@@ -136,8 +136,8 @@ Object {
       "line": "12",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "7",
           "offset": "201",
@@ -145,16 +145,16 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "35",
               "replacementText": "[",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "61",
               "replacementText": "]",
@@ -171,8 +171,8 @@ Object {
       "line": "5",
       "linter": "shellcheck",
       "message": "Prefer [[ ]] over [ ] for tests in Bash/Ksh.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "26",
           "offset": "35",
@@ -180,7 +180,7 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
+    {
       "bucket": "shellcheck",
       "code": "SC2312",
       "column": "9",
@@ -190,8 +190,8 @@ Object {
       "line": "5",
       "linter": "shellcheck",
       "message": "Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "5",
           "offset": "40",
@@ -199,7 +199,7 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
+    {
       "bucket": "shellcheck",
       "code": "SC2312",
       "column": "11",
@@ -209,8 +209,8 @@ Object {
       "line": "7",
       "linter": "shellcheck",
       "message": "Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "5",
           "offset": "97",
@@ -218,16 +218,16 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "92",
               "replacementText": "[",
             },
-            Object {
+            {
               "filePath": "test_data/basic.in.sh",
               "offset": "117",
               "replacementText": "]",
@@ -244,8 +244,8 @@ Object {
       "line": "7",
       "linter": "shellcheck",
       "message": "Prefer [[ ]] over [ ] for tests in Bash/Ksh.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.in.sh",
           "length": "25",
           "offset": "92",
@@ -254,18 +254,18 @@ Object {
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.9.0_empty.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.9.0_empty.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test empty 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "shellcheck",
       "code": "SC2148",
       "column": "1",
@@ -13,26 +13,26 @@ Object {
       "line": "1",
       "linter": "shellcheck",
       "message": "Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/empty.in.sh",
         },
       ],
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shellcheck/test_data/shellcheck_v0.9.0_unicode.check.shot
+++ b/linters/shellcheck/test_data/shellcheck_v0.9.0_unicode.check.shot
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shellcheck test unicode 1`] = `
-Object {
-  "issues": Array [
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "66",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
-            Object {
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "75",
-              "replacementText": "\\"",
+              "replacementText": """,
             },
           ],
         },
@@ -29,8 +29,8 @@ Object {
       "line": "6",
       "linter": "shellcheck",
       "message": "Double quote to prevent globbing and word splitting.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/unicode.in.sh",
           "length": "9",
           "offset": "66",
@@ -38,17 +38,17 @@ Object {
       ],
       "targetType": "shell",
     },
-    Object {
-      "autofixOptions": Array [
-        Object {
-          "replacements": Array [
-            Object {
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
               "filePath": "test_data/unicode.in.sh",
               "length": "1",
               "offset": "66",
               "replacementText": "\${",
             },
-            Object {
+            {
               "filePath": "test_data/unicode.in.sh",
               "offset": "75",
               "replacementText": "}",
@@ -65,8 +65,8 @@ Object {
       "line": "6",
       "linter": "shellcheck",
       "message": "Prefer putting braces around variable references even when not strictly required.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/unicode.in.sh",
           "length": "9",
           "offset": "66",
@@ -75,18 +75,18 @@ Object {
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "shell",
       "linter": "shellcheck",
-      "paths": Array [
+      "paths": [
         "test_data/unicode.in.sh",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shfmt/test_data/shfmt_v3.5.0_basic.check.shot
+++ b/linters/shfmt/test_data/shfmt_v3.5.0_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shfmt test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "shfmt",
       "code": "parse",
       "column": "1",
@@ -11,22 +11,22 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "3",
       "linter": "shfmt",
-      "message": "if statement must end with \\"fi\\"",
+      "message": "if statement must end with "fi"",
       "targetType": "shell",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "shell",
       "linter": "shfmt",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.sh",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/shfmt/test_data/shfmt_v3.5.0_empty.check.shot
+++ b/linters/shfmt/test_data/shfmt_v3.5.0_empty.check.shot
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter shfmt test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "shell",
       "linter": "shfmt",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.sh",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/empty.in.sh",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/sort-package-json/test_data/sort_package_json_v2.1.0_CUSTOM.check.shot
+++ b/linters/sort-package-json/test_data/sort_package_json_v2.1.0_CUSTOM.check.shot
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter sort-package-json test CUSTOM 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [],
-  "taskFailures": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [],
+  "taskFailures": [
+    {
       "details": StringMatching /\\.\\*\\$/m,
       "message": "test_data/package.json",
       "name": "sort-package-json",
     },
   ],
-  "unformattedFiles": Array [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/sort-package-json/test_data/sort_package_json_v2.1.0_test_data.package.json.fmt.shot
+++ b/linters/sort-package-json/test_data/sort_package_json_v2.1.0_test_data.package.json.fmt.shot
@@ -2,45 +2,45 @@
 
 exports[`Testing formatter sort-package-json test CUSTOM 1`] = `
 "{
-  \\"private\\": true,
-  \\"scripts\\": {
-    \\"test\\": \\"jest\\",
-    \\"trunk\\": \\"trunk\\"
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "trunk": "trunk"
   },
-  \\"devDependencies\\": {
-    \\"@trunkio/launcher\\": \\"^1.2.3\\",
-    \\"@types/caller\\": \\"^1.0.0\\",
-    \\"@types/debug\\": \\"^4.1.7\\",
-    \\"@types/jest\\": \\"^29.2.4\\",
-    \\"@types/jest-specific-snapshot\\": \\"^0.5.6\\",
-    \\"@types/node\\": \\"^18.11.18\\",
-    \\"@typescript-eslint/eslint-plugin\\": \\"^5.47.1\\",
-    \\"caller\\": \\"^1.1.0\\",
-    \\"debug\\": \\"^4.3.4\\",
-    \\"eslint\\": \\"^8.30.0\\",
-    \\"eslint-config-prettier\\": \\"^8.5.0\\",
-    \\"eslint-import-resolver-typescript\\": \\"^3.5.2\\",
-    \\"eslint-plugin-import\\": \\"^2.26.0\\",
-    \\"eslint-plugin-jest\\": \\"^27.1.7\\",
-    \\"eslint-plugin-node\\": \\"^11.1.0\\",
-    \\"eslint-plugin-prefer-arrow-functions\\": \\"^3.1.4\\",
-    \\"eslint-plugin-prettier\\": \\"^4.2.1\\",
-    \\"eslint-plugin-simple-import-sort\\": \\"^10.0.0\\",
-    \\"fast-sort\\": \\"^3.2.0\\",
-    \\"jest\\": \\"^29.3.1\\",
-    \\"jest-specific-snapshot\\": \\"^7.0.0\\",
-    \\"semver\\": \\"^7.3.8\\",
-    \\"simple-git\\": \\"^3.15.1\\",
-    \\"ts-jest\\": \\"^29.0.3\\",
-    \\"ts-node\\": \\"^10.9.1\\",
-    \\"typescript\\": \\"^4.9.4\\",
-    \\"yaml\\": \\"^2.2.0\\"
+  "devDependencies": {
+    "@trunkio/launcher": "^1.2.3",
+    "@types/caller": "^1.0.0",
+    "@types/debug": "^4.1.7",
+    "@types/jest": "^29.2.4",
+    "@types/jest-specific-snapshot": "^0.5.6",
+    "@types/node": "^18.11.18",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
+    "caller": "^1.1.0",
+    "debug": "^4.3.4",
+    "eslint": "^8.30.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jest": "^27.1.7",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prefer-arrow-functions": "^3.1.4",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "fast-sort": "^3.2.0",
+    "jest": "^29.3.1",
+    "jest-specific-snapshot": "^7.0.0",
+    "semver": "^7.3.8",
+    "simple-git": "^3.15.1",
+    "ts-jest": "^29.0.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.4",
+    "yaml": "^2.2.0"
   },
-  \\"bundleDependencies\\": [
-    \\"tests\\"
+  "bundleDependencies": [
+    "tests"
   ],
-  \\"engines\\": {
-    \\"node\\": \\">=16\\"
+  "engines": {
+    "node": ">=16"
   }
 }
 "

--- a/linters/sql-formatter/test_data/sql_formatter_v7.0.1_empty.check.shot
+++ b/linters/sql-formatter/test_data/sql_formatter_v7.0.1_empty.check.shot
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter sql-formatter test empty 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "sql",
       "linter": "sql-formatter",
-      "paths": Array [
+      "paths": [
         "test_data/empty.in.sql",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/empty.in.sql",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/sqlfluff/test_data/sqlfluff_v1.4.2_basic_check.check.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v1.4.2_basic_check.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter sqlfluff test basic_check 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "1",
@@ -14,7 +14,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L036",
       "column": "1",
@@ -25,7 +25,7 @@ Object {
       "message": "Select targets should be on a new line unless there is only one select target.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L044",
       "column": "1",
@@ -36,7 +36,7 @@ Object {
       "message": "Query produces an unknown number of result columns.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L013",
       "column": "12",
@@ -47,7 +47,7 @@ Object {
       "message": "Column expression without alias. Use explicit \`AS\` clause.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "20",
@@ -58,7 +58,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "22",
@@ -69,7 +69,7 @@ Object {
       "message": "Unnecessary whitespace found.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "24",
@@ -80,7 +80,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "27",
@@ -91,7 +91,7 @@ Object {
       "message": "Unnecessary whitespace found.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "29",
@@ -102,7 +102,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "34",
@@ -113,7 +113,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "43",
@@ -124,7 +124,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "7",
@@ -136,18 +136,18 @@ Object {
       "targetType": "sql",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "sql",
       "linter": "sqlfluff",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.sql",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/sqlfluff/test_data/sqlfluff_v1.4.4_basic_check.check.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v1.4.4_basic_check.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter sqlfluff test basic_check 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "1",
@@ -14,7 +14,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L036",
       "column": "1",
@@ -25,7 +25,7 @@ Object {
       "message": "Select targets should be on a new line unless there is only one select target.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L044",
       "column": "1",
@@ -36,7 +36,7 @@ Object {
       "message": "Query produces an unknown number of result columns.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L013",
       "column": "12",
@@ -47,7 +47,7 @@ Object {
       "message": "Column expression without alias. Use explicit \`AS\` clause.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "20",
@@ -58,7 +58,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "22",
@@ -69,7 +69,7 @@ Object {
       "message": "Expected only single space before naked identifier. Found '  '.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "24",
@@ -80,7 +80,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "27",
@@ -91,7 +91,7 @@ Object {
       "message": "Expected only single space before 'from' keyword. Found '  '.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L010",
       "column": "29",
@@ -102,7 +102,7 @@ Object {
       "message": "Keywords must be consistently upper case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "34",
@@ -113,7 +113,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L014",
       "column": "43",
@@ -124,7 +124,7 @@ Object {
       "message": "Unquoted identifiers must be consistently lower case.",
       "targetType": "sql",
     },
-    Object {
+    {
       "bucket": "sqlfluff",
       "code": "L039",
       "column": "7",
@@ -136,18 +136,18 @@ Object {
       "targetType": "sql",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "sql",
       "linter": "sqlfluff",
-      "paths": Array [
+      "paths": [
         "test_data/basic_check.in.sql",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/standardrb/test_data/standardrb_v1.3.0_CUSTOM.check.shot
+++ b/linters/standardrb/test_data/standardrb_v1.3.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter standardrb test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "standardrb",
       "code": "Layout/ExtraSpacing",
       "column": "6",
@@ -13,8 +13,8 @@ Object {
       "line": "1",
       "linter": "standardrb",
       "message": "Unnecessary spacing detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "7",
           "offset": "5",
@@ -22,7 +22,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Style/LambdaCall",
       "column": "1",
@@ -32,8 +32,8 @@ Object {
       "line": "12",
       "linter": "standardrb",
       "message": "Prefer the use of \`lambda.call(...)\` over \`lambda.(...)\`.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "44",
           "offset": "59",
@@ -41,7 +41,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Style/StringLiterals",
       "column": "10",
@@ -51,8 +51,8 @@ Object {
       "line": "13",
       "linter": "standardrb",
       "message": "Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "7",
           "offset": "76",
@@ -60,7 +60,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Style/StringLiterals",
       "column": "10",
@@ -70,8 +70,8 @@ Object {
       "line": "14",
       "linter": "standardrb",
       "message": "Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "7",
           "offset": "94",
@@ -79,7 +79,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -89,8 +89,8 @@ Object {
       "line": "4",
       "linter": "standardrb",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "32",
@@ -98,7 +98,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -108,8 +108,8 @@ Object {
       "line": "5",
       "linter": "standardrb",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "33",
@@ -117,7 +117,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -127,8 +127,8 @@ Object {
       "line": "6",
       "linter": "standardrb",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "34",
@@ -136,7 +136,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -146,8 +146,8 @@ Object {
       "line": "7",
       "linter": "standardrb",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "35",
@@ -155,7 +155,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/EmptyLines",
       "column": "1",
@@ -165,8 +165,8 @@ Object {
       "line": "8",
       "linter": "standardrb",
       "message": "Extra blank line detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "36",
@@ -174,7 +174,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/IndentationWidth",
       "column": "1",
@@ -184,8 +184,8 @@ Object {
       "line": "9",
       "linter": "standardrb",
       "message": "Use 2 (not 1) spaces for indentation.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "1",
           "offset": "37",
@@ -193,7 +193,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Layout/IndentationConsistency",
       "column": "2",
@@ -203,8 +203,8 @@ Object {
       "line": "9",
       "linter": "standardrb",
       "message": "Inconsistent indentation detected.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "15",
           "offset": "38",
@@ -212,7 +212,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Style/EmptyMethod",
       "column": "2",
@@ -222,8 +222,8 @@ Object {
       "line": "9",
       "linter": "standardrb",
       "message": "Put the \`end\` of empty method definitions on the next line.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "15",
           "offset": "38",
@@ -231,7 +231,7 @@ Object {
       ],
       "targetType": "ruby",
     },
-    Object {
+    {
       "bucket": "standardrb",
       "code": "Style/SingleLineMethods",
       "column": "2",
@@ -241,8 +241,8 @@ Object {
       "line": "9",
       "linter": "standardrb",
       "message": "Avoid single-line method definitions.",
-      "ranges": Array [
-        Object {
+      "ranges": [
+        {
           "filePath": "test_data/basic.rb",
           "length": "15",
           "offset": "38",
@@ -251,18 +251,18 @@ Object {
       "targetType": "ruby",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "ruby",
       "linter": "standardrb",
-      "paths": Array [
+      "paths": [
         "test_data/basic.rb",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/stringslint/test_data/stringslint_v0.1.1_CUSTOM.check.shot
+++ b/linters/stringslint/test_data/stringslint_v0.1.1_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter stringslint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "stringslint",
       "code": "missing_comment",
       "column": "1",
@@ -11,10 +11,10 @@ Object {
       "level": "LEVEL_MEDIUM",
       "line": "1",
       "linter": "stringslint",
-      "message": "MissingComment Violation: Comment for Localized string \\"abc\\" is missing",
+      "message": "MissingComment Violation: Comment for Localized string "abc" is missing",
       "targetType": "strings",
     },
-    Object {
+    {
       "bucket": "stringslint",
       "code": "unused",
       "column": "1",
@@ -22,10 +22,10 @@ Object {
       "level": "LEVEL_MEDIUM",
       "line": "1",
       "linter": "stringslint",
-      "message": "Unused Violation: Localized string \\"abc\\" is unused",
+      "message": "Unused Violation: Localized string "abc" is unused",
       "targetType": "strings",
     },
-    Object {
+    {
       "bucket": "stringslint",
       "code": "missing",
       "column": "1",
@@ -33,31 +33,31 @@ Object {
       "level": "LEVEL_MEDIUM",
       "line": "3",
       "linter": "stringslint",
-      "message": "Missing Violation: Localized string \\"test\\" is missing",
+      "message": "Missing Violation: Localized string "test" is missing",
       "targetType": "swift",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "strings",
       "linter": "stringslint",
-      "paths": Array [
+      "paths": [
         "test_data/Localizable.strings",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "swift",
       "linter": "stringslint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.swift",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/stylelint/test_data/stylelint_v14.6.1_basic.check.shot
+++ b/linters/stylelint/test_data/stylelint_v14.6.1_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter stylelint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -14,7 +14,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "selector-list-comma-newline-after",
       "column": "4",
@@ -22,10 +22,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "10",
       "linter": "stylelint",
-      "message": "Expected newline after \\",\\"",
+      "message": "Expected newline after ","",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -36,7 +36,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -47,7 +47,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -58,7 +58,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -69,7 +69,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "rule-empty-line-before",
       "column": "1",
@@ -80,7 +80,7 @@ Object {
       "message": "Expected empty line before rule",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "selector-list-comma-newline-after",
       "column": "3",
@@ -88,10 +88,10 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "7",
       "linter": "stylelint",
-      "message": "Expected newline after \\",\\"",
+      "message": "Expected newline after ","",
       "targetType": "css",
     },
-    Object {
+    {
       "bucket": "stylelint",
       "code": "selector-list-comma-newline-after",
       "column": "7",
@@ -99,33 +99,33 @@ Object {
       "level": "LEVEL_HIGH",
       "line": "7",
       "linter": "stylelint",
-      "message": "Expected newline after \\",\\"",
+      "message": "Expected newline after ","",
       "targetType": "css",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fix",
       "fileGroupName": "css",
       "linter": "stylelint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.css",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "css",
       "linter": "stylelint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.css",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/basic.in.css",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/svgo/test_data/svgo_v2.8.0_basic.fmt.shot
+++ b/linters/svgo/test_data/svgo_v2.8.0_basic.fmt.shot
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing formatter svgo test basic 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"120\\" height=\\"120\\" viewBox=\\"0 0 120 120\\" xml:space=\\"preserve\\" style=\\"fill:red\\"><circle cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/><text>  test  </text></svg>"`;
+exports[`Testing formatter svgo test basic 1`] = `"<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120" xml:space="preserve" style="fill:red"><circle cx="60" cy="60" r="50"/><text>  test  </text></svg>"`;

--- a/linters/svgo/test_data/svgo_v3.0.0_basic.fmt.shot
+++ b/linters/svgo/test_data/svgo_v3.0.0_basic.fmt.shot
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing formatter svgo test basic 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" xml:space=\\"preserve\\" width=\\"120\\" height=\\"120\\" style=\\"fill:red\\" viewBox=\\"0 0 120 120\\"><circle cx=\\"60\\" cy=\\"60\\" r=\\"50\\"/><text>  test  </text></svg>"`;
+exports[`Testing formatter svgo test basic 1`] = `"<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="120" height="120" style="fill:red" viewBox="0 0 120 120"><circle cx="60" cy="60" r="50"/><text>  test  </text></svg>"`;

--- a/linters/swiftformat/test_data/swiftformat_v0.50.0_test_data.basic.swift.fmt.shot
+++ b/linters/swiftformat/test_data/swiftformat_v0.50.0_test_data.basic.swift.fmt.shot
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing formatter swiftformat test CUSTOM 1`] = `
-"// Swift \\"Hello, World!\\" Program
+"// Swift "Hello, World!" Program
 
-print(\\"Hello, World!\\")
+print("Hello, World!")
 
 // This is a very long line that swiftformat does not format into multiple lines with the default configuration but maybe a future update will change this behavior.
 
 class Foo {
-    let _foo = \\"foo\\"
+    let _foo = "foo"
     func foo() {
         print(_foo)
     }

--- a/linters/swiftlint/test_data/swiftlint_v0.49.1_CUSTOM.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.49.1_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter swiftlint test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "swiftlint",
       "code": "type_name",
       "column": "8",
@@ -14,7 +14,7 @@ Object {
       "message": "Type Name Violation: Type name should start with an uppercase character: 'a'",
       "targetType": "swift",
     },
-    Object {
+    {
       "bucket": "swiftlint",
       "code": "line_length",
       "column": "1",
@@ -25,7 +25,7 @@ Object {
       "message": "Line Length Violation: Line should be 120 characters or less: currently 139 characters",
       "targetType": "swift",
     },
-    Object {
+    {
       "bucket": "swiftlint",
       "code": "vertical_whitespace",
       "column": "1",
@@ -36,7 +36,7 @@ Object {
       "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line. Currently 2.",
       "targetType": "swift",
     },
-    Object {
+    {
       "bucket": "swiftlint",
       "code": "identifier_name",
       "column": "1",
@@ -48,18 +48,18 @@ Object {
       "targetType": "swift",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "swift",
       "linter": "swiftlint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.swift",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/taplo/test_data/taplo_vrelease-cli-0.6.0_CUSTOM.check.shot
+++ b/linters/taplo/test_data/taplo_vrelease-cli-0.6.0_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter taplo test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "taplo",
       "code": "error",
       "column": "1",
@@ -14,7 +14,7 @@ Object {
       "message": "conflicting keys",
       "targetType": "toml",
     },
-    Object {
+    {
       "bucket": "taplo",
       "code": "error",
       "column": "8",
@@ -26,45 +26,45 @@ Object {
       "targetType": "toml",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "format",
       "fileGroupName": "toml",
       "linter": "taplo",
-      "paths": Array [
+      "paths": [
         "test_data/basic.toml",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "format",
       "fileGroupName": "toml",
       "linter": "taplo",
-      "paths": Array [
+      "paths": [
         "test_data/empty.toml",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "toml",
       "linter": "taplo",
-      "paths": Array [
+      "paths": [
         "test_data/basic.toml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "lint",
       "fileGroupName": "toml",
       "linter": "taplo",
-      "paths": Array [
+      "paths": [
         "test_data/empty.toml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/taplo/test_data/taplo_vrelease-cli-0.6.0_test_data.basic.toml.check.shot
+++ b/linters/taplo/test_data/taplo_vrelease-cli-0.6.0_test_data.basic.toml.check.shot
@@ -3,27 +3,27 @@
 exports[`Testing linter taplo test CUSTOM 1`] = `
 "# This is a TOML document
 
-title = \\"TOML Example\\"
+title = "TOML Example"
 
 [owner]
-name = \\"Tom Preston-Werner\\"
+name = "Tom Preston-Werner"
 dob = 1979-05-27T07:32:00-08:00
 
 [database]
 enabled = true
 ports = [8000, 8001, 8002]
-data = [[\\"delta\\", \\"phi\\"], [3.14]]
+data = [["delta", "phi"], [3.14]]
 temp_targets = { cpu = 79.5, case = 72.0 }
 
 [servers]
 
 
 [servers.alpha]
-ip = \\"10.0.0.1\\"
-role = \\"frontend\\"
+ip = "10.0.0.1"
+role = "frontend"
 
 [servers.beta]
-ip = \\"10.0.0.2\\"
-role = \\"backend\\"
+ip = "10.0.0.2"
+role = "backend"
 "
 `;

--- a/linters/terraform/test_data/terraform_v1.1.0_variables.check.shot
+++ b/linters/terraform/test_data/terraform_v1.1.0_variables.check.shot
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter terraform test variables 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "terraform",
       "code": "Invalid quoted type constraints",
       "file": "test_data/variables.in.tf",
       "level": "LEVEL_HIGH",
       "line": "2",
       "linter": "terraform",
-      "message": "Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around \\"map\\" and write map(string) instead to explicitly indicate that the map elements are strings.",
+      "message": "Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around "map" and write map(string) instead to explicitly indicate that the map elements are strings.",
       "targetType": "terraform",
     },
-    Object {
+    {
       "bucket": "terraform",
       "code": "Missing value",
       "file": "test_data/variables.in.tf.json",
@@ -23,7 +23,7 @@ Object {
       "message": "The JSON data ends prematurely.",
       "targetType": "terraform",
     },
-    Object {
+    {
       "bucket": "terraform",
       "code": "Root value must be object",
       "file": "test_data/variables.in.tf.json",
@@ -34,29 +34,29 @@ Object {
       "targetType": "terraform",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fmt",
       "fileGroupName": "terraform",
       "linter": "terraform",
-      "paths": Array [
+      "paths": [
         "test_data/variables.in.tf",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
-    Object {
+    {
       "command": "validate",
       "fileGroupName": "terraform",
       "linter": "terraform",
-      "paths": Array [
+      "paths": [
         "test_data",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [
-    Object {
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
       "column": "1",
       "file": "test_data/variables.in.tf",
       "issueClass": "ISSUE_CLASS_UNFORMATTED",

--- a/linters/terraform/test_data/terraform_v1.1.0_variables.fmt.shot
+++ b/linters/terraform/test_data/terraform_v1.1.0_variables.fmt.shot
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing formatter terraform test variables 1`] = `
-"variable \\"ssl_certificates\\" {
+"variable "ssl_certificates" {
   type = map(string)
   default = {
-    lorem-elb-us-west-3 = \\"lorem\\"
-    ipsum-elb-us-east-1 = \\"ipsum\\"
-    dolor-elb-us-east-2 = \\"dolor\\"
+    lorem-elb-us-west-3 = "lorem"
+    ipsum-elb-us-east-1 = "ipsum"
+    dolor-elb-us-east-2 = "dolor"
   }
 }
 "

--- a/linters/tflint/test_data/tflint_v0.35.0_bad_config.check.shot
+++ b/linters/tflint/test_data/tflint_v0.35.0_bad_config.check.shot
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter tflint test bad_config 1`] = `
-Object {
-  "issues": Array [],
-  "lintActions": Array [],
-  "taskFailures": Array [
-    Object {
+{
+  "issues": [],
+  "lintActions": [],
+  "taskFailures": [
+    {
       "details": StringMatching /\\.\\*\\$/m,
       "message": "Preparing workspace",
       "name": "tflint",
     },
   ],
-  "unformattedFiles": Array [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/trivy/test_data/trivy_v0.37.1_CUSTOM.check.shot
+++ b/linters/trivy/test_data/trivy_v0.37.1_CUSTOM.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter trivy test CUSTOM 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "trivy",
       "code": "CVE-2022-45198",
       "file": "test_data/nested/requirements.txt",
@@ -12,7 +12,7 @@ Object {
       "message": "Pillow before 9.2.0 performs Improper Handling of Highly Compressed GIF Data (Data Amplification).",
       "targetType": "lockfile",
     },
-    Object {
+    {
       "bucket": "trivy",
       "code": "CVE-2022-45199",
       "file": "test_data/nested/requirements.txt",
@@ -21,7 +21,7 @@ Object {
       "message": "Pillow before 9.3.0 allows denial of service via SAMPLESPERPIXEL.",
       "targetType": "lockfile",
     },
-    Object {
+    {
       "bucket": "trivy",
       "code": "CVE-2022-45198",
       "file": "test_data/requirements.txt",
@@ -30,7 +30,7 @@ Object {
       "message": "Pillow before 9.2.0 performs Improper Handling of Highly Compressed GIF Data (Data Amplification).",
       "targetType": "lockfile",
     },
-    Object {
+    {
       "bucket": "trivy",
       "code": "CVE-2022-45199",
       "file": "test_data/requirements.txt",
@@ -40,36 +40,36 @@ Object {
       "targetType": "lockfile",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "fs",
       "fileGroupName": "lockfile",
       "linter": "trivy",
-      "paths": Array [
+      "paths": [
         "test_data/nested/requirements.txt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "fs",
       "fileGroupName": "lockfile",
       "linter": "trivy",
-      "paths": Array [
+      "paths": [
         "test_data/no_errors/requirements.txt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
-    Object {
+    {
       "command": "fs",
       "fileGroupName": "lockfile",
       "linter": "trivy",
-      "paths": Array [
+      "paths": [
         "test_data/requirements.txt",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/yamllint/test_data/yamllint_v1.26.3_basic.check.shot
+++ b/linters/yamllint/test_data/yamllint_v1.26.3_basic.check.shot
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Testing linter yamllint test basic 1`] = `
-Object {
-  "issues": Array [
-    Object {
+{
+  "issues": [
+    {
       "bucket": "yamllint",
       "code": "quoted-strings",
       "column": "6",
@@ -16,18 +16,18 @@ Object {
       "targetType": "yaml",
     },
   ],
-  "lintActions": Array [
-    Object {
+  "lintActions": [
+    {
       "command": "lint",
       "fileGroupName": "yaml",
       "linter": "yamllint",
-      "paths": Array [
+      "paths": [
         "test_data/basic.in.yaml",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
-  "taskFailures": Array [],
-  "unformattedFiles": Array [],
+  "taskFailures": [],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/yapf/test_data/yapf_v0.32.0_basic.fmt.shot
+++ b/linters/yapf/test_data/yapf_v0.32.0_basic.fmt.shot
@@ -27,7 +27,7 @@ class Globe(object):
 #whitespace below vvv
 
 #A malindented comment
-if __name__ == \\"__main__\\":
+if __name__ == "__main__":
     a = 4 + 1
     b = (2 * 7)
     c = [1, 2, 3]


### PR DESCRIPTION
#194 broke all of our snapshots, since config was changed to respect the [new defaults](https://github.com/igor-dv/jest-specific-snapshot/releases/tag/v8.0.0). We could override this through config, but it's not trivial to wire through due to our custom `jest-specific-snapshot` handling, so we might as well support the new, more concise default anyway.

Also adds a test filter so this sort of things can't be auto-merged in the future. I eyeball-audited all of the updates to make sure they weren't broken.

Snapshots updates by running `PLUGINS_TEST_LINTER_VERSION=Snapshot npm test linters -- -u`