### PR TITLE
Revert tool port

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -5,6 +5,4 @@
 plugins
 user_trunk.yaml
 user.yaml
-# TODO(lauri): Remove shims after a release or two
-shims
 tools

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -5,4 +5,6 @@
 plugins
 user_trunk.yaml
 user.yaml
+# TODO(lauri): Remove shims after a release or two
+shims
 tools

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -67,6 +67,3 @@ actions:
     - linter-test-helper
     - remove-release-snapshots
     - repo-tests
-tools:
-  enabled:
-    - ansible-lint@6.13.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,7 +15,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.2
+      ref: v0.0.4
 
 lint:
   # enabled list inherited from plugin 'configs'
@@ -23,8 +23,8 @@ lint:
     - yamllint@1.26.3
     - checkov@2.3.296
     - nancy@1.0.42
-    - trivy@0.42.1
-    - osv-scanner@1.3.4
+    - trivy@0.43.1
+    - osv-scanner@1.3.5
   disabled:
     # pylint diagnostics are a bit too strict for our parsers
     - pylint

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.12.1
+  version: 1.12.0
 
 api:
   address: api.trunk-staging.io:8443
@@ -15,15 +15,15 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.4
+      ref: v0.0.2
 
 lint:
   # enabled list inherited from plugin 'configs'
   enabled:
     - checkov@2.3.296
     - nancy@1.0.42
-    - trivy@0.43.1
-    - osv-scanner@1.3.5
+    - trivy@0.42.1
+    - osv-scanner@1.3.4
   disabled:
     # pylint diagnostics are a bit too strict for our parsers
     - pylint

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.12.0
+  version: 1.12.3
 
 api:
   address: api.trunk-staging.io:8443
@@ -20,6 +20,7 @@ plugins:
 lint:
   # enabled list inherited from plugin 'configs'
   enabled:
+    - yamllint@1.26.3
     - checkov@2.3.296
     - nancy@1.0.42
     - trivy@0.42.1

--- a/linters/actionlint/plugin.yaml
+++ b/linters/actionlint/plugin.yaml
@@ -1,34 +1,28 @@
 version: 0.1
-downloads:
-  - name: actionlint
-    version: 1.6.9
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_darwin_amd64.tar.gz
-        version: <1.4.1
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_${os}_${cpu}.tar.gz
-      # No x86_64 download available
-      - os: windows
-        url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_windows_386.zip
-tools:
-  definitions:
-    - name: actionlint
-      download: actionlint
-      shims: [actionlint]
-      known_good_version: 1.6.9
 lint:
+  downloads:
+    - name: actionlint
+      version: 1.6.9
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_darwin_amd64.tar.gz
+          version: <1.4.1
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_${os}_${cpu}.tar.gz
+        # No x86_64 download available
+        - os: windows
+          url: https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_windows_386.zip
   definitions:
     - name: actionlint
       files: [github-workflow]
       # Custom parser/trigger type defined in the trunk cli.
-      tools: [actionlint]
+      download: actionlint
       commands:
         - name: lint
           output: actionlint

--- a/linters/ansible-lint/plugin.yaml
+++ b/linters/ansible-lint/plugin.yaml
@@ -1,12 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: ansible-lint
-      runtime: python
-      package: ansible-lint
-      extra_packages: [ansible]
-      shims: [ansible-lint, ansible]
-      known_good_version: 6.13.0
 lint:
   definitions:
     - name: ansible-lint
@@ -30,7 +22,9 @@ lint:
           run: ansible-lint --parseable-severity
           success_codes: [0, 2]
           run_linter_from: directory
-      tools: [ansible-lint]
+      runtime: python
+      package: ansible-lint
+      extra_packages: [ansible]
       suggest_if: never
       direct_configs: [.ansible-lint]
       environment:

--- a/linters/autopep8/plugin.yaml
+++ b/linters/autopep8/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: autopep8
-      runtime: python
-      package: autopep8
-      shims: [autopep8]
 lint:
   definitions:
     - name: autopep8
@@ -18,7 +12,8 @@ lint:
           in_place: true
           cache_results: true
           formatter: true
-      tools: [autopep8]
+      runtime: python
+      package: autopep8
       suggest_if: config_present
       direct_configs: [.pep8]
       affects_cache:

--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: bandit
-      runtime: python
-      package: bandit
-      shims: [bandit]
 lint:
   definitions:
     - name: bandit
       files: [python]
-      tools: [bandit]
+      runtime: python
+      package: bandit
       suggest_if: files_present
       direct_configs: [.bandit]
       commands:

--- a/linters/black/plugin.yaml
+++ b/linters/black/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: black
-      runtime: python
-      package: black[python2,jupyter]
-      shims: [black]
 lint:
   definitions:
     - name: black
@@ -19,7 +13,8 @@ lint:
           allow_empty_files: false
           cache_results: true
           formatter: true
-      tools: [black]
+      runtime: python
+      package: black[python2,jupyter]
       suggest_if: files_present
       affects_cache: [pyproject.toml]
       known_good_version: 22.3.0

--- a/linters/brakeman/plugin.yaml
+++ b/linters/brakeman/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: brakeman
-      runtime: ruby
-      package: brakeman
-      shims: [brakeman]
 lint:
   definitions:
     - name: brakeman
@@ -28,7 +22,8 @@ lint:
           run_from_root_target: apps
       direct_configs: [brakeman.ignore]
       suggest_if: files_present
-      tools: [brakeman]
+      runtime: ruby
+      package: brakeman
       known_good_version: 5.4.0
       version_command:
         parse_regex: ${semver}

--- a/linters/buildifier/plugin.yaml
+++ b/linters/buildifier/plugin.yaml
@@ -1,48 +1,42 @@
 version: 0.1
-downloads:
-  - name: buildifier
-    version: 6.1.0
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildifier-${os}-${cpu}
-        version: ">=6.1.2"
-      # macos arm64 was introduced after this version.
-      - os: macos
-        version: <4.2.0
-        url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-darwin-amd64
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-${os}-${cpu}
-        version: ">=4.0.0"
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildifier-windows-amd64.exe
-        version: ">=6.1.2"
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-windows-amd64.exe
-        version: ">=4.0.0"
-tools:
-  definitions:
-    - name: buildifier
-      download: buildifier
-      shims: [buildifier]
-      known_good_version: 6.1.0
 lint:
+  downloads:
+    - name: buildifier
+      version: 6.1.0
+      executable: true
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildifier-${os}-${cpu}
+          version: ">=6.1.2"
+        # macos arm64 was introduced after this version.
+        - os: macos
+          version: <4.2.0
+          url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-darwin-amd64
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-${os}-${cpu}
+          version: ">=4.0.0"
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/bazelbuild/buildtools/releases/download/v${version}/buildifier-windows-amd64.exe
+          version: ">=6.1.2"
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/bazelbuild/buildtools/releases/download/${version}/buildifier-windows-amd64.exe
+          version: ">=4.0.0"
   definitions:
     - name: buildifier
       files: [starlark, bazel-build, bazel-workspace]
-      tools: [buildifier]
+      download: buildifier
       commands:
         - name: fix
           run: buildifier --lint=fix --warnings=all "${target}"

--- a/linters/cfnlint/plugin.yaml
+++ b/linters/cfnlint/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: cfnlint
-      runtime: python
-      package: cfn-lint
-      shims: [cfn-lint]
 lint:
   definitions:
     - name: cfnlint
@@ -17,7 +11,8 @@ lint:
           error_codes: [32]
           batch: true
           cache_results: true
-      tools: [cfnlint]
+      runtime: python
+      package: cfn-lint
       suggest_if: files_present
       issue_url_format: https://github.com/aws-cloudformation/cfn-lint/blob/main/docs/rules.md
       known_good_version: 0.58.2

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -1,16 +1,11 @@
 version: 0.1
-tools:
-  definitions:
-    - name: checkov
-      runtime: python
-      package: checkov
-      shims: [checkov]
 lint:
   definitions:
     - name: checkov
       supported_platforms: [linux, macos]
       files: [terraform, cloudformation, docker, yaml, json]
-      tools: [checkov]
+      runtime: python
+      package: checkov
       commands:
         - name: lint
           run: checkov -f ${target} -o sarif --output-file-path ${tmpfile},

--- a/linters/circleci/plugin.yaml
+++ b/linters/circleci/plugin.yaml
@@ -1,43 +1,37 @@
 version: 0.1
-downloads:
-  - name: circleci
-    downloads:
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
-        strip_components: 1
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
-        strip_components: 1
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_amd64.tar.gz
-        strip_components: 1
-      - os: linux
-        cpu: arm_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_arm64.tar.gz
-        strip_components: 1
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_windows_amd64.zip
-        strip_components: 1
-tools:
-  definitions:
-    - name: circleci
-      download: circleci
-      shims: [circleci]
-      known_good_version: 0.1.22770
 lint:
   files:
     - name: circleci-config
       comments: [hash]
       filenames:
         - .circleci/config.yml
+  downloads:
+    - name: circleci
+      downloads:
+        - os: macos
+          cpu: arm_64
+          url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
+          strip_components: 1
+        - os: macos
+          cpu: x86_64
+          url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
+          strip_components: 1
+        - os: linux
+          cpu: x86_64
+          url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_amd64.tar.gz
+          strip_components: 1
+        - os: linux
+          cpu: arm_64
+          url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_arm64.tar.gz
+          strip_components: 1
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_windows_amd64.zip
+          strip_components: 1
   definitions:
     - name: circleci
       files: [circleci-config]
-      tools: [circleci]
+      download: circleci
       known_good_version: 0.1.22770
       suggest_if: never
       commands:

