### PR TITLE
Update osv snapshot

### DIFF
--- a/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
+++ b/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter osv-scanner test CUSTOM 1`] = `
 {

--- a/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
+++ b/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
@@ -67,6 +67,15 @@ exports[`Testing linter osv-scanner test CUSTOM 1`] = `
       "targetType": "osv-lockfiles",
     },
     {
+      "code": "GHSA-pxvg-2qj5-37jq",
+      "file": "test_data/Gemfile.lock",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "linter": "osv-scanner",
+      "message": "Nokogiri updates packaged libxml2 to v2.10.4 to resolve multiple CVEs",
+      "targetType": "osv-lockfiles",
+    },
+    {
       "code": "GHSA-36h2-95gj-w488",
       "file": "test_data/go.mod",
       "isSecurity": true,


### PR DESCRIPTION
Address [failure](https://github.com/trunk-io/plugins/actions/runs/4676037039) and mark ready for release. We've had osv-scanner integrated for a limited time, but if we see repeated things like this, we may want to consider a specialized assertion for it.