### PR TITLE
Fix script for trunk-check-pre-push-always

### DIFF
--- a/actions/trunk/trunk-check-pre-push.sh
+++ b/actions/trunk/trunk-check-pre-push.sh
@@ -2,9 +2,29 @@
 #
 # Lightweight wrapper to call trunk-check with optional interactivity.
 
+# Find the trunk binary.
+# TODO: This can be done better by passing the trunk binary path as an environment variable.
+if ! trunk="$(command -v trunk)"; then
+  set -euo pipefail
+  if [[ -f .trunk/bin/trunk && -x .trunk/bin/trunk ]]; then
+    trunk=.trunk/bin/trunk
+  elif [[ -f tools/trunk && -x tools/trunk ]]; then
+    trunk=tools/trunk
+  elif [[ -f trunk && -x trunk ]]; then
+    trunk=./trunk
+  elif [[ -n ${XDG_CACHE_HOME:-} && -f "${XDG_CACHE_HOME}/.cache/trunk/launcher/trunk" && -x "${XDG_CACHE_HOME}/.cache/trunk/launcher/trunk" ]]; then
+    trunk="${XDG_CACHE_HOME}/.cache/trunk/launcher/trunk"
+  elif [[ -n ${HOME:-} && -f "${HOME}/.cache/trunk/launcher/trunk" && -x "${HOME}/.cache/trunk/launcher/trunk" ]]; then
+    trunk="${HOME}/.cache/trunk/launcher/trunk"
+  else
+    echo "Unable to find trunk binary"
+    exit 1
+  fi
+fi
+
 if [[ -t 0 ]]; then
   # STDIN is TTY; can use interactive prompts.
-  trunk check -t git-push "$@"
+  exec "${trunk}" check -t git-push "$@"
 else
-  trunk check "$@"
+  exec "${trunk}" check "$@"
 fi


### PR DESCRIPTION
The script currently assumes that trunk can be found on PATH. We can instead inject logic with a copy of the code that git hooks launcher script uses.

We should also exec the formed command line in the script.