--- a/linters/clang-format/plugin.yaml
+++ b/linters/clang-format/plugin.yaml
@@ -1,30 +1,21 @@
 version: 0.1
-downloads:
-  - name: clang-format
-    version: 14.0.1
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://trunk.io/releases/clang-format-${version}-macos-x86_64.tar.gz
-        version: <14.0.0
-      - os:
-          linux: linux
-          macos: macos
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://trunk.io/releases/clang-format-${version}-${os}-${cpu}.tar.gz
-      # TODO(chris): Windows download
-tools:
-  definitions:
-    - name: clang-format
-      download: clang-format
-      shims: [clang-format]
-      known_good_version: 14.0.1
-      environment:
-        - name: PATH
-          list: ["${linter}/bin"]
 lint:
+  downloads:
+    - name: clang-format
+      version: 14.0.1
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://trunk.io/releases/clang-format-${version}-macos-x86_64.tar.gz
+          version: <14.0.0
+        - os:
+            linux: linux
+            macos: macos
+          cpu:
+            x86_64: x86_64
+            arm_64: arm64
+          url: https://trunk.io/releases/clang-format-${version}-${os}-${cpu}.tar.gz
+        # TODO(chris): Windows download
   definitions:
     - name: clang-format
       supported_platforms: [linux, macos]
@@ -37,9 +28,12 @@ lint:
           stdin: true
           cache_results: true
           formatter: true
-      tools: [clang-format]
+      download: clang-format
       suggest_if: config_present
       direct_configs: [.clang-format]
+      environment:
+        - name: PATH
+          list: ["${linter}/bin"]
       known_good_version: 16.0.3
       version_command:
         parse_regex: ${semver}

--- a/linters/clang-tidy/plugin.yaml
+++ b/linters/clang-tidy/plugin.yaml
@@ -1,30 +1,21 @@
 version: 0.1
-downloads:
-  - name: clang-tidy
-    version: 15.0.6
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://trunk.io/releases/clang-tidy-${version}-macos-x86_64.tar.gz
-        version: <14.0.0
-      - os:
-          linux: linux
-          macos: macos
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://trunk.io/releases/clang-tidy-${version}-${os}-${cpu}.tar.gz
-        # TODO(chris): Windows download
-tools:
-  definitions:
-    - name: clang-tidy
-      download: clang-tidy
-      shims: [clang-tidy]
-      known_good_version: 16.0.3
-      environment:
-        - name: PATH
-          list: ["${linter}/bin"]
 lint:
+  downloads:
+    - name: clang-tidy
+      version: 15.0.6
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://trunk.io/releases/clang-tidy-${version}-macos-x86_64.tar.gz
+          version: <14.0.0
+        - os:
+            linux: linux
+            macos: macos
+          cpu:
+            x86_64: x86_64
+            arm_64: arm64
+          url: https://trunk.io/releases/clang-tidy-${version}-${os}-${cpu}.tar.gz
+        # TODO(chris): Windows download
   definitions:
     - name: clang-tidy
       supported_platforms: [linux, macos]
@@ -37,7 +28,7 @@ lint:
           cache_results: true
           run_linter_from: compile_command
           read_output_from: tmp_file
-      tools: [clang-tidy]
+      download: clang-tidy
       suggest_if: config_present
       direct_configs: [.clang-tidy]
       include_scanner_type: compile_command

--- a/linters/codespell/plugin.yaml
+++ b/linters/codespell/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: codespell
-      runtime: python
-      package: codespell
-      shims: [codespell]
 lint:
   definitions:
     - name: codespell
@@ -14,7 +8,8 @@ lint:
       affects_cache:
         - pyproject.toml
         - setup.cfg
-      tools: [codespell]
+      runtime: python
+      package: codespell
       known_good_version: 2.2.2
       known_bad_versions: [2.2.3]
       commands:

--- a/linters/cspell/plugin.yaml
+++ b/linters/cspell/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: cspell
-      runtime: node
-      package: cspell
-      shims: [cspell]
 lint:
   definitions:
     - name: cspell
       files: [ALL]
-      tools: [cspell]
+      runtime: node
+      package: cspell
       commands:
         - name: lint
           output: regex

--- a/linters/cue-fmt/plugin.yaml
+++ b/linters/cue-fmt/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: cue-fmt
-      runtime: go
-      package: cuelang.org/go/cmd/cue
-      shims: [cue]
 lint:
   definitions:
     - name: cue-fmt
@@ -16,7 +10,8 @@ lint:
           success_codes: [0]
           in_place: true
           formatter: true
-      tools: [cue-fmt]
+      runtime: go
+      package: cuelang.org/go/cmd/cue
       suggest_if: files_present
       # cue-fmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time
       known_good_version: 0.5.0

--- a/linters/djlint/plugin.yaml
+++ b/linters/djlint/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: djlint
-      runtime: python
-      package: djlint
-      shims: [djlint]
 lint:
   definitions:
     - name: djlint
       files: [html]
-      tools: [djlint]
+      runtime: python
+      package: djlint
       commands:
         - name: lint
           output: regex

--- a/linters/dotenv-linter/plugin.yaml
+++ b/linters/dotenv-linter/plugin.yaml
@@ -1,33 +1,27 @@
 version: 0.1
-downloads:
-  - name: dotenv-linter
-    version: 3.2.0
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-darwin-x86_64.tar.gz
-        version: <3.1.1
-      - os:
-          linux: alpine
-          macos: darwin
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-${os}-${cpu}.tar.gz
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-win-x64.zip
-tools:
-  definitions:
-    - name: dotenv-linter
-      download: dotenv-linter
-      shims: [dotenv-linter]
-      known_good_version: 3.2.0
 lint:
+  downloads:
+    - name: dotenv-linter
+      version: 3.2.0
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-darwin-x86_64.tar.gz
+          version: <3.1.1
+        - os:
+            linux: alpine
+            macos: darwin
+          cpu:
+            x86_64: x86_64
+            arm_64: arm64
+          url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-${os}-${cpu}.tar.gz
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/dotenv-linter/dotenv-linter/releases/download/v${version}/dotenv-linter-win-x64.zip
   definitions:
     - name: dotenv-linter
       files: [dotenv]
-      tools: [dotenv-linter]
+      download: dotenv-linter
       commands:
         - name: format
           output: rewrite

--- a/linters/eslint/plugin.yaml
+++ b/linters/eslint/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: eslint
-      runtime: node
-      package: eslint
-      shims: [eslint]
 lint:
   definitions:
     - name: eslint
       files: [typescript, javascript]
-      tools: [eslint]
+      runtime: node
+      package: eslint
       commands:
         - name: lint
           output: eslint

--- a/linters/flake8/plugin.yaml
+++ b/linters/flake8/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: flake8
-      runtime: python
-      package: flake8
-      shims: [flake8]
 lint:
   definitions:
     - name: flake8
@@ -20,7 +14,8 @@ lint:
           run_linter_from: parent_directory
           success_codes: [0]
           cache_results: true
-      tools: [flake8]
+      runtime: python
+      package: flake8
       direct_configs: [.flake8]
       suggest_if: config_present
       affects_cache:

--- a/linters/gitleaks/plugin.yaml
+++ b/linters/gitleaks/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: gitleaks
-      runtime: go
-      package: github.com/zricethezav/gitleaks/v${major_version}
-      shims: [gitleaks]
 lint:
   definitions:
     - name: gitleaks
@@ -18,7 +12,8 @@ lint:
           sandbox_type: copy_targets
           cache_results: true
           allow_empty_files: false
-      tools: [gitleaks]
+      runtime: go
+      package: github.com/zricethezav/gitleaks/v${major_version}
       direct_configs:
         - .gitleaks.config
         - .gitleaks.toml

--- a/linters/gofumpt/plugin.yaml
+++ b/linters/gofumpt/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: gofumpt
-      runtime: go
-      package: mvdan.cc/gofumpt
-      shims: [gofumpt]
 lint:
   definitions:
     - name: gofumpt
-      tools: [gofumpt]
+      runtime: go
       files: [go]
+      package: mvdan.cc/gofumpt
       commands:
         - name: format
           output: rewrite

--- a/linters/goimports/plugin.yaml
+++ b/linters/goimports/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: goimports
-      runtime: go
-      package: golang.org/x/tools/cmd/goimports
-      shims: [goimports]
 lint:
   definitions:
     - name: goimports
@@ -17,7 +11,8 @@ lint:
           stdin: true
           cache_results: true
           formatter: true
-      tools: [goimports]
+      runtime: go
+      package: golang.org/x/tools/cmd/goimports
       suggest_if: never
       environment:
         - name: PATH

--- a/linters/gokart/plugin.yaml
+++ b/linters/gokart/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: gokart
-      runtime: go
-      package: github.com/praetorian-inc/gokart
-      shims: [gokart]
 lint:
   definitions:
     - name: gokart
       files: [go]
-      tools: [gokart]
+      runtime: go
+      package: github.com/praetorian-inc/gokart
       suggest_if: files_present
       environment:
         - name: PATH

--- a/linters/golines/plugin.yaml
+++ b/linters/golines/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: golines
-      runtime: go
-      package: github.com/segmentio/golines
-      shims: [golines]
 lint:
   definitions:
     - name: golines
       files: [go]
-      tools: [golines]
+      runtime: go
+      package: github.com/segmentio/golines
       commands:
         - name: format
           output: rewrite

--- a/linters/google-java-format/plugin.yaml
+++ b/linters/google-java-format/plugin.yaml
@@ -1,10 +1,10 @@
 version: 0.1
-downloads:
-  - name: google-java-format.jar
-    executable: true
-    downloads:
-      - url: https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar
 lint:
