### PR TITLE
fixes

### DIFF
--- a/actions/git-blame-ignore-revs/plugin.yaml
+++ b/actions/git-blame-ignore-revs/plugin.yaml
@@ -4,7 +4,7 @@ actions:
     - id: git-blame-ignore-revs
       display_name: Auto-enable .git-blame-ignore-revs
       description: Automatically configure git to use .git-blame-ignore-revs while the file exists.
-      run: sh ${cwd}/update_config.sh
+      run: bash ${cwd}/update_config.sh
       triggers:
         - files: [.git-blame-ignore-revs]
         - schedule: 24h

--- a/actions/go-mod-tidy-vendor/plugin.yaml
+++ b/actions/go-mod-tidy-vendor/plugin.yaml
@@ -5,6 +5,6 @@ actions:
       display_name: Go Mod Tidy & Vendor
       description: Runs go mod tidy followed by go mod vendor.
       runtime: go
-      run: sh ${plugin}/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
+      run: bash ${plugin}/actions/go-mod-tidy-vendor/go-mod-tidy-vendor.sh
       triggers:
         - files: [go.mod]

--- a/linters/pyright/plugin.yaml
+++ b/linters/pyright/plugin.yaml
@@ -14,7 +14,7 @@ lint:
           cache_results: true
           parser:
             runtime: python
-            run: ${plugin}/linters/pyright/pyright_to_sarif.py
+            run: python ${plugin}/linters/pyright/pyright_to_sarif.py
       runtime: python
       package: pyright
       direct_configs:

--- a/linters/pyright/test_data/pyright_v1.1.315_basic.check.shot
+++ b/linters/pyright/test_data/pyright_v1.1.315_basic.check.shot
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter pyright test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "57",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "pyright",
+      "message": ""Enum" is unknown import symbol",
+      "targetType": "python",
+    },
+    {
+      "column": "13",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#",
+      "level": "LEVEL_LOW",
+      "line": "15",
+      "linter": "pyright",
+      "message": "Type of "a.x" is "int | str"",
+      "targetType": "python",
+    },
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "3",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "18",
+      "linter": "pyright",
+      "message": "Cannot assign member "x" for type "A"
+  Expression of type "float" cannot be assigned to member "x" of class "A"
+    Type "float" cannot be assigned to type "int | str"
+      "float" is incompatible with "int"
+      "float" is incompatible with "str"",
+      "targetType": "python",
+    },
+    {
+      "code": "reportUndefinedVariable",
+      "column": "8",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUndefinedVariable",
+      "level": "LEVEL_HIGH",
+      "line": "24",
+      "linter": "pyright",
+      "message": ""ClassVar" is not defined",
+      "targetType": "python",
+    },
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "9",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "31",
+      "linter": "pyright",
+      "message": "Cannot access member "z" for type "type[A]"
+  Member "z" is unknown",
+      "targetType": "python",
+    },
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "29",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "39",
+      "linter": "pyright",
+      "message": "Function with declared type of "bool" must return value on all code paths
+  Type "None" cannot be assigned to type "bool"",
+      "targetType": "python",
+    },
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "12",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "5",
+      "linter": "pyright",
+      "message": "Expression of type "int" cannot be assigned to return type "str"
+  "int" is incompatible with "str"",
+      "targetType": "python",
+    },
+    {
+      "column": "25",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#",
+      "level": "LEVEL_LOW",
+      "line": "51",
+      "linter": "pyright",
+      "message": "Type of "val" is "int"",
+      "targetType": "python",
+    },
+    {
+      "column": "39",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#",
+      "level": "LEVEL_LOW",
+      "line": "54",
+      "linter": "pyright",
+      "message": "Type of "val" is "int"",
+      "targetType": "python",
+    },
+    {
+      "code": "reportGeneralTypeIssues",
+      "column": "7",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "pyright",
+      "message": "Class declaration "A" is obscured by a declaration of the same name",
+      "targetType": "python",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "pyright",
+      "paths": [
+        "test_data/basic.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -11,7 +11,7 @@ lint:
           output: sarif
           parser:
             runtime: python
-            run: ${cwd}/ruff_to_sarif.py 0
+            run: python ${cwd}/ruff_to_sarif.py 0
           batch: true
           success_codes: [0, 1]
         - name: lint

--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -29,7 +29,7 @@ lint:
           success_codes: [0, 3, 4, 5]
           parser: # necessary to convert file paths from a strange custom format to a standard format
             runtime: python
-            run: ${plugin}/linters/terrascan/sarif_to_sarif.py
+            run: python ${plugin}/linters/terrascan/sarif_to_sarif.py
         - name: lint-docker
           output: sarif
           is_security: true
@@ -39,7 +39,7 @@ lint:
           success_codes: [0, 3, 4, 5]
           parser:
             runtime: python
-            run: ${plugin}/linters/terrascan/sarif_to_sarif.py
+            run: python ${plugin}/linters/terrascan/sarif_to_sarif.py
       version_command:
         parse_regex: "version: v${semver}"
         run: terrascan version


### PR DESCRIPTION
Fixes the following:
- `git-blame-ignore-revs` bug with sh != bash on Linux (also defensively fixed `go-mod-tidy-vendor`)
- Added runtime stems for pyright, ruff, and terrascan (Windows enabler)
- Updated pyright snapshot