### PR TITLE
Update bandit to read output from a tmp file

### DIFF
--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -18,7 +18,7 @@ lint:
           cache_results: true
           is_security: true
       issue_url_format: https://pypi.org/project/bandit/
-      known_good_version: 1.7.3
+      known_good_version: 1.7.5
       version_command:
         parse_regex: ${semver}
         run: bandit --version

--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -11,8 +11,9 @@ lint:
         - name: lint
           # Custom parser type defined in the trunk cli to handle bandit's JSON output.
           output: bandit
-          run: bandit --exit-zero --format json ${target}
+          run: bandit --exit-zero --format json --output ${tmpfile} ${target}
           success_codes: [0]
+          read_output_from: tmp_file
           batch: true
           cache_results: true
           is_security: true

--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -18,7 +18,7 @@ lint:
           cache_results: true
           is_security: true
       issue_url_format: https://pypi.org/project/bandit/
-      known_good_version: 1.7.5
+      known_good_version: 1.7.3
       version_command:
         parse_regex: ${semver}
         run: bandit --version


### PR DESCRIPTION
Occasionally bandit prints a mix of json and progress update text to stdout, which screws up our ability to parse the json, for example:
```
Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
{
  "errors": [],
  "generated_at": "2023-06-23T12:48:22Z",
  "metrics": {
    "_totals": {
...
```

Using `--output` gets around this problem