### PR TITLE
Add stylua

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -4,6 +4,10 @@ lint:
     - name: dashes-inline
       leading_delimiter: --
 
+    - name: dashes-block
+      leading_delimiter: --[[
+      trailing_delimiter: --]]
+
     - name: hash
       leading_delimiter: "#"
 
@@ -298,6 +302,15 @@ lint:
 
         # Ruby
         - Gemfile.lock
+
+    - name: lua
+      extensions:
+        - lua
+      shebangs:
+        - lua
+      comments:
+        - dashes-inline
+        - dashes-block
 
     - name: markdown
       extensions:

--- a/linters/stylua/plugin.yaml
+++ b/linters/stylua/plugin.yaml
@@ -1,0 +1,35 @@
+version: 0.1
+lint:
+  downloads:
+    - name: stylua
+      version: 0.17.0
+      downloads:
+        - os:
+            linux: linux
+            macos: macos
+          cpu:
+            x86_64: x86_64
+            arm_64: aarch64
+          url: https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${cpu}.zip
+  definitions:
+    - name: stylua
+      files: [lua]
+      download: stylua
+      commands:
+        - name: format
+          output: rewrite
+          run: stylua --verify --search-parent-directories --stdin-filepath ${target} -
+          formatter: true
+          stdin: true
+          success_codes: [0, 1]
+      run_linter_from: workspace
+      is_recommended: false
+      direct_configs:
+        - stylua.toml
+        - .stylua.toml
+      environment:
+        - name: PATH
+          list: ["${linter}"]
+      version_command:
+        parse_regex: ${semver}
+        run: stylua --version

--- a/linters/stylua/stylua.test.ts
+++ b/linters/stylua/stylua.test.ts
@@ -1,0 +1,3 @@
+import { linterFmtTest } from "tests";
+
+linterFmtTest({ linterName: "stylua" });

--- a/linters/stylua/stylua.toml
+++ b/linters/stylua/stylua.toml
@@ -1,0 +1,10 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Tabs"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false

--- a/linters/stylua/test_data/basic.in.lua
+++ b/linters/stylua/test_data/basic.in.lua
@@ -1,0 +1,16 @@
+local a <const> = 5
+local b <close>
+
+  function fact (n)
+    if n == 0 then
+      return 1
+    else
+      return n * fact(n-1)
+    end
+  end
+
+      -- read 10 lines storing them in a table
+      a = {}
+      for i=1,10 do
+        a[i] = io.read()
+      end

--- a/linters/stylua/test_data/stylua_v0.17.0_basic.fmt.shot
+++ b/linters/stylua/test_data/stylua_v0.17.0_basic.fmt.shot
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter stylua test basic 1`] = `
+"local a <const> = 5
+local b <close>
+
+function fact(n)
+	if n == 0 then
+		return 1
+	else
+		return n * fact(n - 1)
+	end
+end
+
+-- read 10 lines storing them in a table
+a = {}
+for i = 1, 10 do
+	a[i] = io.read()
+end
+"
+`;

--- a/linters/stylua/test_data/stylua_v0.17.0_empty.fmt.shot
+++ b/linters/stylua/test_data/stylua_v0.17.0_empty.fmt.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter stylua test empty 1`] = `""`;

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ make the discovery, management and integration of new tools as straight-forward 
 | JSON            | [eslint], [prettier], [semgrep]                                                               |
 | Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>, [ktlint]                                     |
 | Kubernetes      | [kube-linter]                                                                                 |
+| Lua             | [stylua]                                                                                      |
 | Markdown        | [markdownlint], [remark-lint]                                                                 |
 | Nix             | [nixpkgs-fmt]                                                                                 |
 | package.json    | [sort-package-json]                                                                           |
@@ -137,6 +138,7 @@ make the discovery, management and integration of new tools as straight-forward 
 [standardrb]: https://github.com/testdouble/standard#readme
 [stringslint]: https://github.com/dral3x/StringsLint#readme
 [stylelint]: https://github.com/stylelint/stylelint#readme
+[stylua]: https://github.com/JohnnyMorganz/StyLua/tree/main
 [svgo]: https://github.com/svg/svgo#readme
 [swiftformat]: https://github.com/nicklockwood/SwiftFormat#readme
 [swiftlint]: https://github.com/realm/SwiftLint#readme


### PR DESCRIPTION
Adds [stylua](https://github.com/JohnnyMorganz/StyLua/tree/main), an opinionated formatter (and a bit more) for lua files. A couple notes: 
1. Adds the comment format and file type for lua, since this is our first lua tool.
2. [`--search-parent-directories`](https://github.com/JohnnyMorganz/StyLua/tree/main#finding-the-configuration) is required in the run command in order for a root level (or other) config file to be respected. However, this falls back to checking `XDG_CACHE_HOME` for a config. This can violate hermeticity across a repo, so I've chosen to dump the default config whenever someone runs `trunk check enable stylua`. This should prevent the likelihood of these cases happening.

Thanks @docwhat for suggesting and starting this!