### PR TITLE
Bump cli version

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.10.1-beta.35
+  version: 1.10.1-beta.39
 
 api:
   address: api.trunk-staging.io:8443

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.10.1-beta.39
+  version: 1.10.1-beta.40
 
 api:
   address: api.trunk-staging.io:8443


### PR DESCRIPTION
Bump the cli version. We want people to be using the daemon fixes, so this and higher should be the standard for this repo for now.