### PR TITLE
Remaining Windows plugins fixes

### DIFF
--- a/actions/trunk/plugin.yaml
+++ b/actions/trunk/plugin.yaml
@@ -45,7 +45,7 @@ actions:
     - id: trunk-check-pre-push-always
       display_name: Trunk Check Pre-Push Hook (Always)
       description: Always run 'trunk check' whenever you run 'git push'
-      run: ${cwd}/trunk-check-pre-push.sh -n --commit-ref-from-pre-push '${hook_stdin_path}'
+      run: bash "${cwd}/trunk-check-pre-push.sh" -n --commit-ref-from-pre-push '${hook_stdin_path}'
       interactive: optional
       triggers:
         - git_hooks: [pre-push]

--- a/linters/black/black.test.ts
+++ b/linters/black/black.test.ts
@@ -2,4 +2,3 @@ import { linterFmtTest } from "tests";
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving failure modes and other autofixes.
 linterFmtTest({ linterName: "black", namedTestPrefixes: ["basic", "basic_nb"] });
-linterFmtTest({ linterName: "black-py", namedTestPrefixes: ["basic"] });

--- a/linters/black/plugin.yaml
+++ b/linters/black/plugin.yaml
@@ -46,6 +46,7 @@ lint:
       affects_cache: [pyproject.toml]
       formatter: true
       known_good_version: 22.3.0
+      deprecated: "'black-py' is now handled by 'black'. Please delete 'black-py' from your config"
       version_command:
         parse_regex: black, version (.*)
         run: black --version

--- a/linters/buildifier/plugin.yaml
+++ b/linters/buildifier/plugin.yaml
@@ -26,6 +26,10 @@ downloads:
         version: ">=4.0.0"
       - os: windows
         cpu: x86_64
+        url: https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildifier-windows-amd64.exe
+        version: ">=6.1.2"
+      - os: windows
+        cpu: x86_64
         url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-windows-amd64.exe
         version: ">=4.0.0"
 tools:

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -2,6 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: checkov
+      supported_platforms: [linux, macos]
       files: [terraform, cloudformation, docker, yaml, json]
       runtime: python
       package: checkov

--- a/linters/clang-format/plugin.yaml
+++ b/linters/clang-format/plugin.yaml
@@ -18,6 +18,7 @@ lint:
         # TODO(chris): Windows download
   definitions:
     - name: clang-format
+      supported_platforms: [linux, macos]
       files: [c/c++, proto]
       commands:
         - name: format

--- a/linters/clang-tidy/plugin.yaml
+++ b/linters/clang-tidy/plugin.yaml
@@ -18,6 +18,7 @@ lint:
         # TODO(chris): Windows download
   definitions:
     - name: clang-tidy
+      supported_platforms: [linux, macos]
       files: [c/c++-source]
       commands:
         - name: lint

--- a/linters/detekt/plugin.yaml
+++ b/linters/detekt/plugin.yaml
@@ -13,6 +13,16 @@ lint:
       download: detekt
       commands:
         - name: lint
+          platforms: [windows]
+          output: sarif
+          run:
+            detekt-cli --build-upon-default-config --config .detekt.yaml --input ${target,} --report
+            sarif:${tmpfile}
+          success_codes: [0, 1, 2]
+          read_output_from: tmp_file
+          batch: true
+          cache_results: true
+        - name: lint
           output: sarif
           run:
             detekt-cli --build-upon-default-config --config .detekt.yaml --input ${target,} --report
@@ -36,6 +46,14 @@ lint:
       files: [kotlin]
       download: detekt
       commands:
+        - name: lint
+          platforms: [windows]
+          output: sarif
+          run:
+            detekt-cli --config .detekt.yaml --input ${target} --report sarif:${tmpfile}
+            --auto-correct
+          success_codes: [0, 1, 2]
+          read_output_from: tmp_file
         - name: lint
           output: sarif
           run:

--- a/linters/iwyu/plugin.yaml
+++ b/linters/iwyu/plugin.yaml
@@ -14,6 +14,7 @@ lint:
         # TODO(chris): Windows download
   definitions:
     - name: include-what-you-use
