### PR TITLE
Make trufflehog batchable

### DIFF
--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -22,6 +22,7 @@ lint:
           read_output_from: stdout
           success_codes: [0, 183]
           is_security: true
+          batch: true
           parser:
             runtime: python
             run: ${plugin}/linters/trufflehog/trufflehog_to_sarif.py


### PR DESCRIPTION
I probably should have caught this in the first pass, but from what I can tell, there's no reason it shouldn't be batchable, and it frequently errors on medium/large codebases when not batched and running with `-a`.