### PR TITLE
Don't autosuggest nancy

### DIFF
--- a/linters/nancy/plugin.yaml
+++ b/linters/nancy/plugin.yaml
@@ -34,7 +34,7 @@ lint:
       version_command:
         parse_regex: nancy version ${semver}
         run: nancy --version
-      suggest_if: files_present
+      suggest_if: never
       environment:
         - name: PATH
           list: ["${runtime}", "${linter}", "${env.PATH}"]


### PR DESCRIPTION
Nancy can have some painfully flaky installs, even with our retry threshold. Let's not auto-recommend it anymore for go repos.