### PR TITLE
Some messaging in truck-check-pre-push-always

### DIFF
--- a/actions/trunk/trunk-check-pre-push.sh
+++ b/actions/trunk/trunk-check-pre-push.sh
@@ -24,7 +24,9 @@ fi
 
 if [[ -t 0 ]]; then
   # STDIN is TTY; can use interactive prompts.
+  echo "Running trunk in interactive mode."
   exec "${trunk}" check -t git-push "$@"
 else
+  echo "Running trunk in non-interactive mode; if this fails, please try your git or trunk command manually from a terminal."
   exec "${trunk}" check "$@"
 fi


### PR DESCRIPTION
Remind the user that trunk is running in non-interactive mode, and if there are
issues, then the user can try running the command manually from a terminal.