### PR TITLE
Fix python download

### DIFF
--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -5,7 +5,6 @@ downloads:
       - os:
           linux: unknown-linux-gnu
           macos: apple-darwin
-          windows: pc-windows-msvc-shared
         cpu:
           x86_64: x86_64
           arm_64: aarch64
@@ -13,9 +12,15 @@ downloads:
         url: https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-${version}+20220318-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
       - os:
+          windows: pc-windows-msvc-shared
+        cpu:
+          x86_64: x86_64
+        version: <=3.10.3
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-${version}+20220318-${cpu}-${os}-install_only.tar.gz
+        strip_components: 1
+      - os:
           linux: unknown-linux-gnu
           macos: apple-darwin
-          windows: pc-windows-msvc-shared
         cpu:
           x86_64: x86_64
           arm_64: aarch64
@@ -23,12 +28,25 @@ downloads:
         url: https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-${version}+20221106-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
       - os:
-          linux: unknown-linux-gnu
-          macos: apple-darwin
           windows: pc-windows-msvc-shared
         cpu:
           x86_64: x86_64
+        version: <=3.10.8
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-${version}+20221106-${cpu}-${os}-install_only.tar.gz
+        strip_components: 1
+      - os:
+          linux: unknown-linux-gnu
+          macos: apple-darwin
+        cpu:
+          x86_64: x86_64
           arm_64: aarch64
+        version: <=3.11.1
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
+        strip_components: 1
+      - os:
+          windows: pc-windows-msvc-shared
+        cpu:
+          x86_64: x86_64
         version: <=3.11.1
         url: https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
         strip_components: 1


### PR DESCRIPTION
This was failing a download verification test since no such aarch64 Windows download exists.