### PR TITLE
Fix rome/swiftlint snapshots from nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: ./.github/actions/linter_tests
         with:
           linter-version: ${{ matrix.linter-version }}
-          append-args: -- --json --outputFile=${{ matrix.os }}-res.json
+          append-args: linters -- --json --outputFile=${{ matrix.os }}-res.json
 
       - name: Upload Test Outputs for Upload Job
         # Only upload results from latest. Always run, except when cancelled.

--- a/linters/rome/test_data/rome_v12.0.0_basic_check.check.shot
+++ b/linters/rome/test_data/rome_v12.0.0_basic_check.check.shot
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter rome test basic_check 1`] = `
+{
+  "issues": [
+    {
+      "bucket": "rome",
+      "code": "lint/style/useEnumInitializers",
+      "column": "12",
+      "file": "test_data/basic_check.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "rome",
+      "message": "The enum member should be initialized.",
+      "targetType": "typescript",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "check",
+      "fileGroupName": "typescript",
+      "linter": "rome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "fmt",
+      "fileGroupName": "typescript",
+      "linter": "rome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
+      "column": "1",
+      "file": "test_data/basic_check.in.ts",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "rome",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
+}
+`;

--- a/linters/rome/test_data/rome_v12.0.0_basic_fmt.fmt.shot
+++ b/linters/rome/test_data/rome_v12.0.0_basic_fmt.fmt.shot
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter rome test basic_fmt 1`] = `
+"const foobar = () => {};
+const barfoo = () => {};
+
+enum Bar {
+	Baz,
+}
+
+const foo = (bar: Bar) => {
+	switch (bar) {
+		case Bar.Baz:
+			foobar();
+			barfoo();
+			break;
+	}
+	{
+		!foo ? null : 1;
+	}
+};
+"
+`;

--- a/linters/swiftlint/test_data/swiftlint_v0.51.0_CUSTOM.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.51.0_CUSTOM.check.shot
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter swiftlint test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "bucket": "swiftlint",
+      "code": "type_name",
+      "column": "8",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "swiftlint",
+      "message": "Type Name Violation: Type name 'a' should start with an uppercase character",
+      "targetType": "swift",
+    },
+    {
+      "bucket": "swiftlint",
+      "code": "line_length",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "3",
+      "linter": "swiftlint",
+      "message": "Line Length Violation: Line should be 120 characters or less; currently it has 139 characters",
+      "targetType": "swift",
+    },
+    {
+      "bucket": "swiftlint",
+      "code": "vertical_whitespace",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "5",
+      "linter": "swiftlint",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line; currently 2",
+      "targetType": "swift",
+    },
+    {
+      "bucket": "swiftlint",
+      "code": "identifier_name",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "swiftlint",
+      "message": "Identifier Name Violation: Function name 'Bar()' should start with a lowercase character",
+      "targetType": "swift",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "test_data/basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Fixes the rome and swiftlint snapshots failing in [Nightly](https://github.com/trunk-io/plugins/actions/runs/4545942776/jobs/8013945123). Marks them as release-ready. Also makes a small fix so nightly release tests don't run repo_tests.