### PR TITLE
Use python3 stems rather than python

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -128,7 +128,9 @@ jobs:
         with:
           linter-version: Latest
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          append-args: ${{needs.detect_changes.outputs.linters-files }}
+          # TODO(Tyler): We need downloads to work with known_bad_versions
+          append-args:
+            ${{needs.detect_changes.outputs.linters-files }} -- --testPathIgnorePatterns=trufflehog
 
       - name: Tool Tests
         # Run tests using KnownGoodVersion with any modified tools and conditionally all tools. Don't run when cancelled.
@@ -148,9 +150,7 @@ jobs:
           needs.detect_changes.outputs.tools-files != ''
         uses: ./.github/actions/tool_tests
         with:
-          # TODO(Tyler): We need downloads to work with known_bad_versions
-          append-args:
-            ${{ needs.detect_changes.outputs.tools-files }} -- --testPathIgnorePatterns=trufflehog
+          append-args: ${{ needs.detect_changes.outputs.tools-files }}
 
   # Run repo healthcheck tests
   repo_tests:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,7 +148,9 @@ jobs:
           needs.detect_changes.outputs.tools-files != ''
         uses: ./.github/actions/tool_tests
         with:
-          append-args: ${{ needs.detect_changes.outputs.tools-files }}
+          # TODO(Tyler): We need downloads to work with known_bad_versions
+          append-args:
+            ${{ needs.detect_changes.outputs.tools-files }} -- --testPathIgnorePatterns=trufflehog
 
   # Run repo healthcheck tests
   repo_tests:

--- a/actions/hello-world/python/plugin.yaml
+++ b/actions/hello-world/python/plugin.yaml
@@ -6,6 +6,6 @@ actions:
       description: prints 'Hello World' to the terminal during pre-commit trigger
       runtime: python
       packages_file: requirements.txt
-      run: python ${cwd}/hello # {cwd} resolves to current directory containing this plugin.yaml file
+      run: python3 ${cwd}/hello # {cwd} resolves to current directory containing this plugin.yaml file
       triggers:
         - git_hooks: [pre-commit]

--- a/linters/codespell/plugin.yaml
+++ b/linters/codespell/plugin.yaml
@@ -19,6 +19,6 @@ lint:
           read_output_from: stdout
           parser:
             runtime: python
-            run: python ${plugin}/linters/codespell/codespell_to_sarif.py
+            run: python3 ${plugin}/linters/codespell/codespell_to_sarif.py
           batch: true
           cache_results: true

--- a/linters/nancy/plugin.yaml
+++ b/linters/nancy/plugin.yaml
@@ -30,7 +30,7 @@ lint:
           is_security: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/nancy/parse.py
+            run: python3 ${plugin}/linters/nancy/parse.py
       version_command:
         parse_regex: nancy version ${semver}
         run: nancy --version

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -31,7 +31,7 @@ lint:
           is_security: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/osv-scanner/osv_to_sarif.py
+            run: python3 ${plugin}/linters/osv-scanner/osv_to_sarif.py
       issue_url_format: https://osv.dev/{}
       suggest_if: files_present
       environment:

--- a/linters/pyright/plugin.yaml
+++ b/linters/pyright/plugin.yaml
@@ -14,7 +14,7 @@ lint:
           cache_results: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/pyright/pyright_to_sarif.py
+            run: python3 ${plugin}/linters/pyright/pyright_to_sarif.py
       runtime: python
       package: pyright
       direct_configs:

--- a/linters/pyright/pylint.test.ts
+++ b/linters/pyright/pylint.test.ts
@@ -1,3 +1,0 @@
-import { linterCheckTest } from "tests";
-
-linterCheckTest({ linterName: "pyright" });

--- a/linters/pyright/pyright.test.ts
+++ b/linters/pyright/pyright.test.ts
@@ -1,0 +1,3 @@
+import { linterCheckTest } from "tests";
+
+linterCheckTest({ linterName: "pyright" });