+  downloads:
+    - name: google-java-format.jar
+      executable: true
+      downloads:
+        - url: https://github.com/google/google-java-format/releases/download/v${version}/google-java-format-${version}-all-deps.jar
   definitions:
     - name: google-java-format
       files: [java]

--- a/linters/graphql-schema-linter/plugin.yaml
+++ b/linters/graphql-schema-linter/plugin.yaml
@@ -5,7 +5,9 @@ tools:
       runtime: node
       package: graphql-schema-linter
       known_good_version: 3.0.1
-      shims: [graphql-schema-linter]
+      shims:
+        - name: graphql-schema-linter
+          target: graphql-schema-linter
 lint:
   definitions:
     - name: graphql-schema-linter

--- a/linters/hadolint/plugin.yaml
+++ b/linters/hadolint/plugin.yaml
@@ -1,36 +1,30 @@
 version: 0.1
-downloads:
-  - name: hadolint
-    version: 2.8.0
-    executable: true
-    downloads:
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64
-      - os: linux
-        cpu: arm_64
-        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-arm64
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
-      # Use rosetta
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Windows-x86_64.exe
-tools:
-  definitions:
-    - name: hadolint
-      download: hadolint
-      shims: [hadolint]
-      known_good_version: 2.8.0
 lint:
+  downloads:
+    - name: hadolint
+      version: 2.8.0
+      executable: true
+      downloads:
+        - os: linux
+          cpu: x86_64
+          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64
+        - os: linux
+          cpu: arm_64
+          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-arm64
+        - os: macos
+          cpu: x86_64
+          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
+        # Use rosetta
+        - os: macos
+          cpu: arm_64
+          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Windows-x86_64.exe
   definitions:
     - name: hadolint
       files: [docker]
-      tools: [hadolint]
+      download: hadolint
       commands:
         - name: lint
           # Custom parser type defined in the trunk cli to handle hadolint's JSON output.

--- a/linters/isort/plugin.yaml
+++ b/linters/isort/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: isort
-      runtime: python
-      package: isort
-      shims: [isort]
 lint:
   definitions:
     - name: isort
@@ -17,7 +11,8 @@ lint:
           batch: true
           in_place: true
           formatter: true
-      tools: [isort]
+      runtime: python
+      package: isort
       direct_configs: [.isort.cfg]
       suggest_if: files_present
       affects_cache:

--- a/linters/iwyu/plugin.yaml
+++ b/linters/iwyu/plugin.yaml
@@ -1,29 +1,22 @@
 version: 0.1
-downloads:
-  - name: include-what-you-use
-    downloads:
-      - os:
-          linux: linux
-          macos: macos
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://trunk.io/releases/include-what-you-use-${version}-${os}-${cpu}.tar.gz
-      # TODO(chris): Windows download
-tools:
-  definitions:
-    - name: include-what-you-use
-      download: include-what-you-use
-      shims: [include-what-you-use]
-      known_good_version: 0.19
-      environment:
-        - name: PATH
-          list: ["${tool}/bin"]
 lint:
+  downloads:
+    - name: include-what-you-use
+      version: 0.19
+      downloads:
+        - os:
+            linux: linux
+            macos: macos
+          cpu:
+            x86_64: x86_64
+            arm_64: arm64
+          url: https://trunk.io/releases/include-what-you-use-${version}-${os}-${cpu}.tar.gz
+        # TODO(chris): Windows download
   definitions:
     - name: include-what-you-use
+      supported_platforms: [linux, macos]
       files: [c/c++-source]
-      tools: [include-what-you-use]
+      download: include-what-you-use
       commands:
         - name: lint
           run_linter_from: compile_command
@@ -38,6 +31,9 @@ lint:
       include_scanner_type: compile_command
       query_compile_commands: true
       suggest_if: never
+      environment:
+        - name: PATH
+          list: ["${linter}/bin"]
       known_good_version: 0.19
       version_command:
         parse_regex: include-what-you-use ([^ ]+).*

--- a/linters/kube-linter/plugin.yaml
+++ b/linters/kube-linter/plugin.yaml
@@ -1,30 +1,24 @@
 version: 0.1
-downloads:
-  - name: kube-linter
-    version: 0.5.0
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        url: https://github.com/stackrox/kube-linter/releases/download/${version}/kube-linter-${os}
-        version: <0.6.1
-      - os:
-          linux: linux
-          macos: darwin
-        url: https://github.com/stackrox/kube-linter/releases/download/v${version}/kube-linter-${os}
-      - os: windows
-        url: https://github.com/stackrox/kube-linter/releases/download/v${version}/kube-linter.exe
-tools:
+lint:
+  downloads:
+    - name: kube-linter
+      version: 0.5.0
+      executable: true
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          url: https://github.com/stackrox/kube-linter/releases/download/${version}/kube-linter-${os}
+          version: <0.6.1
+        - os:
+            linux: linux
+            macos: darwin
+          url: https://github.com/stackrox/kube-linter/releases/download/v${version}/kube-linter-${os}
+        - os: windows
+          url: https://github.com/stackrox/kube-linter/releases/download/v${version}/kube-linter.exe
   definitions:
     - name: kube-linter
       download: kube-linter
-      shims: [kube-linter]
-      known_good_version: 0.5.0
-lint:
-  definitions:
-    - name: kube-linter
-      tools: [kube-linter]
       files:
         - yaml
       commands:

--- a/linters/markdownlint/plugin.yaml
+++ b/linters/markdownlint/plugin.yaml
@@ -1,16 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: markdownlint
-      runtime: node
-      package: markdownlint-cli
-      shims: [markdownlint]
-      known_good_version: 0.31.1
 lint:
   definitions:
     - name: markdownlint
       files: [markdown]
-      tools: [markdownlint]
+      runtime: node
+      package: markdownlint-cli
       commands:
         - name: lint
           # Custom parser type defined in the trunk cli to handle markdownlint's JSON output.

--- a/linters/mypy/plugin.yaml
+++ b/linters/mypy/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: mypy
-      runtime: python
-      package: mypy
-      shims: [mypy]
 lint:
   definitions:
     - name: mypy
@@ -19,7 +13,8 @@ lint:
             --show-column-numbers ${target}
           success_codes: [0, 1]
           stdin: false
-      tools: [mypy]
+      runtime: python
+      package: mypy
       direct_configs:
         - mypy.ini
         - .mypy.ini

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -1,31 +1,26 @@
 version: 0.1
-downloads:
-  - name: osv-scanner
-    version: 1.2.0
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_${os}_${cpu}
-      - os: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_windows_${cpu}.exe
-tools:
-  definitions:
-    - name: osv-scanner
-      download: osv-scanner
-      shims: [osv-scanner]
 lint:
+  downloads:
+    - name: osv-scanner
+      version: 1.2.0
+      executable: true
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_${os}_${cpu}
+        - os: windows
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_windows_${cpu}.exe
   definitions:
     - name: osv-scanner
       files: [lockfile]
-      tools: [osv-scanner]
+      download: osv-scanner
       known_good_version: 1.2.0
       commands:
         - name: scan

--- a/linters/prettier/plugin.yaml
+++ b/linters/prettier/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: prettier
-      runtime: node
-      package: prettier
-      shims: [prettier]
 lint:
   definitions:
     - name: prettier
@@ -27,7 +21,8 @@ lint:
           batch: true
           in_place: true
           formatter: true
-      tools: [prettier]
+      runtime: node
+      package: prettier
       suggest_if: files_present
       direct_configs:
         - .prettierrc

--- a/linters/pylint/plugin.yaml
+++ b/linters/pylint/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: pylint
-      runtime: python
-      package: pylint
-      shims: [pylint]
 lint:
   definitions:
     - name: pylint
@@ -18,7 +12,8 @@ lint:
           read_output_from: tmp_file
           batch: true
           cache_results: true
-      tools: [pylint]
+      runtime: python
+      package: pylint
       suggest_if: config_present
       direct_configs:
         - pylintrc

--- a/linters/pyright/plugin.yaml
+++ b/linters/pyright/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: pyright
-      runtime: node
-      package: pyright
-      shims: [pyright]
 lint:
   definitions:
     - name: pyright
@@ -21,7 +15,8 @@ lint:
           parser:
             runtime: python
             run: python3 ${plugin}/linters/pyright/pyright_to_sarif.py
-      tools: [pyright]
+      runtime: node
+      package: pyright
       direct_configs:
         - pyrightconfig.json
       affects_cache:

--- a/linters/renovate/plugin.yaml
+++ b/linters/renovate/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: renovate
-      runtime: node
-      package: renovate
-      shims: [renovate]
 lint:
   files:
     - name: renovate-config

--- a/linters/rome/plugin.yaml
+++ b/linters/rome/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: rome
-      runtime: node
-      package: rome
-      shims: [rome]
 lint:
   definitions:
     - name: rome
@@ -31,7 +25,8 @@ lint:
           cache_results: true
           formatter: true
           in_place: true
-      tools: [rome]
+      runtime: node
+      package: rome
       suggest_if: config_present
       direct_configs:
         - rome.json

--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: ruff
-      runtime: python
-      package: ruff
-      shims: [ruff]
 lint:
   definitions:
     - name: ruff
@@ -28,7 +22,8 @@ lint:
             run: python3 ${cwd}/ruff_to_sarif.py 1
           batch: true
           success_codes: [0, 1]
-      tools: [ruff]
+      runtime: python
+      package: ruff
       direct_configs: [pyproject.toml, ruff.toml]
       affects_cache:
         - setup.cfg

--- a/linters/scalafmt/plugin.yaml
+++ b/linters/scalafmt/plugin.yaml
@@ -1,31 +1,25 @@
 version: 0.1
