### PR TITLE
Fix snapshots for flaky linters, add version commands

### DIFF
--- a/linters/nancy/plugin.yaml
+++ b/linters/nancy/plugin.yaml
@@ -31,6 +31,9 @@ lint:
           parser:
             runtime: python
             run: ${plugin}/linters/nancy/parse.py
+      version_command:
+        parse_regex: nancy version ${semver}
+        run: nancy --version
       suggest_if: never
       environment:
         - name: PATH

--- a/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
+++ b/linters/osv-scanner/test_data/osv_scanner_v1.2.0_CUSTOM.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter osv-scanner test CUSTOM 1`] = `
 {
@@ -471,7 +472,7 @@ exports[`Testing linter osv-scanner test CUSTOM 1`] = `
       "issueUrl": "https://osv.dev/GO-2020-0041",
       "level": "LEVEL_HIGH",
       "linter": "osv-scanner",
-      "message": "Vulnerability in github.com/unknwon/cae 1.0.0: Due to improper path santization, archives containing relative file paths can cause files to be written (or overwritten) outside of the target directory.",
+      "message": "Vulnerability in github.com/unknwon/cae 1.0.0: Due to improper path sanitization, archives containing relative file paths can cause files to be written (or overwritten) outside of the target directory.",
       "targetType": "osv-lockfiles",
     },
     {

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -49,6 +49,9 @@ lint:
           parser:
             runtime: python
             run: ${plugin}/linters/trivy/trivy_config_to_sarif.py
+      version_command:
+        parse_regex: Version ${semver}
+        run: trivy --version
 
       environment:
         - name: PATH

--- a/linters/trivy/test_data/trivy_v0.37.1_CUSTOM.check.shot
+++ b/linters/trivy/test_data/trivy_v0.37.1_CUSTOM.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trivy test CUSTOM 1`] = `
 {


### PR DESCRIPTION
Achieves the following:
- Fixes osv-scanner snapshot and marks as release-ready
- Marks trivy snapshot as release-ready
- Adds version command for trivy
- Adds version command for nancy (it fails to install pretty frequently--this should in theory make us retry the download a couple of times)