### PR TITLE
Add prisma as format

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -377,6 +377,10 @@ lint:
         - .prettierrc
         - .stylelintrc
 
+    - name: prisma
+      extensions:
+        - prisma
+
     - name: proto
       extensions:
         - proto

--- a/linters/prisma/plugin.yaml
+++ b/linters/prisma/plugin.yaml
@@ -1,0 +1,16 @@
+version: 0.1
+lint:
+  definitions:
+    - name: prisma
+      tools: [prisma]
+      files: [prisma]
+      known_good_version: 4.16.1
+      suggest_if: never
+      commands:
+        - name: prisma format
+          output: rewrite
+          success_codes: [0]
+          in_place: true
+          batch: true
+          formatter: true
+          run: prisma format --schema=${target}

--- a/linters/prisma/prisma.test.ts
+++ b/linters/prisma/prisma.test.ts
@@ -1,0 +1,3 @@
+import { linterFmtTest } from "tests";
+
+linterFmtTest({ linterName: "prisma" });

--- a/linters/prisma/test_data/prisma_v4.16.1_test0.fmt.shot
+++ b/linters/prisma/test_data/prisma_v4.16.1_test0.fmt.shot
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter prisma test test0 1`] = `
+"datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  email     String   @unique
+  name      String?
+  role      Role     @default(USER)
+  posts     Post[]
+}
+
+model Post {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean  @default(false)
+  title     String   @db.VarChar(255)
+  author    User?    @relation(fields: [authorId], references: [id])
+  authorId  Int?
+}
+
+enum Role {
+  USER
+  ADMIN
+}
+"
+`;

--- a/linters/prisma/test_data/test0.in.prisma
+++ b/linters/prisma/test_data/test0.in.prisma
@@ -1,0 +1,32 @@
+datasource db {
+  provider = "postgresql"
+  url  = env("DATABASE_URL")
+}
+
+generator client {
+  provider   = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  email     String   @unique
+  name       String?
+  role      Role     @default(USER)
+  posts     Post[]
+}
+
+model Post {
+  id          Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean  @default(false)
+  title       String   @db.VarChar(255)
+  author    User?       @relation(fields: [authorId], references: [id])
+  authorId  Int?
+}
+
+enum Role {
+  USER
+  ADMIN
+}

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ trunk check enable {linter}
 | package.json    | [sort-package-json]                                                                                                 |
 | Perl            | [perlcritic], [perltidy]                                                                                            |
 | PNG             | [oxipng]                                                                                                            |
+| Prisma          | [prisma]                                                                                                            |
 | Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                                                    |
 | Python          | [autopep8], [bandit], [black], [flake8], [isort], [mypy], [pylint], [pyright] [semgrep], [yapf], [ruff], [sourcery] |
 | Renovate        | [renovate]                                                                                                          |
@@ -127,6 +128,7 @@ trunk check enable {linter}
 [perltidy]: https://metacpan.org/dist/Perl-Tidy/view/bin/perltidy
 [pragma-once]: linters/pragma-once/readme.md
 [prettier]: https://github.com/prettier/prettier#readme
+[prisma]: https://github.com/prisma/prisma#readme
 [pylint]: https://github.com/PyCQA/pylint#readme
 [pyright]: https://github.com/microsoft/pyright
 [remark-lint]: https://github.com/remarkjs/remark-lint#readme


### PR DESCRIPTION
Enable prisma format

Linter depends on a tool, and requires latest beta to work.