-downloads:
-  - name: scalafmt
-    version: 3.4.3
-    executable: true
-    downloads:
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-linux-musl
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-macos
-      # Use rosetta
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-macos
-      # No windows release
-tools:
-  definitions:
-    - name: scalafmt
-      download: scalafmt
-      shims: [scalafmt]
-      known_good_version: 3.4.3
 lint:
+  downloads:
+    - name: scalafmt
+      version: 3.4.3
+      executable: true
+      downloads:
+        - os: linux
+          cpu: x86_64
+          url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-linux-musl
+        - os: macos
+          cpu: x86_64
+          url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-macos
+        # Use rosetta
+        - os: macos
+          cpu: arm_64
+          url: https://github.com/scalameta/scalafmt/releases/download/v${version}/scalafmt-macos
+        # No windows release
   definitions:
     - name: scalafmt
       files: [scala]
-      tools: [scalafmt]
+      download: scalafmt
       direct_configs: [.scalafmt.conf]
       suggest_if: config_present
       commands:

--- a/linters/semgrep/plugin.yaml
+++ b/linters/semgrep/plugin.yaml
@@ -1,16 +1,11 @@
 version: 0.1
-tools:
-  definitions:
-    - name: semgrep
-      runtime: python
-      package: semgrep
-      shims: [semgrep]
 lint:
   definitions:
     - name: semgrep
       supported_platforms: [linux, macos]
       files: [ALL]
-      tools: [semgrep]
+      runtime: python
+      package: semgrep
       commands:
         - name: check
           output: sarif

--- a/linters/shellcheck/plugin.yaml
+++ b/linters/shellcheck/plugin.yaml
@@ -1,33 +1,27 @@
 version: 0.1
-downloads:
-  - name: shellcheck
-    version: 0.8.0
-    downloads:
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz
-        strip_components: 1
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
-        strip_components: 1
-      # Use rosetta
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
-        strip_components: 1
-      # No windows release
-tools:
-  definitions:
-    - name: shellcheck
-      download: shellcheck
-      shims: [shellcheck]
-      known_good_version: 0.8.0
 lint:
+  downloads:
+    - name: shellcheck
+      version: 0.8.0
+      downloads:
+        - os: linux
+          cpu: x86_64
+          url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.linux.x86_64.tar.xz
+          strip_components: 1
+        - os: macos
+          cpu: x86_64
+          url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
+          strip_components: 1
+        # Use rosetta
+        - os: macos
+          cpu: arm_64
+          url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
+          strip_components: 1
+        # No windows release
   definitions:
     - name: shellcheck
       files: [shell]
-      tools: [shellcheck]
+      download: shellcheck
       commands:
         - name: lint
           # Custom parser type defined in the trunk cli to handle rubocop's JSON output.

--- a/linters/shfmt/plugin.yaml
+++ b/linters/shfmt/plugin.yaml
@@ -1,12 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: shfmt
-      runtime: go
-      package: mvdan.cc/sh/v${major_version}/cmd/shfmt
-      shims: [shfmt]
-      # shfmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time
-      known_good_version: 3.6.0
 lint:
   definitions:
     - name: shfmt
@@ -20,7 +12,8 @@ lint:
           formatter: true
           batch: true
           in_place: true
-      tools: [shfmt]
+      runtime: go
+      package: mvdan.cc/sh/v${major_version}/cmd/shfmt
       suggest_if: files_present
       affects_cache: [.editorconfig]
       # shfmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time

--- a/linters/sort-package-json/plugin.yaml
+++ b/linters/sort-package-json/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sort-package-json
-      runtime: node
-      package: sort-package-json
-      shims: [sort-package-json]
 lint:
   files:
     - name: package-json
@@ -21,6 +15,7 @@ lint:
           success_codes: [0]
           in_place: true
           formatter: true
-      tools: [sort-package-json]
+      runtime: node
+      package: sort-package-json
       suggest_if: never # decide whether this is something we want on by default
       known_good_version: 2.1.0

--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -1,11 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sourcery
-      runtime: python
-      package: sourcery
-      shims: [sourcery]
-      known_good_version: 1.2.0
 lint:
   definitions:
     - name: sourcery
@@ -26,7 +19,8 @@ lint:
           batch: true
           # NOTE(Tyler): Autofixes will show up as complete "formatting-like" diagnostics. However, strictly speaking, this isn't a formatter, so we don't want to set formatter: true
           in_place: true
-      tools: [sourcery]
+      runtime: python
+      package: sourcery
       suggest_if: never
       direct_configs:
         - .sourcery.yaml

--- a/linters/sourcery/readme.md
+++ b/linters/sourcery/readme.md
@@ -20,8 +20,7 @@ CI:
 
 <!-- trunk-ignore-begin(markdownlint/MD029) -->
 
-2. Run `.trunk/tools/sourcery login` (you may have to run `trunk tools install` to install the
-   `sourcery` shim) during as a setup before the `trunk check` step
+2. Run `trunk exec sourcery login` during as a setup before the `trunk check` step
 
 3. Set up an established environment override, as we've done here with
    [\_plugin.yaml](./test_data/_plugin.yaml).

--- a/linters/sql-formatter/plugin.yaml
+++ b/linters/sql-formatter/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sql-formatter
-      runtime: node
-      package: sql-formatter
-      shims: [sql-formatter]
 lint:
   definitions:
     - name: sql-formatter
@@ -16,7 +10,8 @@ lint:
           success_codes: [0]
           formatter: true
           stdin: true
-      tools: [sql-formatter]
+      runtime: node
+      package: sql-formatter
       known_good_version: 7.0.1
       suggest_if: never
       version_command:

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sqlfluff
-      runtime: python
-      package: sqlfluff
-      shims: [sqlfluff]
 lint:
   definitions:
     - name: sqlfluff
       files: [sql, sql-j2, dml, ddl]
-      tools: [sqlfluff]
+      runtime: python
+      package: sqlfluff
       known_good_version: 1.4.5
       direct_configs:
         - .sqlfluff

--- a/linters/sqlfmt/plugin.yaml
+++ b/linters/sqlfmt/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sqlfmt
-      runtime: python
-      package: shandy-sqlfmt
-      shims: [sqlfmt]
 lint:
   definitions:
     - name: sqlfmt
       files: [sql, sql-j2]
-      tools: [sqlfmt]
+      runtime: python
+      package: shandy-sqlfmt
       known_good_version: 0.16.0
       # trunk-ignore(yamllint/quoted-strings): see https://github.com/adrienverge/yamllint/issues/516
       extra_packages: ["shandy-sqlfmt[jinjafmt]"]

--- a/linters/stringslint/plugin.yaml
+++ b/linters/stringslint/plugin.yaml
@@ -1,19 +1,13 @@
 version: 0.1
-downloads:
-  # This is a Mac-exclusive linter
-  - name: stringslint
-    version: 0.1.1
-    downloads:
-      # macOS only, universal binary supports x86_64 and arm64
-      - os: macos
-        url: https://github.com/dral3x/StringsLint/releases/download/${version}/portable_stringslint.zip
-tools:
-  definitions:
-    - name: stringslint
-      download: stringslint
-      shims: [stringslint]
-      known_good_version: 0.1.1
 lint:
+  downloads:
+    # This is a Mac-exclusive linter
+    - name: stringslint
+      version: 0.1.1
+      downloads:
+        # macOS only, universal binary supports x86_64 and arm64
+        - os: macos
+          url: https://github.com/dral3x/StringsLint/releases/download/${version}/portable_stringslint.zip
   definitions:
     - name: stringslint
       files:
@@ -22,7 +16,7 @@ lint:
         - strings
         - xib
         - storyboard
-      tools: [stringslint]
+      download: stringslint
       commands:
         - name: lint
           output: regex

--- a/linters/stylelint/plugin.yaml
+++ b/linters/stylelint/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: stylelint
-      runtime: node
-      package: stylelint
-      shims: [stylelint]
 lint:
   definitions:
     - name: stylelint
       files: [css, sass]
-      tools: [stylelint]
+      runtime: node
+      package: stylelint
       commands:
         - name: lint
           # Custom parser type defined in the trunk cli to handle stylelint's JSON output.

--- a/linters/stylua/plugin.yaml
+++ b/linters/stylua/plugin.yaml
@@ -1,27 +1,21 @@
 version: 0.1
-downloads:
-  - name: stylua
-    version: 0.17.0
-    downloads:
-      - os:
-          linux: linux
-          macos: macos
-          windows: windows
-        cpu:
-          x86_64: x86_64
-          arm_64: aarch64
-        url: https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${cpu}.zip
-tools:
-  definitions:
-    - name: stylua
-      download: stylua
-      shims: [stylua]
-      known_good_version: 0.17.0
 lint:
+  downloads:
+    - name: stylua
+      version: 0.17.0
+      downloads:
+        - os:
+            linux: linux
+            macos: macos
+            windows: windows
+          cpu:
+            x86_64: x86_64
+            arm_64: aarch64
+          url: https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/stylua-${os}-${cpu}.zip
   definitions:
     - name: stylua
       files: [lua]
-      tools: [stylua]
+      download: stylua
       commands:
         - name: format
           output: rewrite
@@ -31,10 +25,12 @@ lint:
           success_codes: [0, 1]
       run_linter_from: workspace
       suggest_if: config_present
-      known_good_version: 0.17.0
       direct_configs:
         - stylua.toml
         - .stylua.toml
+      environment:
+        - name: PATH
+          list: ["${linter}"]
       version_command:
         parse_regex: ${semver}
         run: stylua --version

