### PR TITLE
Wrong Rome Filename

### DIFF
--- a/linters/rome/plugin.yaml
+++ b/linters/rome/plugin.yaml
@@ -29,7 +29,7 @@ lint:
       package: rome
       suggest_if: config_present
       direct_configs:
-        - .rome.json
+        - rome.json
       affects_cache:
         - package.json
         - .editorconfig # Undocumented config file


### PR DESCRIPTION
Hi folks! Currently the name of filename config is wrong. The correct name is `rome.json`. Look https://github.com/rome/tools/blob/main/rome.json.