### PR TITLE
Forward ssh auth sock in LFS git hooks

### DIFF
--- a/actions/git/plugin.yaml
+++ b/actions/git/plugin.yaml
@@ -7,4 +7,7 @@ actions:
       run: git lfs "${hook}" ${@}
       triggers:
         - git_hooks: [post-checkout, post-commit, post-merge, pre-push]
+      environment:
+        - name: SSH_AUTH_SOCK
+          value: ${env.SSH_AUTH_SOCK}
       notify_on_error: false

--- a/actions/git/plugin.yaml
+++ b/actions/git/plugin.yaml
@@ -10,4 +10,9 @@ actions:
       environment:
         - name: SSH_AUTH_SOCK
           value: ${env.SSH_AUTH_SOCK}
+          optional: true
+        - name: SSH_AGENT_PID
+          value: ${env.SSH_AGENT_PID}
+          optional: true
+
       notify_on_error: false


### PR DESCRIPTION
Otherwise users will have to type their ssh keyfile passwords out even after running `ssh-add`