--- a/linters/svgo/plugin.yaml
+++ b/linters/svgo/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: svgo
-      runtime: node
-      package: svgo
-      shims: [svgo]
 lint:
   definitions:
     # while svgo could be a formatter, it is optimizing, not formatting, so it's more intuitive to run on `trunk check`
@@ -18,7 +12,8 @@ lint:
           success_codes: [0]
           batch: true
           in_place: true
-      tools: [svgo]
+      runtime: node
+      package: svgo
       direct_configs: [svgo.config.js, svgo.config.mjs, svgo.config.cjs]
       suggest_if: files_present
       known_good_version: 2.8.0

--- a/linters/swiftformat/plugin.yaml
+++ b/linters/swiftformat/plugin.yaml
@@ -1,22 +1,17 @@
 version: 0.1
-downloads:
-  - name: swiftformat
-    downloads:
-      # Universal binary, both x86_64 and arm64
-      - os: macos
-        url: https://github.com/nicklockwood/SwiftFormat/releases/download/${version}/swiftformat.zip
-      # There exists a Linux download, but it is not self-contained. It expects some libFoundation.so to exist on the system.
-tools:
-  definitions:
-    - name: swiftformat
-      download: swiftformat
-      shims: [swiftformat]
-      known_good_version: 0.50.0
 lint:
+  downloads:
+    - name: swiftformat
+      downloads:
+        # Universal binary, both x86_64 and arm64
+        - os: macos
+          url: https://github.com/nicklockwood/SwiftFormat/releases/download/${version}/swiftformat.zip
+        # There exists a Linux download, but it is not self-contained. It expects some libFoundation.so to exist on the system.
+
   definitions:
     - name: swiftformat
       files: [swift]
-      tools: [swiftformat]
+      download: swiftformat
       commands:
         - name: format
           output: rewrite

--- a/linters/swiftlint/plugin.yaml
+++ b/linters/swiftlint/plugin.yaml
@@ -1,23 +1,18 @@
 version: 0.1
-downloads:
-  - name: swiftlint
-    version: 0.49.1
-    downloads:
-      # macOS only, universal binary supports x86_64 and arm64
-      - os: macos
-        url: https://github.com/realm/SwiftLint/releases/download/${version}/portable_swiftlint.zip
-tools:
-  definitions:
-    - name: swiftlint
-      download: swiftlint
-      shims: [swiftlint]
-      known_good_version: 0.49.1
 lint:
+  downloads:
+    - name: swiftlint
+      version: 0.49.1
+      downloads:
+        # macOS only, universal binary supports x86_64 and arm64
+        - os: macos
+          url: https://github.com/realm/SwiftLint/releases/download/${version}/portable_swiftlint.zip
+
   definitions:
     - name: swiftlint
       files:
         - swift
-      tools: [swiftlint]
+      download: swiftlint
       commands:
         - name: lint
           output: regex

--- a/linters/taplo/plugin.yaml
+++ b/linters/taplo/plugin.yaml
@@ -1,81 +1,76 @@
 version: 0.1
-downloads:
-  - name: taplo
-    args:
-      semver: ${version}=>(?:release-cli-|release-taplo-cli-)?(?P<semver>.*)
-    downloads:
-      # Versions >=0.8.0
-      - os: linux
-        cpu: x86_64
-        version: ">=0.8.0"
-        url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-linux-x86_64.gz
-      - os: macos
-        cpu: x86_64
-        version: ">=0.8.0"
-        url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-darwin-x86_64.gz
-        # Use rosetta
-      - os: macos
-        cpu: arm_64
-        version: ">=0.8.0"
-        url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-darwin-aarch64.gz
-      # https://github.com/tamasfe/taplo/issues/397
-      # - os: windows
-      #   cpu: x86_64
-      #   version: ">=0.8.0"
-      #   url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-windows-x86_64.zip
-
-      # Versions >=0.6.7
-      - os: linux
-        cpu: x86_64
-        version: ">=0.6.7"
-        url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-unknown-linux-gnu.tar.gz
-      - os: macos
-        cpu: x86_64
-        version: ">=0.6.7"
-        url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-apple-darwin-gnu.tar.gz
-        # Use rosetta
-      - os: macos
-        cpu: arm_64
-        version: ">=0.6.7"
-        url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-apple-darwin-gnu.tar.gz
-
-      # Versions >=0.6.0
-      - os: linux
-        cpu: x86_64
-        version: ">=0.6.0"
-        url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-unknown-linux-gnu.tar.gz
-      - os: macos
-        cpu: x86_64
-        version: ">=0.6.0"
-        url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-apple-darwin-gnu.tar.gz
-      # Use rosetta
-      - os: macos
-        cpu: arm_64
-        version: ">=0.6.0"
-        url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-apple-darwin-gnu.tar.gz
-
-      # All older versions
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-unknown-linux-gnu.tar.gz
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-apple-darwin-gnu.tar.gz
-      # Use rosetta
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-apple-darwin-gnu.tar.gz
-tools:
-  definitions:
-    - name: taplo
-      download: taplo
-      shims: [taplo]
-      known_good_version: release-cli-0.6.0
 lint:
+  downloads:
+    - name: taplo
+      args:
+        semver: ${version}=>(?:release-cli-|release-taplo-cli-)?(?P<semver>.*)
+      downloads:
+        # Versions >=0.8.0
+        - os: linux
+          cpu: x86_64
+          version: ">=0.8.0"
+          url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-linux-x86_64.gz
+        - os: macos
+          cpu: x86_64
+          version: ">=0.8.0"
+          url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-darwin-x86_64.gz
+          # Use rosetta
+        - os: macos
+          cpu: arm_64
+          version: ">=0.8.0"
+          url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-darwin-aarch64.gz
+        # https://github.com/tamasfe/taplo/issues/397
+        # - os: windows
+        #   cpu: x86_64
+        #   version: ">=0.8.0"
+        #   url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-windows-x86_64.zip
+
+        # Versions >=0.6.7
+        - os: linux
+          cpu: x86_64
+          version: ">=0.6.7"
+          url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-unknown-linux-gnu.tar.gz
+        - os: macos
+          cpu: x86_64
+          version: ">=0.6.7"
+          url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-apple-darwin-gnu.tar.gz
+          # Use rosetta
+        - os: macos
+          cpu: arm_64
+          version: ">=0.6.7"
+          url: https://github.com/tamasfe/taplo/releases/download/release-taplo-cli-${semver}/taplo-x86_64-apple-darwin-gnu.tar.gz
+
+        # Versions >=0.6.0
+        - os: linux
+          cpu: x86_64
+          version: ">=0.6.0"
+          url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-unknown-linux-gnu.tar.gz
+        - os: macos
+          cpu: x86_64
+          version: ">=0.6.0"
+          url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-apple-darwin-gnu.tar.gz
+        # Use rosetta
+        - os: macos
+          cpu: arm_64
+          version: ">=0.6.0"
+          url: https://github.com/tamasfe/taplo/releases/download/release-cli-${semver}/taplo-${semver}-x86_64-apple-darwin-gnu.tar.gz
+
+        # All older versions
+        - os: linux
+          cpu: x86_64
+          url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-unknown-linux-gnu.tar.gz
+        - os: macos
+          cpu: x86_64
+          url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-apple-darwin-gnu.tar.gz
+        # Use rosetta
+        - os: macos
+          cpu: arm_64
+          url: https://github.com/tamasfe/taplo/releases/download/${version}/taplo-x86_64-apple-darwin-gnu.tar.gz
+
   definitions:
     - name: taplo
       files: [toml]
-      tools: [taplo]
+      download: taplo
       commands:
         - name: lint
           # Custom parser type defined in the trunk cli to handle taplo's output.

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -1,31 +1,25 @@
 version: 0.1
-downloads:
-  - name: terraform
-    version: 1.1.4
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_darwin_amd64.zip
-        version: <1.0.2
-      - os:
-          linux: linux
-          macos: darwin
-          windows: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${cpu}.zip
-tools:
-  definitions:
-    - name: terraform
-      download: terraform
-      shims: [terraform]
-      known_good_version: 1.1.4
 lint:
+  downloads:
+    - name: terraform
+      version: 1.1.4
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_darwin_amd64.zip
+          version: <1.0.2
+        - os:
+            linux: linux
+            macos: darwin
+            windows: windows
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${cpu}.zip
   definitions:
     - name: terraform
       files: [terraform]
-      tools: [terraform]
+      download: terraform
       commands:
         - name: validate
           # Custom parser type defined in the trunk cli to handle terraform's JSON output.

--- a/linters/terragrunt/plugin.yaml
+++ b/linters/terragrunt/plugin.yaml
@@ -1,18 +1,18 @@
 version: 0.1
-downloads:
-  - name: terragrunt
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_${os}_${cpu}
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_windows_amd64.exe
 tools:
+  downloads:
+    - name: terragrunt
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_${os}_${cpu}
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_windows_amd64.exe
   definitions:
     - name: terragrunt
       known_good_version: 0.45.8
@@ -21,9 +21,22 @@ tools:
         - name: terragrunt
           target: terragrunt
 lint:
+  downloads:
+    - name: terragrunt
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_${os}_${cpu}
+        - os: windows
+          cpu: x86_64
+          url: https://github.com/gruntwork-io/terragrunt/releases/download/v${version}/terragrunt_windows_amd64.exe
   definitions:
     - name: terragrunt
-      tools: [terragrunt]
+      download: terragrunt
       known_good_version: 0.45.8
       files: [hcl]
       suggest_if: never

--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -1,26 +1,20 @@
 version: 0.1
