### PR TITLE
Add test for swiftlint nested config

### DIFF
--- a/linters/swiftlint/swiftlint.test.ts
+++ b/linters/swiftlint/swiftlint.test.ts
@@ -1,4 +1,49 @@
 import { customLinterCheckTest } from "tests";
+import { TrunkDriver } from "tests/driver";
 import { skipOS } from "tests/utils";
 
-customLinterCheckTest({ linterName: "swiftlint", args: "-a", skipTestIf: skipOS(["linux"]) });
+customLinterCheckTest({
+  linterName: "swiftlint",
+  testName: "basic",
+  args: "-a",
+  skipTestIf: skipOS(["linux"]),
+});
+
+const configSetup = (driver: TrunkDriver) => {
+  // top-level config 1. This is used as the base for all nested configs.
+  driver.writeFile(
+    ".trunk/configs/.swiftlint.yml",
+    `disabled_rules:
+  - line_length
+  - identifier_name`
+  );
+
+  // nested config 2. Files in its directory should apply configs 1 and 2
+  driver.writeFile(
+    "test_data/.swiftlint.yml",
+    `disabled_rules:
+  - type_name`
+  );
+
+  // nested config 3. Files in its directory should apply configs 1 and 3
+  driver.writeFile(
+    "test_data/subdir/.swiftlint.yml",
+    `disabled_rules:
+  - vertical_whitespace`
+  );
+
+  // Include 3 copies of basic.swift:
+  // - basic.swift (config 1)
+  // - test_data/basic.swift (config 1 and 2)
+  // - test_data/subdir/basic.swift (config 1 and 3)
+  driver.copyFile("test_data/basic.swift", "basic.swift");
+  driver.copyFile("basic.swift", "test_data/subdir/basic.swift");
+};
+
+customLinterCheckTest({
+  linterName: "swiftlint",
+  testName: "nested_configs",
+  args: "-a",
+  skipTestIf: skipOS(["linux"]),
+  preCheck: configSetup,
+});