+      supported_platforms: [linux, macos]
       files: [c/c++-source]
       download: include-what-you-use
       commands:

--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -9,6 +9,7 @@ lint:
         - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
   definitions:
     - name: ktlint
+      supported_platforms: [linux, macos]
       files: [kotlin]
       download: ktlint
       runtime: java

--- a/linters/mypy/plugin.yaml
+++ b/linters/mypy/plugin.yaml
@@ -2,6 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: mypy
+      supported_platforms: [linux, macos]
       files: [python, python-interface]
       commands:
         - name: lint

--- a/linters/nixpkgs-fmt/plugin.yaml
+++ b/linters/nixpkgs-fmt/plugin.yaml
@@ -2,6 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: nixpkgs-fmt
+      supported_platforms: [linux, macos]
       package: nixpkgs-fmt
       runtime: rust
       files: [nix]

--- a/linters/osv-scanner/osv_to_sarif.py
+++ b/linters/osv-scanner/osv_to_sarif.py
@@ -58,7 +58,12 @@ def to_result_sarif(
 
 
 def main(argv):
-    osv_json = json.load(sys.stdin)
+    # On Windows, Unicode characters in the osv-scanner output cause json parsing errors. Filter them out since we don't care about their fields.
+    if sys.platform == "win32":
+        filtered_stdin = "".join(i for i in sys.stdin.read() if ord(i) < 256)
+        osv_json = json.loads(filtered_stdin)
+    else:
+        osv_json = json.load(sys.stdin)
     results = osv_json.get("results", [])
     if results is None:
         results = []

--- a/linters/pyright/plugin.yaml
+++ b/linters/pyright/plugin.yaml
@@ -15,7 +15,7 @@ lint:
           parser:
             runtime: python
             run: python3 ${plugin}/linters/pyright/pyright_to_sarif.py
-      runtime: python
+      runtime: node
       package: pyright
       direct_configs:
         - pyrightconfig.json

--- a/linters/pyright/pyright_to_sarif.py
+++ b/linters/pyright/pyright_to_sarif.py
@@ -25,7 +25,7 @@ for result in json.load(sys.stdin)["generalDiagnostics"]:
             }
         ],
         "message": {
-            "text": result["message"],
+            "text": result["message"].replace("Â", ""),
         },
     }
     if "rule" in result:

--- a/linters/remark-lint/plugin.yaml
+++ b/linters/remark-lint/plugin.yaml
@@ -2,6 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: remark-lint
+      supported_platforms: [linux, macos]
       files: [markdown]
       package: remark-cli
       extra_packages:

--- a/linters/semgrep/plugin.yaml
+++ b/linters/semgrep/plugin.yaml
@@ -2,6 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: semgrep
+      supported_platforms: [linux, macos]
       files: [ALL]
       runtime: python
       package: semgrep

--- a/linters/sort-package-json/plugin.yaml
+++ b/linters/sort-package-json/plugin.yaml
@@ -6,6 +6,7 @@ lint:
 
   definitions:
     - name: sort-package-json
+      supported_platforms: [linux, macos]
       files: [package-json]
       commands:
         - name: format

--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -6,6 +6,7 @@ lint:
         - os:
             linux: linux
             macos: darwin
+            windows: windows
           cpu:
             x86_64: amd64
             arm_64: arm64

--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -40,6 +40,9 @@ runtimes:
       runtime_environment:
         - name: HOME
           value: ${env.HOME:-}
+        - name: SYSTEMROOT
+          value: ${env.SYSTEMROOT}
+          optional: true
         - name: PATH
           list:
             - "${runtime}/bin"


### PR DESCRIPTION
Abridged version of #330

Applies supported_platforms for the following:
- The following linters are disabled on Windows with no immediate plans to support: brakeman, haml-lint, nixpkgs-fmt, rubocop, rufo, standardrb, taplo, ansible-lint, scalafmt, semgrep, shellcheck, stringslint, swiftformat, swiftlint
- The following linters are disabled on Windows with some intermediate plans to support: checkov, clang-format, clang-tidy, iwyu, ktlint, mypy, remark-lint, sort-package-json

Also fixes python needing `SYSTEMROOT` set when invoked from powershell.