-downloads:
-  - name: terrascan
-    version: 1.18.1
-    downloads:
-      - os:
-          linux: Linux
-          macos: Darwin
-          windows: Windows
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://github.com/tenable/terrascan/releases/download/v${version}/terrascan_${version}_${os}_${cpu}.tar.gz
-tools:
+lint:
+  downloads:
+    - name: terrascan
+      version: 1.18.1
+      downloads:
+        - os:
+            linux: Linux
+            macos: Darwin
+            windows: Windows
+          cpu:
+            x86_64: x86_64
+            arm_64: arm64
+          url: https://github.com/tenable/terrascan/releases/download/v${version}/terrascan_${version}_${os}_${cpu}.tar.gz
   definitions:
     - name: terrascan
       download: terrascan
-      shims: [terrascan]
-      known_good_version: 1.18.1
-lint:
-  definitions:
-    - name: terrascan
-      tools: [terrascan]
       known_good_version: 1.18.1
       suggest_if: files_present
       commands:

--- a/linters/tflint/plugin.yaml
+++ b/linters/tflint/plugin.yaml
@@ -1,27 +1,21 @@
 version: 0.1
-downloads:
-  - name: tflint
-    version: 0.35.0
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://github.com/terraform-linters/tflint/releases/download/v${version}/tflint_darwin_amd64.zip
-        version: <0.29.1
-      - os:
-          linux: linux
-          macos: darwin
-          windows: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/terraform-linters/tflint/releases/download/v${version}/tflint_${os}_${cpu}.zip
-tools:
-  definitions:
-    - name: tflint
-      download: tflint
-      shims: [tflint]
-      known_good_version: 0.35.0
 lint:
+  downloads:
+    - name: tflint
+      version: 0.35.0
+      downloads:
+        # macos arm64 was introduced after this version.
+        - os: macos
+          url: https://github.com/terraform-linters/tflint/releases/download/v${version}/tflint_darwin_amd64.zip
+          version: <0.29.1
+        - os:
+            linux: linux
+            macos: darwin
+            windows: windows
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/terraform-linters/tflint/releases/download/v${version}/tflint_${os}_${cpu}.zip
   definitions:
     - name: tflint
       files: [terraform]
@@ -45,7 +39,7 @@ lint:
           run_linter_from: root_file
           run_from_root_target: .tflint.hcl
       suggest_if: files_present
-      tools: [tflint]
+      download: tflint
       direct_configs: [.tflint.hcl]
       environment:
         - name: PATH

--- a/linters/tfsec/plugin.yaml
+++ b/linters/tfsec/plugin.yaml
@@ -1,32 +1,27 @@
 version: 0.1
-downloads:
-  - name: tfsec
-    version: 1.28.1
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-${os}-${cpu}
-      - os: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-windows-${cpu}.exe
-tools:
-  definitions:
-    - name: tfsec
-      download: tfsec
-      shims: [tfsec]
-      known_good_version: 1.28.1
 lint:
+  downloads:
+    - name: tfsec
+      version: 1.28.1
+      executable: true
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-${os}-${cpu}
+        - os: windows
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/aquasecurity/tfsec/releases/download/v${version}/tfsec-windows-${cpu}.exe
+
   definitions:
     - name: tfsec
       files: [terraform]
-      tools: [tfsec]
+      download: tfsec
       known_good_version: 1.28.1
       suggest_if: files_present
       commands:

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -1,33 +1,28 @@
 version: 0.1
-downloads:
-  - name: trivy
-    downloads:
-      - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_Linux-${cpu}.tar.gz
-        os: linux
-        cpu:
-          x86_64: 64bit
-          arm_64: ARM
-      - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_macOS-${cpu}.tar.gz
-        os: macos
-        cpu:
-          x86_64: 64bit
-          arm_64: ARM64
-      - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_windows-${cpu}.zip
-        os: windows
-        cpu:
-          x86_64: 64bit
-          arm_64: ARM64
-tools:
-  definitions:
-    - name: trivy
-      download: trivy
-      shims: [trivy]
-      known_good_version: 0.37.1
 lint:
+  downloads:
+    - name: trivy
+      downloads:
+        - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_Linux-${cpu}.tar.gz
+          os: linux
+          cpu:
+            x86_64: 64bit
+            arm_64: ARM
+        - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_macOS-${cpu}.tar.gz
+          os: macos
+          cpu:
+            x86_64: 64bit
+            arm_64: ARM64
+        - url: https://github.com/aquasecurity/trivy/releases/download/v${version}/trivy_${version}_windows-${cpu}.zip
+          os: windows
+          cpu:
+            x86_64: 64bit
+            arm_64: ARM64
+
   definitions:
     - name: trivy
       files: [lockfile, docker, yaml, terraform]
-      tools: [trivy]
+      download: trivy
       suggest_if: files_present
       known_good_version: 0.37.1
       commands:

--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -1,26 +1,20 @@
 version: 0.1
-downloads:
-  - name: trufflehog
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-          windows: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/trufflesecurity/trufflehog/releases/download/v${version}/trufflehog_${version}_${os}_${cpu}.tar.gz
-tools:
-  definitions:
-    - name: trufflehog
-      download: trufflehog
-      shims: [trufflehog]
-      known_good_version: 3.31.3
 lint:
+  downloads:
+    - name: trufflehog
+      downloads:
+        - os:
+            linux: linux
+            macos: darwin
+            windows: windows
+          cpu:
+            x86_64: amd64
+            arm_64: arm64
+          url: https://github.com/trufflesecurity/trufflehog/releases/download/v${version}/trufflehog_${version}_${os}_${cpu}.tar.gz
   definitions:
     - name: trufflehog
       files: [ALL]
-      tools: [trufflehog]
+      download: trufflehog
       known_good_version: 3.31.3
       known_bad_versions: [3.41.0]
       commands:

--- a/linters/txtpbfmt/plugin.yaml
+++ b/linters/txtpbfmt/plugin.yaml
@@ -1,15 +1,10 @@
 version: 0.1
-tools:
-  definitions:
-    - name: txtpbfmt
-      runtime: go
-      package: github.com/protocolbuffers/txtpbfmt/cmd/txtpbfmt
-      shims: [txtpbfmt]
 lint:
   definitions:
     - name: txtpbfmt
       files: [textproto]
-      tools: [txtpbfmt]
+      runtime: go
+      package: github.com/protocolbuffers/txtpbfmt/cmd/txtpbfmt
       commands:
         - name: format
           output: rewrite

--- a/linters/yamllint/plugin.yaml
+++ b/linters/yamllint/plugin.yaml
@@ -1,10 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: yamllint
-      runtime: python
-      package: yamllint
-      shims: [yamllint]
 lint:
   definitions:
     - name: yamllint
@@ -17,7 +11,8 @@ lint:
           success_codes: [0, 1, 2]
           run: yamllint -f parsable ${target}
           read_output_from: stdout
-      tools: [yamllint]
+      runtime: python
+      package: yamllint
       suggest_if: files_present
       direct_configs:
         - .yamllint

--- a/linters/yapf/plugin.yaml
+++ b/linters/yapf/plugin.yaml
@@ -1,11 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: yapf
-      runtime: python
-      package: yapf
-      extra_packages: [toml]
-      shims: [yapf]
 lint:
   definitions:
     - name: yapf
@@ -20,7 +13,9 @@ lint:
           allow_empty_files: false
           cache_results: true
           formatter: true
-      tools: [yapf]
+      runtime: python
+      package: yapf
+      extra_packages: [toml]
       direct_configs:
         - .style.yapf
         - .yapfignore

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.12.1"
+required_trunk_version: ">=1.12.0"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -27,7 +27,7 @@ const executionEnv = (sandbox: string) => {
     // This keeps test downloads separate from manual trunk invocations
     TRUNK_DOWNLOAD_CACHE: path.resolve(
       fs.realpathSync(os.tmpdir()),
-      `${TEMP_PREFIX}testing_download_cache`
+      `${TEMP_PREFIX}testing_download_cache`,
     ),
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
@@ -104,7 +104,7 @@ export class GenericTrunkDriver {
       }
       fs.writeFileSync(
         path.resolve(this.sandboxPath, ".trunk/trunk.yaml"),
-        newTrunkYamlContents(this.setupSettings.trunkVersion)
+        newTrunkYamlContents(this.setupSettings.trunkVersion),
       );
     }
 
