### PR TITLE
fix(clippy): allow updating the local cache

### DIFF
--- a/linters/clippy/plugin.yaml
+++ b/linters/clippy/plugin.yaml
@@ -14,7 +14,7 @@ lint:
           # Custom parser type defined in the trunk cli to handle clippy's JSON output.
           output: clippy
           target: ${parent_with(Cargo.toml)}
-          run: cargo clippy --message-format json --frozen -- --cap-lints=warn --no-deps
+          run: cargo clippy --message-format json --locked -- --cap-lints=warn --no-deps
           success_codes: [0, 101, 383]
           run_linter_from: directory
           disable_upstream: true


### PR DESCRIPTION
`--frozen` forces clippy to not update the local cache, but this breaks clippy in CI scenarios (the original reason that this was OK was that users would populate this cache themselves)

`--locked` asserts that the lockfile stays locked, which is what we really want for linter invocations