### PR TITLE
Reenable trivy tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,7 +109,8 @@ jobs:
     needs: detect_changes
     if:
       needs.detect_changes.outputs.linters == 'true' || needs.detect_changes.outputs.all-linters ==
-      'linters'
+      'linters' || needs.detect_changes.outputs.tools == 'true' ||
+      needs.detect_changes.outputs.all-tools == 'tools'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -129,6 +130,9 @@ jobs:
       - name: Linter Tests
         # Run tests using KnownGoodVersion with any modified linters and conditionally all linters
         uses: ./.github/actions/linter_tests
+        if:
+          needs.detect_changes.outputs.linters == 'true' || needs.detect_changes.outputs.all-linters
+          == 'linters'
         with:
           linter-version: KnownGoodVersion
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
@@ -148,14 +152,21 @@ jobs:
           append-args: ${{needs.detect_changes.outputs.linters-files }}
 
       - name: Tool Tests
+        # Run tests using KnownGoodVersion with any modified tools and conditionally all tools. Don't run when cancelled.
         uses: ./.github/actions/tool_tests
+        if:
+          (failure() || success()) && needs.detect_changes.outputs.tools == 'true' ||
+          needs.detect_changes.outputs.all-tools == 'tools'
         with:
           append-args:
             ${{ needs.detect_changes.outputs.all-tools }} ${{
             needs.detect_changes.outputs.tools-files }}
 
       - name: Tool Tests Latest
-        if: (failure() || success()) && needs.detect_changes.outputs.tools == 'true'
+        # Run tests using Latest with any modified tools (see filters.yaml). Don't run when cancelled.
+        if:
+          (failure() || success()) && needs.detect_changes.outputs.tools == 'true' &&
+          needs.detect_changes.outputs.tools-files != ''
         uses: ./.github/actions/tool_tests
         with:
           append-args: ${{ needs.detect_changes.outputs.tools-files }}

--- a/linters/trivy/trivy.test.ts
+++ b/linters/trivy/trivy.test.ts
@@ -1,8 +1,6 @@
 import { customLinterCheckTest } from "tests";
 
-// TODO(Tyler): Test is temporarily disabled for trivy config errors
 customLinterCheckTest({
   linterName: "trivy",
   args: "-a -y",
-  skipTestIf: () => true,
 });


### PR DESCRIPTION
Arose from [new rule](https://github.com/aquasecurity/trivy/issues/4124). Resolved upon clearing cache after trivy introduced a rollback.

Also adds a few missing filters and conditionals to PR test runs.