### PR TITLE
A few remaining tools linter conversions

### DIFF
--- a/linters/golines/plugin.yaml
+++ b/linters/golines/plugin.yaml
@@ -1,10 +1,15 @@
 version: 0.1
+tools:
+  definitions:
+    - name: golines
+      runtime: go
+      package: github.com/segmentio/golines
+      shims: [golines]
 lint:
   definitions:
     - name: golines
       files: [go]
-      runtime: go
-      package: github.com/segmentio/golines
+      tools: [golines]
       commands:
         - name: format
           output: rewrite

--- a/linters/google-java-format/plugin.yaml
+++ b/linters/google-java-format/plugin.yaml
@@ -1,10 +1,10 @@
 version: 0.1
+downloads:
+  - name: google-java-format.jar
+    executable: true
+    downloads:
+      - url: https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar
 lint:
-  downloads:
-    - name: google-java-format.jar
-      executable: true
-      downloads:
-        - url: https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar
   definitions:
     - name: google-java-format
       files: [java]

--- a/linters/iwyu/plugin.yaml
+++ b/linters/iwyu/plugin.yaml
@@ -16,6 +16,9 @@ tools:
       download: include-what-you-use
       shims: [include-what-you-use]
       known_good_version: 0.19
+      environment:
+        - name: PATH
+          list: ["${tool}/bin"]
 lint:
   definitions:
     - name: include-what-you-use
@@ -35,9 +38,6 @@ lint:
       include_scanner_type: compile_command
       query_compile_commands: true
       suggest_if: never
-      environment:
-        - name: PATH
-          list: ["${linter}/bin"]
       known_good_version: 0.19
       version_command:
         parse_regex: include-what-you-use ([^ ]+).*

--- a/linters/iwyu/plugin.yaml
+++ b/linters/iwyu/plugin.yaml
@@ -1,22 +1,26 @@
 version: 0.1
-lint:
-  downloads:
-    - name: include-what-you-use
-      version: 0.19
-      downloads:
-        - os:
-            linux: linux
-            macos: macos
-          cpu:
-            x86_64: x86_64
-            arm_64: arm64
-          url: https://trunk.io/releases/include-what-you-use-${version}-${os}-${cpu}.tar.gz
-        # TODO(chris): Windows download
+downloads:
+  - name: include-what-you-use
+    downloads:
+      - os:
+          linux: linux
+          macos: macos
+        cpu:
+          x86_64: x86_64
+          arm_64: arm64
+        url: https://trunk.io/releases/include-what-you-use-${version}-${os}-${cpu}.tar.gz
+      # TODO(chris): Windows download
+tools:
   definitions:
     - name: include-what-you-use
-      supported_platforms: [linux, macos]
-      files: [c/c++-source]
       download: include-what-you-use
+      shims: [include-what-you-use]
+      known_good_version: 0.19
+lint:
+  definitions:
+    - name: include-what-you-use
+      files: [c/c++-source]
+      tools: [include-what-you-use]
       commands:
         - name: lint
           run_linter_from: compile_command

--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -1,21 +1,17 @@
 version: 0.1
-downloads:
-  - name: ktlint
-    executable: true
-    downloads:
-      # Cross-platform download
-      - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
-tools:
-  definitions:
-    - name: ktlint
-      download: ktlint
-      shims: [ktlint]
-      known_good_version: 0.43.2
 lint:
+  downloads:
+    - name: ktlint
+      version: 0.43.2
+      executable: true
+      downloads:
+        # Cross-platform download
+        - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
   definitions:
     - name: ktlint
+      supported_platforms: [linux, macos]
       files: [kotlin]
-      tools: [ktlint]
+      download: ktlint
       runtime: java
       commands:
         - name: format

--- a/linters/ktlint/plugin.yaml
+++ b/linters/ktlint/plugin.yaml
@@ -1,17 +1,21 @@
 version: 0.1
-lint:
-  downloads:
-    - name: ktlint
-      version: 0.43.2
-      executable: true
-      downloads:
-        # Cross-platform download
-        - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
+downloads:
+  - name: ktlint
+    executable: true
+    downloads:
+      # Cross-platform download
+      - url: https://github.com/pinterest/ktlint/releases/download/${version}/ktlint
+tools:
   definitions:
     - name: ktlint
-      supported_platforms: [linux, macos]
-      files: [kotlin]
       download: ktlint
+      shims: [ktlint]
+      known_good_version: 0.43.2
+lint:
+  definitions:
+    - name: ktlint
+      files: [kotlin]
+      tools: [ktlint]
       runtime: java
       commands:
         - name: format

--- a/linters/stylua/plugin.yaml
+++ b/linters/stylua/plugin.yaml
@@ -1,21 +1,27 @@
 version: 0.1
-lint:
-  downloads:
+downloads:
+  - name: stylua
+    version: 0.17.0
+    downloads:
+      - os:
+          linux: linux
+          macos: macos
+          windows: windows
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        url: https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${cpu}.zip
+tools:
+  definitions:
     - name: stylua
-      version: 0.17.0
-      downloads:
-        - os:
-            linux: linux
-            macos: macos
-            windows: windows
-          cpu:
-            x86_64: x86_64
-            arm_64: aarch64
-          url: https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${cpu}.zip
+      download: stylua
+      shims: [stylua]
+      known_good_version: 0.17.0
+lint:
   definitions:
     - name: stylua
       files: [lua]
-      download: stylua
+      tools: [stylua]
       commands:
         - name: format
           output: rewrite
@@ -25,12 +31,10 @@ lint:
           success_codes: [0, 1]
       run_linter_from: workspace
       suggest_if: config_present
+      known_good_version: 0.17.0
       direct_configs:
         - stylua.toml
         - .stylua.toml
-      environment:
-        - name: PATH
-          list: ["${linter}"]
       version_command:
         parse_regex: ${semver}
         run: stylua --version


### PR DESCRIPTION
Remaining:
- buf (due to naming stuff)
- google-java-format (weirdness - could be done with tools if we expose runtimes)
- gofmt - because we just call go (we can expose runtimes)
- remark-lint - weirdness with symlinks
- ktlint - race condition between tool install and health check