### PR TITLE
Tell trufflehog not to update itself

### DIFF
--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -18,7 +18,7 @@ lint:
       commands:
         - name: lint
           output: sarif
-          run: trufflehog filesystem --json --fail --no-verification ${target}
+          run: trufflehog filesystem --json --fail --no-verification --no-update ${target}
           read_output_from: stdout
           success_codes: [0, 183]
           is_security: true


### PR DESCRIPTION
I got this when running trufflehog with `trunk -a --filter=trufflehog`:
```
        {"level":"error","ts":"2023-06-05T13:06:31-07:00","logger":"trufflehog","msg":"error occured with trufflehog updater 🐷","error":"cannot move binary (exec: \"mv\": executable file not found in $PATH)"}
```

Apparently, trufflehog will try to auto-update itself if we don't pass `--no-update`.