### PR TITLE
Fix ansible-lint@6.15.0 and fix customLinterFmtTest

### DIFF
--- a/linters/ansible-lint/plugin.yaml
+++ b/linters/ansible-lint/plugin.yaml
@@ -10,7 +10,8 @@ lint:
           # sarif support was added in version 6.1.0
           output: sarif
           run: ansible-lint -f sarif
-          success_codes: [0, 2]
+          # ansible-lint >=6.15.0 return exit code 5 when no files matched
+          success_codes: [0, 2, 5]
           run_linter_from: directory
         - name: lint
           version: ">=5.1.3"

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -259,7 +259,7 @@ export const customLinterFmtTest = ({
 }) => {
   describe(`Testing formatter ${linterName}`, () => {
     // Step 1: Detect versions to test against if PLUGINS_TEST_LINTER_VERSION=Snapshots
-    const linterVersions = getVersionsForTest(dirname, linterName, testName, "fmt");
+    const linterVersions = getVersionsForTest(dirname, linterName, `${testName}.*`, "fmt");
     linterVersions.forEach((linterVersion) => {
       // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
       describe("test", () => {


### PR DESCRIPTION
1. ansible-lint@6.15.0 was released 2 days ago and changes its exit codes.
2. I missed a fix for customLinterFmtTest regex; included it here.