### PR TITLE
Rollback cli to 1.11.2-beta.17

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,7 +131,7 @@ jobs:
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           # TODO(Tyler): We need downloads to work with known_bad_versions
           append-args:
-            linters/stylua # TODO: TYLER REVERT
+            linters/s # TODO: TYLER REVERT
             # ${{needs.detect_changes.outputs.linters-files }}
 
       - name: Tool Tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -116,9 +116,8 @@ jobs:
           linter-version: KnownGoodVersion
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           append-args:
-            linters/stylua # TODO: TYLER REVERT
-            # ${{ needs.detect_changes.outputs.all-linters }} ${{
-            # needs.detect_changes.outputs.linters-files }}
+            ${{ needs.detect_changes.outputs.all-linters }} ${{
+            needs.detect_changes.outputs.linters-files }}
 
       - name: Linter Tests Latest
         # Run tests on Latest with any modified linters (see filters.yaml). Don't run when cancelled.
@@ -130,9 +129,7 @@ jobs:
           linter-version: Latest
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           # TODO(Tyler): We need downloads to work with known_bad_versions
-          append-args:
-            linters/s # TODO: TYLER REVERT
-            # ${{needs.detect_changes.outputs.linters-files }}
+          append-args: ${{needs.detect_changes.outputs.linters-files }}
 
       - name: Tool Tests
         # Run tests using KnownGoodVersion with any modified tools and conditionally all tools. Don't run when cancelled.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -116,8 +116,9 @@ jobs:
           linter-version: KnownGoodVersion
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           append-args:
-            ${{ needs.detect_changes.outputs.all-linters }} ${{
-            needs.detect_changes.outputs.linters-files }}
+            linters/stylua # TODO: TYLER REVERT
+            # ${{ needs.detect_changes.outputs.all-linters }} ${{
+            # needs.detect_changes.outputs.linters-files }}
 
       - name: Linter Tests Latest
         # Run tests on Latest with any modified linters (see filters.yaml). Don't run when cancelled.
@@ -130,7 +131,8 @@ jobs:
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           # TODO(Tyler): We need downloads to work with known_bad_versions
           append-args:
-            ${{needs.detect_changes.outputs.linters-files }} -- --testPathIgnorePatterns=trufflehog
+            linters/stylua # TODO: TYLER REVERT
+            # ${{needs.detect_changes.outputs.linters-files }}
 
       - name: Tool Tests
         # Run tests using KnownGoodVersion with any modified tools and conditionally all tools. Don't run when cancelled.

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.11.2-beta.18
+  version: 1.11.2-beta.17
 
 api:
   address: api.trunk-staging.io:8443

--- a/linters/stylua/stylua.test.ts
+++ b/linters/stylua/stylua.test.ts
@@ -1,3 +1,8 @@
 import { linterFmtTest } from "tests";
 
-linterFmtTest({ linterName: "stylua" });
+linterFmtTest({
+  linterName: "stylua",
+  postCheck: (driver) => {
+    console.log(driver.readFile(".trunk/trunk.yaml"));
+  },
+});

--- a/linters/stylua/stylua.test.ts
+++ b/linters/stylua/stylua.test.ts
@@ -2,7 +2,4 @@ import { linterFmtTest } from "tests";
 
 linterFmtTest({
   linterName: "stylua",
-  postCheck: (driver) => {
-    console.log(driver.readFile(".trunk/trunk.yaml"));
-  },
 });

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.11.2-beta.18"
+required_trunk_version: ">=1.11.2-beta.17"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -604,6 +604,11 @@ export const linterFmtTest = ({
           it(prefix, async () => {
             const debug = baseDebug.extend(driver.debugNamespace);
             const testRunResult = await driver.runFmtUnit(inputPath, linterName);
+
+            if (linterName === "stylua") {
+              console.log(driver.readFile(".trunk/trunk.yaml")); // TODO: REMOVE
+            }
+
             expect(testRunResult).toMatchObject({
               success: true,
               landingState: {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -605,8 +605,9 @@ export const linterFmtTest = ({
             const debug = baseDebug.extend(driver.debugNamespace);
             const testRunResult = await driver.runFmtUnit(inputPath, linterName);
 
+            // TODO(Tyler): Investigating some flakiness with stylua. Leave this in until resolved.
             if (linterName === "stylua") {
-              console.log(driver.readFile(".trunk/trunk.yaml")); // TODO: REMOVE
+              console.log(driver.readFile(".trunk/trunk.yaml"));
             }
 
             expect(testRunResult).toMatchObject({

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -23,7 +23,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.11.2-beta.18",
+    trunkVersion: "1.11.2-beta.17",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
Rollback the CLI in order for give service side changes more time to interact with LUV. Should fix [failed upload to prod](https://github.com/trunk-io/plugins/actions/runs/5420698740/jobs/9867552719).