--- a/linters/remark-lint/plugin.yaml
+++ b/linters/remark-lint/plugin.yaml
@@ -37,7 +37,7 @@ lint:
           read_output_from: stderr
           parser:
             runtime: python
-            run: python ${cwd}/parse.py
+            run: python3 ${cwd}/parse.py
       symlinks:
         # symlink the tool node_modules into the sandbox. this enables
         # the hermetic tool to run correctly with plugins

--- a/linters/renovate/plugin.yaml
+++ b/linters/renovate/plugin.yaml
@@ -20,7 +20,7 @@ lint:
           read_output_from: stdout
           parser:
             runtime: python
-            run: python ${cwd}/parse.py
+            run: python3 ${cwd}/parse.py
       direct_configs:
         - renovate.json
         - renovate.json5

--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -11,7 +11,7 @@ lint:
           output: sarif
           parser:
             runtime: python
-            run: python ${cwd}/ruff_to_sarif.py 0
+            run: python3 ${cwd}/ruff_to_sarif.py 0
           batch: true
           success_codes: [0, 1]
         - name: lint
@@ -19,7 +19,7 @@ lint:
           output: sarif
           parser:
             runtime: python
-            run: python ${cwd}/ruff_to_sarif.py 1
+            run: python3 ${cwd}/ruff_to_sarif.py 1
           batch: true
           success_codes: [0, 1]
       runtime: python

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -17,7 +17,7 @@ lint:
           read_output_from: stdout
           parser:
             runtime: python
-            run: python ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
+            run: python3 ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
         - name: fix
           run: sqlfluff fix ${target} --disable-progress-bar --force
           output: rewrite

--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -29,7 +29,7 @@ lint:
           success_codes: [0, 3, 4, 5]
           parser: # necessary to convert file paths from a strange custom format to a standard format
             runtime: python
-            run: python ${plugin}/linters/terrascan/sarif_to_sarif.py
+            run: python3 ${plugin}/linters/terrascan/sarif_to_sarif.py
         - name: lint-docker
           output: sarif
           is_security: true
@@ -39,7 +39,7 @@ lint:
           success_codes: [0, 3, 4, 5]
           parser:
             runtime: python
-            run: python ${plugin}/linters/terrascan/sarif_to_sarif.py
+            run: python3 ${plugin}/linters/terrascan/sarif_to_sarif.py
       version_command:
         parse_regex: "version: v${semver}"
         run: terrascan version

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -36,7 +36,7 @@ lint:
           is_security: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/trivy/trivy_fs_to_sarif.py
+            run: python3 ${plugin}/linters/trivy/trivy_fs_to_sarif.py
         - name: config
           output: sarif
           run: trivy config ${target} --format json --cache-dir ${shared_cachedir}
@@ -47,7 +47,7 @@ lint:
           is_security: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/trivy/trivy_config_to_sarif.py
+            run: python3 ${plugin}/linters/trivy/trivy_config_to_sarif.py
       version_command:
         parse_regex: Version ${semver}
         run: trivy --version

--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -26,7 +26,7 @@ lint:
           cache_results: true
           parser:
             runtime: python
-            run: python ${plugin}/linters/trufflehog/trufflehog_to_sarif.py
+            run: python3 ${plugin}/linters/trufflehog/trufflehog_to_sarif.py
       suggest_if: files_present
       environment:
         - name: PATH

--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -15,6 +15,7 @@ lint:
       files: [ALL]
       download: trufflehog
       known_good_version: 3.31.3
+      known_bad_versions: [3.41.0]
       commands:
         - name: lint
           output: sarif

--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -50,5 +50,5 @@ runtimes:
           value: ${linter}
       known_good_version: 3.10.8
       version_commands:
-        - run: python --version
+        - run: python3 --version
           parse_regex: Python ${semver}


### PR DESCRIPTION
`python3` will resolve correctly on Linux and MacOS.

Also turns off `Latest` trufflehog tests on PRs temporarily. Created [ticket](https://linear.app/trunk/issue/TRUNK-7679/make-known-bad-versions-work-for-downloads)