### PR TITLE
Add snapshot for new circleci output format

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -80,7 +80,7 @@ jobs:
           cp package-lock.json package-lock.json.bak
           cp -r .github/actions .github/actions.bak
           # Include any newly generated snapshots that have been marked release-ready
-          grep "// RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
+          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
         continue-on-error: true
 
       - name: Get Latest Release
@@ -103,7 +103,7 @@ jobs:
           mv package-lock.json.bak package-lock.json
           mv .github/actions.bak .github/actions
           # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
-          grep "// RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
+          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
         continue-on-error: true
 
       - name: Cache tool downloads

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -88,7 +88,9 @@ actions:
     - id: remove-release-snapshots
       display_name: Remove Release Snapshots
       description: Remove release tag from snapshots that were added to the release
-      run: grep "// RELEASE" -r --include=*.shot -l | xargs -I {} sed -i -e '/^\/\/ RELEASE/d' {}
+      run:
+        grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} sed -i -e
+        '/^\/\/ trunk-upgrade-validation:RELEASE/d' {}
       shell: bash
 
   enabled:

--- a/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
+++ b/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// RELEASE
+
+exports[`Testing linter circleci test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "bucket": "circleci",
+      "code": "error",
+      "file": "test_data/bad_version/.circleci/config.yml",
+      "level": "LEVEL_HIGH",
+      "linter": "circleci",
+      "message": "Error: config compilation contains errors: [{Cannot find circleci/node@2.99 in the orb registry. Check that the namespace, orb name and version are correct.}]",
+      "targetType": "circleci-config",
+    },
+    {
+      "bucket": "circleci",
+      "code": "error",
+      "file": "test_data/malformed/.circleci/config.yml",
+      "level": "LEVEL_HIGH",
+      "linter": "circleci",
+      "message": "Error: config compilation contains errors: [{ERROR IN CONFIG FILE:} {[#/jobs/install-node-example] 0 subschemas matched instead of one} {1. [#/jobs/install-node-example] only 1 subschema matches out of 2} {|   1. [#/jobs/install-node-example] 6 schema violations found} {|   |   1. [#/jobs/install-node-example/docker/1] 2 schema violations found} {|   |   |   1. [#/jobs/install-node-example/docker/1] extraneous key [foo] is not permitted} {|   |   |   |   Permitted keys:} {|   |   |   |     - image} {|   |   |   |     - name} {|   |   |   |     - entrypoint} {|   |   |   |     - command} {|   |   |   |     - user} {|   |   |   |     - environment} {|   |   |   |     - aws_auth} {|   |   |   |     - auth} {|   |   |   |   Passed keys:} {|   |   |   |     - foo} {|   |   |   2. [#/jobs/install-node-example/docker/1] required key [image] not found} {|   |   2. [#/jobs/install-node-example/steps/3] 0 subschemas matched instead of one} {|   |   |   1. [#/jobs/install-node-example/steps/3] expected type: String, found: Mapping} {|   |   |   |   Shorthand commands, like \`checkout\`} {|   |   |   |   SCHEMA:} {|   |   |   |     type: string} {|   |   |   |   INPUT:} {|   |   |   |     rerun:} {|   |   |   |     - true} {|   |   |   2. [#/jobs/install-node-example/steps/3] extraneous key [rerun] is not permitted} {|   |   |   |   \`when\`/\`unless\` step} {|   |   |   |   Permitted keys:} {|   |   |   |     - when} {|   |   |   |     - unless} {|   |   |   |   Passed keys:} {|   |   |   |     - rerun} {|   |   |   3. [#/jobs/install-node-example/steps/3/rerun] no subschema matched out of the total 2 subschemas} {|   |   |   |   1. [#/jobs/install-node-example/steps/3/rerun] expected type: Mapping, found: Sequence} {|   |   |   |   |   SCHEMA:} {|   |   |   |   |     type:} {|   |   |   |   |     - object} {|   |   |   |   |     - string} {|   |   |   |   |   INPUT:} {|   |   |   |   |     - true} {|   |   |   |   2. [#/jobs/install-node-example/steps/3/rerun] expected type: String, found: Sequence} {|   |   |   |   |   SCHEMA:} {|   |   |   |   |     type:} {|   |   |   |   |     - object} {|   |   |   |   |     - string} {|   |   |   |   |   INPUT:} {|   |   |   |   |     - true} {2. [#/jobs/install-node-example] expected type: String, found: Mapping} {|   Job may be a string reference to another job}]",
+      "targetType": "circleci-config",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/bad_version/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/basic/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/malformed/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
+++ b/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// RELEASE
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter circleci test CUSTOM 1`] = `
 {

--- a/linters/nancy/test_data/nancy_v1.0.41_CUSTOM.check.shot
+++ b/linters/nancy/test_data/nancy_v1.0.41_CUSTOM.check.shot
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// RELEASE
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter nancy test CUSTOM 1`] = `
 {

--- a/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.check.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.check.shot
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// RELEASE
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter sqlfluff test basic_check 1`] = `
 {

--- a/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_fmt.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_fmt.fmt.shot
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// RELEASE
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter sqlfluff test basic_fmt 1`] = `
 "SELECT


### PR DESCRIPTION
The output changed as of https://github.com/CircleCI-Public/circleci-cli/releases/tag/v0.1.24705 (see [failed job](https://github.com/trunk-io/plugins/actions/runs/4493495218/jobs/7906295231)), adding a new snapshot with a RELEASE tag should provide no interruption to the linter validation service.