### PR TITLE
Revert "Add hadolint macOS arm64 native binaries (#221)"

### DIFF
--- a/linters/hadolint/plugin.yaml
+++ b/linters/hadolint/plugin.yaml
@@ -5,11 +5,6 @@ lint:
       version: 2.8.0
       executable: true
       downloads:
-        # First version with arm64 support for Mac.
-        - os: macos
-          cpu: arm_64
-          version: ">=2.10.0"
-          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-arm64
         - os: linux
           cpu: x86_64
           url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64


### PR DESCRIPTION
This reverts commit b87e6407b8c3418700919de602c369822e81255c.

This download doesn't actually exist.