### PR TITLE
fix istioctl download declaration

### DIFF
--- a/tools/istioctl/plugin.yaml
+++ b/tools/istioctl/plugin.yaml
@@ -3,13 +3,13 @@ tools:
   downloads:
     - name: istioctl
       downloads:
-        - os:
-            linux: linux
-            macos: osx
+        - os: macos
+          url: https://github.com/istio/istio/releases/download/${version}/istioctl-${version}-osx-amd64.tar.gz
+        - os: linux
           cpu:
             x86_64: amd64
             arm_64: arm64
-          url: https://github.com/istio/istio/releases/download/${version}/istioctl-${version}-${os}-${cpu}.tar.gz
+          url: https://github.com/istio/istio/releases/download/${version}/istioctl-${version}-linux-${cpu}.tar.gz
   definitions:
     - name: istioctl
       download: istioctl


### PR DESCRIPTION
does not have arm64 build for mac