### PR TITLE
Add sandbox-type support

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 cli:
   # version used for local trunk runs and testing
-  version: 1.7.1-beta.9
+  version: 1.8.2-beta.6
 
 plugins:
   sources:

--- a/linters/cspell/plugin.yaml
+++ b/linters/cspell/plugin.yaml
@@ -6,7 +6,8 @@ lint:
       runtime: node
       package: cspell
       commands:
-        - output: regex
+        - name: lint
+          output: regex
           parse_regex: ((?P<path>.*):(?P<line>\d+):(?P<col>\d+) - (?P<message>.*))
           run: cspell --no-progress --no-summary --show-suggestions --no-cache ${target}
           batch: true
@@ -15,7 +16,7 @@ lint:
           cache_results: false
           # TODO(Tyler): In order to respect a symlinked config into the root, we create the entire sandbox manually,
           # otherwise the config is ignored. We should add an option for the config to be copied directly into the sandbox.
-          in_place: true
+          sandbox_type: copy_targets
       direct_configs:
         - .cspell.json
         - cspell.json

--- a/linters/gitleaks/plugin.yaml
+++ b/linters/gitleaks/plugin.yaml
@@ -10,7 +10,7 @@ lint:
           output: sarif
           read_output_from: tmp_file
           success_codes: [0, 101]
-          in_place: true
+          sandbox_type: copy_targets
           cache_results: true
           allow_empty_files: false
         - name: lint
@@ -19,7 +19,7 @@ lint:
           output: sarif
           read_output_from: tmp_file
           success_codes: [0, 101]
-          in_place: true
+          sandbox_type: copy_targets
           cache_results: true
           allow_empty_files: false
         - name: lint
@@ -28,7 +28,7 @@ lint:
           output: sarif
           read_output_from: tmp_file
           success_codes: [0]
-          in_place: true
+          sandbox_type: copy_targets
           cache_results: true
           allow_empty_files: false
       runtime: go

--- a/linters/gokart/plugin.yaml
+++ b/linters/gokart/plugin.yaml
@@ -12,15 +12,12 @@ lint:
       commands:
         - name: lint
           output: sarif
-          # gokart says it should run on the parent dir, but it doesn't follow symlinks correctly in our shadow,
-          # so in order to run with a sandboxed environment, run on the files directly.
-          # TODO(Tyler): We should add an option to make an expanded shadow tree to support this
+          target: ${parent}
           run: gokart scan -i analyzers.yml -s ${target}
           success_codes: [0]
           read_output_from: stdout
-          # TODO(Chris): We need a new configuration option which means copy files into a sandbox.
-          # This is an abuse of in_place which implies that.
-          in_place: true
+          # gokart runs on directory targets but requires these directories to not be symlinks
+          sandbox_type: expanded
           run_linter_from: root_file
           is_security: true
       direct_configs:

--- a/linters/gokart/test_data/gokart_v0.5.1_CUSTOM.check.shot
+++ b/linters/gokart/test_data/gokart_v0.5.1_CUSTOM.check.shot
@@ -94,7 +94,7 @@ exports[`Testing linter gokart test CUSTOM 1`] = `
       "fileGroupName": "go",
       "linter": "gokart",
       "paths": [
-        "test_data/path_traversal/path_traversal.in.go",
+        "test_data/path_traversal",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
@@ -103,7 +103,7 @@ exports[`Testing linter gokart test CUSTOM 1`] = `
       "fileGroupName": "go",
       "linter": "gokart",
       "paths": [
-        "test_data/sql_injection/sql_injection.in.go",
+        "test_data/sql_injection",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },

--- a/linters/google-java-format/plugin.yaml
+++ b/linters/google-java-format/plugin.yaml
@@ -10,7 +10,8 @@ lint:
       files: [java]
       download: google-java-format.jar
       commands:
-        - output: rewrite
+        - name: format
+          output: rewrite
           run: java -jar ${linter}/google-java-format.jar --replace ${target}
           success_codes: [0]
           in_place: true

--- a/linters/remark-lint/plugin.yaml
+++ b/linters/remark-lint/plugin.yaml
@@ -32,7 +32,7 @@ lint:
           output: sarif
           run: remark ${target} --frail --output --report=vfile-reporter-json
           success_codes: [0, 1]
-          in_place: true
+          sandbox_type: copy_targets
           cache_results: true
           read_output_from: stderr
           parser:

--- a/linters/semgrep/plugin.yaml
+++ b/linters/semgrep/plugin.yaml
@@ -15,9 +15,7 @@ lint:
           success_codes: [0]
           batch: true
           cache_results: true
-          # TODO(Chris): We need a new configuration option which means copy files into a sandbox.
-          # This is an abuse of in_place which implies that.
-          in_place: true
+          sandbox_type: copy_targets
       direct_configs:
         - .semgrep.yaml
         - .semgrep.yml

--- a/linters/shellcheck/plugin.yaml
+++ b/linters/shellcheck/plugin.yaml
@@ -27,10 +27,7 @@ lint:
           output: shellcheck
           run: shellcheck ${target} -f json --external-sources
           error_codes: [2]
-          # Shellcheck doesn't properly follow `source` when our symlink forrest symlinks a folder
-          # containing the source file. This option forces trunk to create real parent folders and
-          # copy rather than symlink the target file.
-          in_place: true
+          sandbox_type: copy_targets
       direct_configs:
         - .shellcheckrc
         - shellcheckrc

--- a/linters/sqlfmt/plugin.yaml
+++ b/linters/sqlfmt/plugin.yaml
@@ -9,7 +9,8 @@ lint:
       # trunk-ignore(yamllint/quoted-strings): see https://github.com/adrienverge/yamllint/issues/516
       extra_packages: ["shandy-sqlfmt[jinjafmt]"]
       commands:
-        - output: rewrite
+        - name: format
+          output: rewrite
           run: sqlfmt ${target}
           success_codes: [0]
           read_output_from: stderr

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.7.0"
+required_trunk_version: ">=1.8.2-beta.6"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -24,7 +24,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.7.0",
+    trunkVersion: "1.8.2-beta.6",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
Previously, we were using `in_place: true` as a hacky mechanism for copying files into a sandbox to be linted. `in_place` is meant to be reserved for formatters. Now, we have the `sandbox_type: normal | expanded | copy_targets` flag to replace it, as well as to enable `gokart` to correctly run on directories with an expanded shadow tree (in_place does not work for linters that run on directory targets).

Will require a `required_trunk_version` bump.