### PR TITLE
Fix snapshots and remove release tags

### DIFF
--- a/linters/ansible-lint/test_data/ansible_lint_v6.14.3_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.14.3_FQCN.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
 {

--- a/linters/ansible-lint/test_data/ansible_lint_v6.14.3_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.14.3_non_FQCN.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
 {

--- a/linters/buf/test_data/buf_format_v1.17.0_buf_lint.fmt.shot
+++ b/linters/buf/test_data/buf_format_v1.17.0_buf_lint.fmt.shot
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter buf-format test buf_lint 1`] = `
+"syntax = "proto3";
+
+package trunk;
+
+enum GoodEnum {
+  lower_case_UNSPECIFIED = 0;
+  GOOD_ENUM_VALUE_1 = 1;
+}
+"
+`;

--- a/linters/buf/test_data/buf_lint_v1.17.0_buf_lint.check.shot
+++ b/linters/buf/test_data/buf_lint_v1.17.0_buf_lint.check.shot
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter buf-lint test buf_lint 1`] = `
+{
+  "issues": [
+    {
+      "code": "FILE_LOWER_SNAKE_CASE",
+      "column": "1",
+      "file": "test_data/buf_lint.in.proto",
+      "issueUrl": "https://docs.buf.build/lint/rules#file_lower_snake_case",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "buf-lint",
+      "message": "Filename "buf_lint.in.proto" should be lower_snake_case.proto, such as "buf_lint_in.proto".",
+      "targetType": "proto",
+    },
+    {
+      "code": "PACKAGE_DIRECTORY_MATCH",
+      "column": "1",
+      "file": "test_data/buf_lint.in.proto",
+      "issueUrl": "https://docs.buf.build/lint/rules#package_directory_match",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "buf-lint",
+      "message": "Files with package "trunk" must be within a directory "trunk" relative to root but were in directory "test_data".",
+      "targetType": "proto",
+    },
+    {
+      "code": "PACKAGE_VERSION_SUFFIX",
+      "column": "1",
+      "file": "test_data/buf_lint.in.proto",
+      "issueUrl": "https://docs.buf.build/lint/rules#package_version_suffix",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "buf-lint",
+      "message": "Package name "trunk" should be suffixed with a correctly formed version, such as "trunk.v1".",
+      "targetType": "proto",
+    },
+    {
+      "code": "ENUM_VALUE_PREFIX",
+      "column": "3",
+      "file": "test_data/buf_lint.in.proto",
+      "issueUrl": "https://docs.buf.build/lint/rules#enum_value_prefix",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "buf-lint",
+      "message": "Enum value name "lower_case_UNSPECIFIED" should be prefixed with "GOOD_ENUM_".",
+      "targetType": "proto",
+    },
+    {
+      "code": "ENUM_VALUE_UPPER_SNAKE_CASE",
+      "column": "3",
+      "file": "test_data/buf_lint.in.proto",
+      "issueUrl": "https://docs.buf.build/lint/rules#enum_value_upper_snake_case",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "buf-lint",
+      "message": "Enum value name "lower_case_UNSPECIFIED" should be UPPER_SNAKE_CASE, such as "LOWER_CASE_UNSPECIFIED".",
+      "targetType": "proto",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "proto",
+      "linter": "buf-lint",
+      "paths": [
+        "test_data/buf_lint.in.proto",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
+++ b/linters/circleci/test_data/circleci_v0.1.24705_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter circleci test CUSTOM 1`] = `
 {

--- a/linters/djlint/test_data/djlint_v1.19.17_logout.check.shot
+++ b/linters/djlint/test_data/djlint_v1.19.17_logout.check.shot
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter djlint test logout 1`] = `
+{
+  "issues": [
+    {
+      "code": "H017",
+      "column": "4",
+      "file": "test_data/logout.in.html",
+      "issueUrl": "https://www.djlint.com/docs/linter/#rules",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "djlint",
+      "message": "Tag should be self closing. :: <link>",
+      "targetType": "html",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "fmt",
+      "fileGroupName": "html",
+      "linter": "djlint",
+      "paths": [
+        "test_data/logout.in.html",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "html",
+      "linter": "djlint",
+      "paths": [
+        "test_data/logout.in.html",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
+      "column": "1",
+      "file": "test_data/logout.in.html",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "djlint",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
+}
+`;

--- a/linters/djlint/test_data/djlint_v1.19.17_logout.fmt.shot
+++ b/linters/djlint/test_data/djlint_v1.19.17_logout.fmt.shot
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter djlint test logout 1`] = `
+"{% extends "base.html" %}
+{% load i18n %}
+{% block contentLoggedIn %}You are currently logged in.{% endblock %}
+{% block content %}
+    <!--{% trans "Logged out" %}-->
+    <p>You are currently logged out.</p>
+    <link></link>
+<a href="{% url auth_login %}">{% trans "Log in" %}</a>
+{% endblock %}
+"
+`;

--- a/linters/nancy/test_data/nancy_v1.0.41_CUSTOM.check.shot
+++ b/linters/nancy/test_data/nancy_v1.0.41_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter nancy test CUSTOM 1`] = `
 {

--- a/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
+++ b/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter osv-scanner test CUSTOM 1`] = `
 {

--- a/linters/rome/test_data/rome_v12.0.0_basic_check.check.shot
+++ b/linters/rome/test_data/rome_v12.0.0_basic_check.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter rome test basic_check 1`] = `
 {

--- a/linters/rome/test_data/rome_v12.0.0_basic_fmt.fmt.shot
+++ b/linters/rome/test_data/rome_v12.0.0_basic_fmt.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter rome test basic_fmt 1`] = `
 "const foobar = () => {};

--- a/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.check.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter sqlfluff test basic_check 1`] = `
 {

--- a/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_fmt.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_fmt.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter sqlfluff test basic_fmt 1`] = `
 "SELECT

--- a/linters/swiftlint/test_data/swiftlint_v0.51.0_CUSTOM.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.51.0_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter swiftlint test CUSTOM 1`] = `
 {


### PR DESCRIPTION
Remove the release tags for latest testing that were included in the previous release.

Adds new snapshots for `buf-lint` and `djlint`, which released new versions yesterday with subtle changes. 