--- a/linters/swiftlint/test_data/swiftlint_v0.49.1_basic.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.49.1_basic.check.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing linter swiftlint test CUSTOM 1`] = `
+exports[`Testing linter swiftlint test basic 1`] = `
 {
   "issues": [
     {
@@ -10,7 +10,7 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "swiftlint",
-      "message": "Type Name Violation: Type name 'a' should start with an uppercase character",
+      "message": "Type Name Violation: Type name should start with an uppercase character: 'a'",
       "targetType": "swift",
     },
     {
@@ -20,7 +20,7 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "level": "LEVEL_MEDIUM",
       "line": "3",
       "linter": "swiftlint",
-      "message": "Line Length Violation: Line should be 120 characters or less; currently it has 139 characters",
+      "message": "Line Length Violation: Line should be 120 characters or less: currently 139 characters",
       "targetType": "swift",
     },
     {
@@ -30,7 +30,7 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "level": "LEVEL_MEDIUM",
       "line": "5",
       "linter": "swiftlint",
-      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line; currently 2",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line. Currently 2.",
       "targetType": "swift",
     },
     {
@@ -40,7 +40,7 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "level": "LEVEL_HIGH",
       "line": "6",
       "linter": "swiftlint",
-      "message": "Identifier Name Violation: Function name 'Bar()' should start with a lowercase character",
+      "message": "Identifier Name Violation: Function name should start with a lowercase character: 'Bar()'",
       "targetType": "swift",
     },
   ],

--- a/linters/swiftlint/test_data/swiftlint_v0.49.1_nested_configs.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.49.1_nested_configs.check.shot
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing linter swiftlint test CUSTOM 1`] = `
+exports[`Testing linter swiftlint test nested_configs 1`] = `
 {
   "issues": [
     {
       "code": "type_name",
       "column": "8",
-      "file": "test_data/basic.swift",
+      "file": "basic.swift",
       "level": "LEVEL_HIGH",
       "line": "1",
       "linter": "swiftlint",
@@ -14,13 +14,13 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "targetType": "swift",
     },
     {
-      "code": "line_length",
+      "code": "vertical_whitespace",
       "column": "1",
-      "file": "test_data/basic.swift",
+      "file": "basic.swift",
       "level": "LEVEL_MEDIUM",
-      "line": "3",
+      "line": "5",
       "linter": "swiftlint",
-      "message": "Line Length Violation: Line should be 120 characters or less: currently 139 characters",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line. Currently 2.",
       "targetType": "swift",
     },
     {
@@ -34,13 +34,13 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "targetType": "swift",
     },
     {
-      "code": "identifier_name",
-      "column": "1",
-      "file": "test_data/basic.swift",
+      "code": "type_name",
+      "column": "8",
+      "file": "test_data/subdir/basic.swift",
       "level": "LEVEL_HIGH",
-      "line": "6",
+      "line": "1",
       "linter": "swiftlint",
-      "message": "Identifier Name Violation: Function name should start with a lowercase character: 'Bar()'",
+      "message": "Type Name Violation: Type name should start with an uppercase character: 'a'",
       "targetType": "swift",
     },
   ],
@@ -50,7 +50,25 @@ exports[`Testing linter swiftlint test CUSTOM 1`] = `
       "fileGroupName": "swift",
       "linter": "swiftlint",
       "paths": [
+        "basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
         "test_data/basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "test_data/subdir/basic.swift",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },

--- a/linters/swiftlint/test_data/swiftlint_v0.51.0_basic.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.51.0_basic.check.shot
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter swiftlint test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "type_name",
+      "column": "8",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "swiftlint",
+      "message": "Type Name Violation: Type name 'a' should start with an uppercase character",
+      "targetType": "swift",
+    },
+    {
+      "code": "line_length",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "3",
+      "linter": "swiftlint",
+      "message": "Line Length Violation: Line should be 120 characters or less; currently it has 139 characters",
+      "targetType": "swift",
+    },
+    {
+      "code": "vertical_whitespace",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "5",
+      "linter": "swiftlint",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line; currently 2",
+      "targetType": "swift",
+    },
+    {
+      "code": "identifier_name",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "swiftlint",
+      "message": "Identifier Name Violation: Function name 'Bar()' should start with a lowercase character",
+      "targetType": "swift",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "test_data/basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/swiftlint/test_data/swiftlint_v0.51.0_nested_configs.check.shot
+++ b/linters/swiftlint/test_data/swiftlint_v0.51.0_nested_configs.check.shot
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter swiftlint test nested_configs 1`] = `
+{
+  "issues": [
+    {
+      "code": "type_name",
+      "column": "8",
+      "file": "basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "swiftlint",
+      "message": "Type Name Violation: Type name 'a' should start with an uppercase character",
+      "targetType": "swift",
+    },
+    {
+      "code": "vertical_whitespace",
+      "column": "1",
+      "file": "basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "5",
+      "linter": "swiftlint",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line; currently 2",
+      "targetType": "swift",
+    },
+    {
+      "code": "vertical_whitespace",
+      "column": "1",
+      "file": "test_data/basic.swift",
+      "level": "LEVEL_MEDIUM",
+      "line": "5",
+      "linter": "swiftlint",
+      "message": "Vertical Whitespace Violation: Limit vertical whitespace to a single empty line; currently 2",
+      "targetType": "swift",
+    },
+    {
+      "code": "type_name",
+      "column": "8",
+      "file": "test_data/subdir/basic.swift",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "swiftlint",
+      "message": "Type Name Violation: Type name 'a' should start with an uppercase character",
+      "targetType": "swift",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "test_data/basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "swift",
+      "linter": "swiftlint",
+      "paths": [
+        "test_data/subdir/basic.swift",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Adds test that asserts behavior with nested swiftlint configs. Behavior adheres to [documented nested configs](https://github.com/realm/SwiftLint#nested-configurations) (i.e. merges up to one nested config file with the base config file).