@@ -264,11 +264,11 @@ export class GenericTrunkDriver {
 
   async runTrunkCmd(
     argStr: string,
-    execOptions?: ExecOptions
+    execOptions?: ExecOptions,
   ): Promise<{ stdout: string; stderr: string }> {
     return await this.runTrunk(
       argStr.split(" ").filter((arg) => arg.length > 0),
-      execOptions
+      execOptions,
     );
   }
 
@@ -279,7 +279,7 @@ export class GenericTrunkDriver {
    */
   async runTrunk(
     args: string[],
-    execOptions?: ExecOptions
+    execOptions?: ExecOptions,
   ): Promise<{ stdout: string; stderr: string }> {
     const trunkPath = ARGS.cliPath ?? "trunk";
     return await execFilePromise(
@@ -289,7 +289,7 @@ export class GenericTrunkDriver {
         cwd: this.sandboxPath,
         env: executionEnv(this.sandboxPath ?? ""),
         ...execOptions,
-      }
+      },
     );
   }
 

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -258,6 +258,7 @@ export class GenericTrunkDriver {
   getFullTrunkConfig = (): any => {
     const printConfig = execSync(`${ARGS.cliPath ?? "trunk"} config print`, {
       cwd: this.sandboxPath,
+      env: executionEnv(this.sandboxPath ?? ""),
     });
     return YAML.parse(printConfig.toString());
   };

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -27,7 +27,7 @@ const executionEnv = (sandbox: string) => {
     // This keeps test downloads separate from manual trunk invocations
     TRUNK_DOWNLOAD_CACHE: path.resolve(
       fs.realpathSync(os.tmpdir()),
-      `${TEMP_PREFIX}testing_download_cache`,
+      `${TEMP_PREFIX}testing_download_cache`
     ),
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
@@ -104,7 +104,7 @@ export class GenericTrunkDriver {
       }
       fs.writeFileSync(
         path.resolve(this.sandboxPath, ".trunk/trunk.yaml"),
-        newTrunkYamlContents(this.setupSettings.trunkVersion),
+        newTrunkYamlContents(this.setupSettings.trunkVersion)
       );
     }
 
@@ -258,18 +258,17 @@ export class GenericTrunkDriver {
   getFullTrunkConfig = (): any => {
     const printConfig = execSync(`${ARGS.cliPath ?? "trunk"} config print`, {
       cwd: this.sandboxPath,
-      env: executionEnv(this.sandboxPath ?? ""),
     });
     return YAML.parse(printConfig.toString());
   };
 
   async runTrunkCmd(
     argStr: string,
-    execOptions?: ExecOptions,
+    execOptions?: ExecOptions
   ): Promise<{ stdout: string; stderr: string }> {
     return await this.runTrunk(
       argStr.split(" ").filter((arg) => arg.length > 0),
-      execOptions,
+      execOptions
     );
   }
 
@@ -280,7 +279,7 @@ export class GenericTrunkDriver {
    */
   async runTrunk(
     args: string[],
-    execOptions?: ExecOptions,
+    execOptions?: ExecOptions
   ): Promise<{ stdout: string; stderr: string }> {
     const trunkPath = ARGS.cliPath ?? "trunk";
     return await execFilePromise(
@@ -290,7 +289,7 @@ export class GenericTrunkDriver {
         cwd: this.sandboxPath,
         env: executionEnv(this.sandboxPath ?? ""),
         ...execOptions,
-      },
+      }
     );
   }
 

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -92,7 +92,7 @@ export class TrunkLintDriver extends GenericTrunkDriver {
       // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)
       return (
         (this.getFullTrunkConfig().lint.definitions.find(
-          ({ name }: { name: string }) => name === this.linter
+          ({ name }: { name: string }) => name === this.linter,
         )?.known_good_version as string) ?? ""
       );
       // trunk-ignore-end(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)
@@ -118,13 +118,13 @@ export class TrunkLintDriver extends GenericTrunkDriver {
       // Prefer calling `check enable` over editing trunk.yaml directly because it also handles version, etc.
       this.debug("Enabling %s", linterVersionString);
       await this.runTrunkCmd(
-        `check enable ${linterVersionString} --monitor=false --bypass-validated`
+        `check enable ${linterVersionString} --monitor=false --bypass-validated`,
       );
 
       // Retrieve the enabled version
       const newTrunkContents = fs.readFileSync(
         path.resolve(this.sandboxPath, ".trunk/trunk.yaml"),
-        "utf8"
+        "utf8",
       );
       const enabledVersionRegex = `(?<linter>${this.linter})@(?<version>.+)\n`;
       const foundIn = newTrunkContents.match(enabledVersionRegex);
@@ -145,7 +145,7 @@ export class TrunkLintDriver extends GenericTrunkDriver {
   parseRunResult(
     trunkRunResult: TrunkRunResult,
     trunkVerb: TrunkVerb,
-    targetAbsPath?: string
+    targetAbsPath?: string,
   ): TestResult {
     return {
       success: [0, 1].includes(trunkRunResult.exitCode),
@@ -195,7 +195,7 @@ export class TrunkLintDriver extends GenericTrunkDriver {
           outputJson: JSON.parse(fs.readFileSync(resultJsonPath, { encoding: "utf-8" })),
         },
         "Check",
-        targetAbsPath
+        targetAbsPath,
       );
     } catch (error: any) {
       // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-member-access)
@@ -273,7 +273,7 @@ export class TrunkLintDriver extends GenericTrunkDriver {
           outputJson: JSON.parse(fs.readFileSync(resultJsonPath, { encoding: "utf-8" })),
         },
         "Format",
-        targetAbsPath
+        targetAbsPath,
       );
     } catch (error: any) {
       // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-member-access)

--- a/tests/driver/tool_driver.ts
+++ b/tests/driver/tool_driver.ts
@@ -73,7 +73,7 @@ export class TrunkToolDriver extends GenericTrunkDriver {
       // Retrieve the enabled version
       const newTrunkContents = fs.readFileSync(
         path.resolve(this.sandboxPath, ".trunk/trunk.yaml"),
-        "utf8"
+        "utf8",
       );
       const enabledVersionRegex = `(?<tool>${this.tool})@(?<version>.+)\n`;
       const foundIn = newTrunkContents.match(enabledVersionRegex);
@@ -105,7 +105,7 @@ export class TrunkToolDriver extends GenericTrunkDriver {
       // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)
       return (
         (this.getFullTrunkConfig().tool.definitions.find(
-          ({ name }: { name: string }) => name === this.tool
+          ({ name }: { name: string }) => name === this.tool,
         )?.known_good_version as string) ?? ""
       );
       // trunk-ignore-end(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -57,7 +57,7 @@ const conditionalTest = (
   skipTest: boolean,
   name: string,
   fn?: jest.ProvidesCallback | undefined,
-  timeout?: number | undefined
+  timeout?: number | undefined,
 ) => (skipTest ? it.skip(name, fn, timeout) : it(name, fn, timeout));
 
 export type TestCallback = (driver: TrunkLintDriver) => unknown;
@@ -105,13 +105,13 @@ export const setupDriver = (
   { setupGit = true, setupTrunk = true, trunkVersion = undefined }: SetupSettings,
   linterName?: string,
   version?: string,
-  preCheck?: TestCallback
+  preCheck?: TestCallback,
 ): TrunkLintDriver => {
   const driver = new TrunkLintDriver(
     dirname,
     { setupGit, setupTrunk, trunkVersion },
     linterName,
-    version
+    version,
   );
 
   beforeAll(async () => {
@@ -138,13 +138,13 @@ export const setupTrunkToolDriver = (
   { setupGit = true, setupTrunk = true, trunkVersion = undefined }: SetupSettings,
   toolName?: string,
   version?: string,
-  preCheck?: ToolTestCallback
+  preCheck?: ToolTestCallback,
 ): TrunkToolDriver => {
   const driver = new TrunkToolDriver(
     dirname,
     { setupGit, setupTrunk, trunkVersion },
     toolName,
-    version
+    version,
   );
 
   beforeAll(async () => {
@@ -276,12 +276,12 @@ export const customLinterCheckTest = ({
             testName,
             "check",
             driver.enabledVersion,
-            versionGreaterThanOrEqual
+            versionGreaterThanOrEqual,
           );
           debug("Using snapshot %s", path.basename(primarySnapshotPath));
           expect(testRunResult.landingState).toMatchSpecificSnapshot(
             primarySnapshotPath,
-            landingStateWrapper(testRunResult.landingState, primarySnapshotPath)
+            landingStateWrapper(testRunResult.landingState, primarySnapshotPath),
           );
 
           // Step 4b: Verify that any specified files match their expected snapshots for that linter version.
@@ -293,7 +293,7 @@ export const customLinterCheckTest = ({
               normalizedName,
               "check",
               driver.enabledVersion,
-              versionGreaterThanOrEqual
+              versionGreaterThanOrEqual,
             );
             debug("Using snapshot %s", path.basename(snapshotPath));
             expect(driver.readFile(pathToSnapshot)).toMatchSpecificSnapshot(snapshotPath);
@@ -378,7 +378,7 @@ export const customLinterFmtTest = ({
               normalizedName,
               "fmt",
               driver.enabledVersion,
-              versionGreaterThanOrEqual
+              versionGreaterThanOrEqual,
             );
             debug("Using snapshot %s", path.basename(snapshotPath));
             expect(driver.readFile(pathToSnapshot)).toMatchSpecificSnapshot(snapshotPath);
@@ -463,19 +463,19 @@ export const fuzzyLinterCheckTest = ({
             testName,
             "check",
             driver.enabledVersion,
-            versionGreaterThanOrEqual
+            versionGreaterThanOrEqual,
           );
           debug("Using snapshot %s", path.basename(primarySnapshotPath));
           expect(strippedLandingState).toMatchSpecificSnapshot(
             primarySnapshotPath,
-            landingStateWrapper(strippedLandingState, primarySnapshotPath)
+            landingStateWrapper(strippedLandingState, primarySnapshotPath),
           );
 
           // Step 4b: Verify that the fileIssues pass the assertion callback.
           debug("Checking against assertion callback");
           fileIssueAssertionCallback(
             testRunResult.landingState?.issues ?? [],
-            driver.enabledVersion
+            driver.enabledVersion,
           );
 
           if (postCheck) {
@@ -546,12 +546,12 @@ export const linterCheckTest = ({
               linterName,
               prefix,
               "check",
-              driver.enabledVersion
+              driver.enabledVersion,
             );
             debug("Using snapshot %s", path.basename(snapshotPath));
             expect(testRunResult.landingState).toMatchSpecificSnapshot(
               snapshotPath,
-              landingStateWrapper(testRunResult.landingState, snapshotPath)
+              landingStateWrapper(testRunResult.landingState, snapshotPath),
             );
 
             if (postCheck) {
@@ -625,12 +625,12 @@ export const linterFmtTest = ({
               linterName,
               prefix,
               "fmt",
-              driver.enabledVersion
+              driver.enabledVersion,
             );
             debug("Using snapshot %s", path.basename(snapshotPath));
             // trunk-ignore(eslint/@typescript-eslint/no-non-null-assertion)
             expect(fs.readFileSync(testRunResult.targetPath!, "utf-8")).toMatchSpecificSnapshot(
-              snapshotPath
+              snapshotPath,
             );
 
             if (postCheck) {

--- a/tests/jest_setup.ts
+++ b/tests/jest_setup.ts
@@ -19,7 +19,7 @@ expect.extend({
       throw new Error("Actual value must be an array of file issues");
     }
     const overlap = (actual as FileIssue[]).filter((actualIssue) =>
-      expected.some(fileIssueEquals(actualIssue))
+      expected.some(fileIssueEquals(actualIssue)),
     );
     const pass = overlap.length >= minimumOverlap;
     return {

--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -50,7 +50,7 @@ const parseTestStatus = (status: string): TestResultStatus => {
  */
 const mergeTestStatuses = (
   original: TestResultStatus,
-  incoming: TestResultStatus
+  incoming: TestResultStatus,
 ): TestResultStatus => {
   if (incoming == "failed") {
     return incoming;
@@ -239,12 +239,12 @@ const writeTestResults = (testResults: TestResultSummary) => {
       }
       return accumulator;
     },
-    []
+    [],
   );
   const failures = Array.from(testResults.linters).reduce(
     (
       accumulator: FailedVersion[],
-      [linter, { version, testResultStatus: status, allVersions }]
+      [linter, { version, testResultStatus: status, allVersions }],
     ) => {
       if (status !== "passed" && status !== "skipped") {
         const additionalFailedVersion: FailedVersion = { linter, version, status, allVersions };
@@ -252,7 +252,7 @@ const writeTestResults = (testResults: TestResultSummary) => {
       }
       return accumulator;
     },
-    []
+    [],
   );
 
   const resultsObject = {
@@ -275,11 +275,11 @@ const parseTestResultsAndWrite = () => {
   const testResults = Object.values(TestOS).map((os) => parseResultsJson(os));
   const totalParsedTests = testResults.reduce(
     (total, testResultsSummary) => total + testResultsSummary.linters.size,
-    0
+    0,
   );
   if (totalParsedTests === 0) {
     throw new Error(
-      "No tests were parsed. Output files should be named {ubuntu-latest-res.json|macos-latest-res.json}"
+      "No tests were parsed. Output files should be named {ubuntu-latest-res.json|macos-latest-res.json}",
     );
   }
 

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -42,7 +42,7 @@ describe("Global config health check", () => {
       expect(testRunResult.stdout).toContain("local:");
     } catch (error) {
       console.log(
-        "`trunk config print` failed. You likely have bad configuration or need to update trunkVersion in this test."
+        "`trunk config print` failed. You likely have bad configuration or need to update trunkVersion in this test.",
       );
       throw error;
     }
@@ -217,7 +217,7 @@ describe("Explicitly enabled healthcheck", () => {
 
         return enabledLinters;
       },
-      []
+      [],
     );
 
     // No linters should be enabled by default
@@ -231,7 +231,7 @@ describe("Explicitly enabled healthcheck", () => {
 
         return enabledActions;
       },
-      []
+      [],
     );
 
     // Built-in actions only

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -23,7 +23,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.12.1",
+    trunkVersion: "1.12.0",
     // ThenChange plugin.yaml
   });
 
@@ -42,7 +42,7 @@ describe("Global config health check", () => {
       expect(testRunResult.stdout).toContain("local:");
     } catch (error) {
       console.log(
-        "`trunk config print` failed. You likely have bad configuration or need to update trunkVersion in this test.",
+        "`trunk config print` failed. You likely have bad configuration or need to update trunkVersion in this test."
       );
       throw error;
     }
@@ -217,7 +217,7 @@ describe("Explicitly enabled healthcheck", () => {
 
         return enabledLinters;
       },
-      [],
+      []
     );
 
     // No linters should be enabled by default
@@ -231,7 +231,7 @@ describe("Explicitly enabled healthcheck", () => {
 
         return enabledActions;
       },
-      [],
+      []
     );
 
     // Built-in actions only

--- a/tests/repo_tests/no_missing_download.test.ts
+++ b/tests/repo_tests/no_missing_download.test.ts
@@ -26,17 +26,9 @@ describe("All linters that use downloads must define them", () => {
 
         yamlContents.lint?.definitions?.forEach((definition: any) => {
           if (definition.download) {
-            const downloads: string[] = [];
-            if (yamlContents.lint?.downloads) {
-              yamlContents.lint?.downloads.forEach((download: any) => {
-                downloads.push(download.name);
-              });
-            }
-            if (yamlContents.downloads) {
-              yamlContents.downloads.forEach((download: any) => {
-                downloads.push(download.name);
-              });
-            }
+            const downloads = (yamlContents.lint?.downloads ?? []).map(
+              (download: any) => download?.name
+            );
             expect(downloads).toContain(definition.download);
             // trunk-ignore-end(eslint)
           }

--- a/tests/repo_tests/no_missing_download.test.ts
+++ b/tests/repo_tests/no_missing_download.test.ts
@@ -27,7 +27,7 @@ describe("All linters that use downloads must define them", () => {
         yamlContents.lint?.definitions?.forEach((definition: any) => {
           if (definition.download) {
             const downloads = (yamlContents.lint?.downloads ?? []).map(
-              (download: any) => download?.name
+              (download: any) => download?.name,
             );
             expect(downloads).toContain(definition.download);
             // trunk-ignore-end(eslint)

--- a/tests/repo_tests/readme_inclusion.test.ts
+++ b/tests/repo_tests/readme_inclusion.test.ts
@@ -8,7 +8,7 @@ const abbreviationMapping = new Map<string, string>([["iwyu", "include-what-you-
 const readmeContents = fs.readFileSync(path.resolve(REPO_ROOT, "readme.md"), { encoding: "utf-8" });
 const readmeTableContents = readmeContents.substring(
   readmeContents.indexOf("### Supported Linters"),
-  readmeContents.indexOf("### Supported Trunk Actions")
+  readmeContents.indexOf("### Supported Trunk Actions"),
 );
 const reducedReadmeContents = readmeTableContents ? readmeTableContents : readmeContents;
 

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -88,7 +88,7 @@ export const getSnapshotName = (
   linterName: string,
   prefix: string,
   checkType: CheckType,
-  linterVersion?: string
+  linterVersion?: string,
 ) => {
   const normalizedName = linterName.replace(/-/g, "_");
   if (!linterVersion) {
@@ -123,11 +123,11 @@ export const getSnapshotPathForAssert = (
   prefix: string,
   checkType: CheckType,
   linterVersion?: string,
-  versionGreaterThanOrEqual?: (_a: string, _b: string) => boolean
+  versionGreaterThanOrEqual?: (_a: string, _b: string) => boolean,
 ): string => {
   const specificVersionSnapshotName = path.resolve(
     snapshotDirPath,
-    getSnapshotName(linterName, prefix, checkType, linterVersion)
+    getSnapshotName(linterName, prefix, checkType, linterVersion),
   );
 
   // If this is a versionless linter, don't specify a version.
@@ -181,7 +181,7 @@ export const getVersionsForTest = (
   dirname: string,
   linterName: string,
   prefix: string,
-  checkType: CheckType
+  checkType: CheckType,
 ) => {
   // TODO(Tyler): Add ARGS.linterVersion Query case for full matrix coverage
   let matchExists = false;
@@ -201,7 +201,7 @@ export const getVersionsForTest = (
   // Check if no snapshots exist yet. If this is the case, run with KnownGoodVersion and Latest, and print advisory text.
   if (!matchExists && !ARGS.linterVersion) {
     console.log(
-      `No snapshots detected for ${linterName} ${prefix} ${checkType} test. Running test against KnownGoodVersion. See tests/readme.md for more information.`
+      `No snapshots detected for ${linterName} ${prefix} ${checkType} test. Running test against KnownGoodVersion. See tests/readme.md for more information.`,
     );
     return ["KnownGoodVersion"];
   }

--- a/tests/utils/landing_state.ts
+++ b/tests/utils/landing_state.ts
@@ -23,7 +23,7 @@ const extractLintActionFields = ({
 
 const extractTaskFailureFields = (
   sandboxPath: string,
-  { detailPath, ...rest }: TaskFailure
+  { detailPath, ...rest }: TaskFailure,
 ): TaskFailure => ({
   ...rest,
   details: detailPath
@@ -84,7 +84,7 @@ const normalizeIssues = ({
  */
 const extractLandingStateFields = (
   sandboxPath: string,
-  { issues = [], unformattedFiles = [], lintActions = [], taskFailures = [] }: LandingState
+  { issues = [], unformattedFiles = [], lintActions = [], taskFailures = [] }: LandingState,
 ) =>
   <LandingState>{
     issues: sort(issues.map(normalizeIssues)).asc((issue) => [
@@ -109,7 +109,7 @@ const extractLandingStateFields = (
       action.paths,
     ]),
     taskFailures: sort(
-      taskFailures.map((failure) => extractTaskFailureFields(sandboxPath, failure))
+      taskFailures.map((failure) => extractTaskFailureFields(sandboxPath, failure)),
     ).asc((failure) => [failure.name, failure.message]),
   };
 
@@ -128,7 +128,7 @@ export const extractLandingState = (sandboxPath: string, json: unknown): Landing
  */
 export const tryParseLandingState = (
   sandboxPath: string,
-  outputJson: unknown
+  outputJson: unknown,
 ): LandingState | undefined => {
   if (!outputJson) {
     return undefined;


### PR DESCRIPTION
Backs out the tools changes so that Windows will work and so that the Release Version Service will be able to correctly query latest.

We will want to re-add this (and re-`fmt` once tools support is fully accounted for with regard to the Release Version Service and Windows).