### PR TITLE
Add trufflehog new snapshot

### DIFF
--- a/linters/trufflehog/test_data/trufflehog_v3.40.0_secrets.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.40.0_secrets.check.shot
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog test secrets 1`] = `
+{
+  "issues": [
+    {
+      "code": "AWS",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog",
+      "message": "AKIAXYZDQCEN4EXAMPLE",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog",
+      "message": "[secret redacted]",
+      "targetType": "ALL",
+    },
+    {
+      "code": "PrivateKey",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog",
+      "message": "-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog",
+      "message": "https://admin:********@the-internet.herokuapp.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/secrets.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Trufflehog release [v3.40.0](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.40.0) changes URI redaction. Update the snapshot and tag for release.