### PR TITLE
Add suggest if for sourcery

### DIFF
--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -21,6 +21,7 @@ lint:
           in_place: true
       runtime: python
       package: sourcery
+      suggest_if: config_present
       direct_configs:
         - .sourcery.yaml
         - sourcery.yaml

--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -21,7 +21,7 @@ lint:
           in_place: true
       runtime: python
       package: sourcery
-      suggest_if: config_present
+      suggest_if: never
       direct_configs:
         - .sourcery.yaml
         - sourcery.yaml


### PR DESCRIPTION
Because sourcery requires additional CI (auth) setup, we probably don't want to turn it on automatically, even if people already have the config.