### PR TITLE
tflint v0.47.0

### DIFF
--- a/linters/tflint/plugin.yaml
+++ b/linters/tflint/plugin.yaml
@@ -28,6 +28,15 @@ lint:
           read_output_from: stdout
           run_linter_from: root_directory
           run_from_root_target: .tflint.hcl
+          version: ">=0.47.0"
+        - name: lint
+          output: sarif
+          prepare_run: tflint --init
+          run: tflint --format=sarif ${target} --force
+          success_codes: [0, 1]
+          read_output_from: stdout
+          run_linter_from: root_file
+          run_from_root_target: .tflint.hcl
       suggest_if: files_present
       download: tflint
       direct_configs: [.tflint.hcl]
@@ -39,7 +48,7 @@ lint:
         - name: GITHUB_TOKEN
           value: ${env.GITHUB_TOKEN}
           optional: true
-      known_good_version: 0.47.0
+      known_good_version: 0.35.0
       version_command:
         parse_regex: ${semver}
         run: tflint --version

--- a/linters/tflint/plugin.yaml
+++ b/linters/tflint/plugin.yaml
@@ -23,10 +23,10 @@ lint:
         - name: lint
           output: sarif
           prepare_run: tflint --init
-          run: tflint --format=sarif ${target} --force
-          success_codes: [0, 1]
+          run: tflint --format=sarif ${target} --recursive
+          success_codes: [0, 1, 2]
           read_output_from: stdout
-          run_linter_from: root_file
+          run_linter_from: root_directory
           run_from_root_target: .tflint.hcl
       suggest_if: files_present
       download: tflint
@@ -39,7 +39,7 @@ lint:
         - name: GITHUB_TOKEN
           value: ${env.GITHUB_TOKEN}
           optional: true
-      known_good_version: 0.35.0
+      known_good_version: 0.47.0
       version_command:
         parse_regex: ${semver}
         run: tflint --version


### PR DESCRIPTION
tflint plugin didn't work with tflint 0.47.0. I think it is because this version shows:

```
Command line arguments support was dropped in v0.47. Use --chdir or --filter instead.
```

My projects work well with the configuration from this PR.