### PR TITLE
Fix osv-scanner parser

### DIFF
--- a/linters/google-java-format/plugin.yaml
+++ b/linters/google-java-format/plugin.yaml
@@ -26,3 +26,6 @@ lint:
       runtime: java
       suggest_if: never
       known_good_version: 1.15.0
+      version_command:
+        parse_regex: "google-java-format: Version ${semver}"
+        run: java -jar ${linter}/google-java-format.jar.exe --version

--- a/linters/osv-scanner/osv_to_sarif.py
+++ b/linters/osv-scanner/osv_to_sarif.py
@@ -78,9 +78,12 @@ def main(argv):
                 # <=1.34.0: summaries could have empty text
                 # >=1.35.0: summaries with empty text were removed
                 if "summary" not in vuln or len(vuln["summary"]) == 0:
-                    description = vuln["details"]
+                    message = vuln["details"]
                 else:
-                    description = f'Vulnerability in {pkg["name"]} {pkg["version"]}: {vuln["summary"]}'
+                    message = vuln["summary"]
+                description = (
+                    f'Vulnerability in {pkg["name"]} {pkg["version"]}: {message}'
+                )
 
                 lines = [
                     zero_indexed + 1

--- a/linters/osv-scanner/osv_to_sarif.py
+++ b/linters/osv-scanner/osv_to_sarif.py
@@ -75,12 +75,12 @@ def main(argv):
             pkg = pkg_vulns["package"]
             for vuln in pkg_vulns["vulnerabilities"]:
                 vuln_id = vuln["id"]
-                description = vuln["summary"]
-                if len(description) == 0:
+                # <=1.34.0: summaries could have empty text
+                # >=1.35.0: summaries with empty text were removed
+                if "summary" not in vuln or len(vuln["summary"]) == 0:
                     description = vuln["details"]
-                description = (
-                    f'Vulnerability in {pkg["name"]} {pkg["version"]}: {description}'
-                )
+                else:
+                    description = f'Vulnerability in {pkg["name"]} {pkg["version"]}: {vuln["summary"]}'
 
                 lines = [
                     zero_indexed + 1

--- a/linters/osv-scanner/osv_to_sarif.py
+++ b/linters/osv-scanner/osv_to_sarif.py
@@ -77,10 +77,10 @@ def main(argv):
                 vuln_id = vuln["id"]
                 # <=1.34.0: summaries could have empty text
                 # >=1.35.0: summaries with empty text were removed
-                if "summary" not in vuln or len(vuln["summary"]) == 0:
-                    message = vuln["details"]
-                else:
+                if "summary" in vuln and len(vuln["summary"]) > 0:
                     message = vuln["summary"]
+                else:
+                    message = vuln["details"]
                 description = (
                     f'Vulnerability in {pkg["name"]} {pkg["version"]}: {message}'
                 )


### PR DESCRIPTION
Osv-scanner 1.3.5 released, which removes empty string `"summary"` fields from the JSON. Modifies the parser to handle this. Fixes [nightly run](https://github.com/trunk-io/plugins/actions/runs/5398728395) (CLI run requires some other fixes). 

Also adds a `version_command` for google-java-format so hopefully the downloads are less flaky.