### PR TITLE
Fix ktlint with new jdk

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -12,10 +12,12 @@ framework: &framework
 
 all-linters:
   - *framework
+  - runtimes/**
   - tests/driver/!(tool_driver.ts)
 
 all-tools:
   - *framework
+  - runtimes/**
   - tests/driver/!(lint_driver.ts)
 
 # Run tests against specific linters if existing linters have been modified or updated.

--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -25,7 +25,7 @@ lint:
         - .editorconfig
       environment:
         - name: PATH
-          list: ["${linter}", "${env.PATH}"]
+          list: ["${linter}"]
         - name: LANG
           # C.UTF-8 is preferred for machine output, but mac barfs on that
           value: en_US.UTF-8

--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -25,7 +25,7 @@ lint:
         - .editorconfig
       environment:
         - name: PATH
-          list: ["${linter}"]
+          list: ["${linter}", "${env.PATH}"]
         - name: LANG
           # C.UTF-8 is preferred for machine output, but mac barfs on that
           value: en_US.UTF-8

--- a/runtimes/java/plugin.yaml
+++ b/runtimes/java/plugin.yaml
@@ -16,6 +16,21 @@ downloads:
         url: https://cdn.azul.com/zulu/bin/zulu17.30.15-ca-jdk17.0.1-${os}_${cpu}.tar.gz
         strip_components: 1
 
+  - name: jdk-13
+    downloads:
+      - os:
+          linux: linux
+          macos: macosx
+        cpu:
+          x86_64: x64
+          arm_64: aarch64
+        url: https://cdn.azul.com/zulu/bin/zulu13.48.19-ca-jdk13.0.11-${os}_${cpu}.tar.gz
+        strip_components: 1
+      - os: windows
+        cpu: x86_64
+        url: https://cdn.azul.com/zulu/bin/zulu13.48.19-ca-jdk13.0.11-win_x64.zip
+        strip_components: 1
+
   - name: jdk-11
     downloads:
       - os:
@@ -38,7 +53,7 @@ downloads:
 runtimes:
   definitions:
     - type: java
-      download: jdk-17
+      download: jdk-13
       runtime_environment:
         - name: HOME
           value: ${env.HOME:-}
@@ -55,7 +70,7 @@ runtimes:
       linter_environment:
         - name: PATH
           list: ["${linter}/bin"]
-      known_good_version: 17.0.1
+      known_good_version: 13.0.11
       version_commands:
         - run: java --version
           parse_regex: ${semver}


### PR DESCRIPTION
Output complained that `sed` was not available in jdk-16 and jdk-17, so used jdk-13, which has all the [downloads](https://cdn.azul.com/zulu/bin/) we need.