### PR TITLE
Add test coverage of checkov suppressed issues

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.12.4-beta.6
+  version: 1.12.4-beta.7
 
 api:
   address: api.trunk-staging.io:8443

--- a/linters/checkov/test_data/basic_kubernetes.in.yaml
+++ b/linters/checkov/test_data/basic_kubernetes.in.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod1
+  annotations:
+    checkov.io/skip1: CKV_K8S_37=suppress this issue
 spec:
   containers:
     - name: main

--- a/linters/checkov/test_data/checkov_v2.3.259_basic_kubernetes.check.shot
+++ b/linters/checkov/test_data/checkov_v2.3.259_basic_kubernetes.check.shot
@@ -15,7 +15,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -33,7 +33,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -51,7 +51,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -69,7 +69,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -87,7 +87,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -105,7 +105,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -123,7 +123,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -141,7 +141,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -159,7 +159,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -177,7 +177,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -195,7 +195,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -213,7 +213,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -231,7 +231,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -249,25 +249,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
-          "offset": "56",
-        },
-      ],
-      "targetType": "yaml",
-    },
-    {
-      "code": "CKV_K8S_37",
-      "column": "1",
-      "file": "test_data/basic_kubernetes.in.yaml",
-      "isSecurity": true,
-      "level": "LEVEL_HIGH",
-      "line": "2",
-      "linter": "checkov",
-      "message": "Minimize the admission of containers with capabilities assigned",
-      "ranges": [
-        {
-          "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -285,7 +267,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -303,7 +285,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -321,7 +303,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -339,7 +321,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -357,7 +339,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],

--- a/linters/checkov/test_data/checkov_v2.3.264_basic_kubernetes.check.shot
+++ b/linters/checkov/test_data/checkov_v2.3.264_basic_kubernetes.check.shot
@@ -15,7 +15,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -33,7 +33,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -51,7 +51,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -69,7 +69,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -87,7 +87,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -105,7 +105,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -123,7 +123,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -141,7 +141,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -159,7 +159,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -177,7 +177,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -195,7 +195,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -213,7 +213,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -231,7 +231,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -249,25 +249,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
-          "offset": "56",
-        },
-      ],
-      "targetType": "yaml",
-    },
-    {
-      "code": "CKV_K8S_37",
-      "column": "1",
-      "file": "test_data/basic_kubernetes.in.yaml",
-      "isSecurity": true,
-      "level": "LEVEL_HIGH",
-      "line": "2",
-      "linter": "checkov",
-      "message": "Minimize the admission of containers with capabilities assigned",
-      "ranges": [
-        {
-          "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -285,7 +267,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -303,7 +285,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -321,7 +303,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -339,7 +321,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -357,7 +339,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],

--- a/linters/checkov/test_data/checkov_v2.3.75_basic_kubernetes.check.shot
+++ b/linters/checkov/test_data/checkov_v2.3.75_basic_kubernetes.check.shot
@@ -15,7 +15,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -33,7 +33,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -51,7 +51,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -69,7 +69,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -87,7 +87,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -105,7 +105,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -123,7 +123,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -141,7 +141,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -159,7 +159,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -177,7 +177,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -195,7 +195,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -213,7 +213,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -231,7 +231,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -249,25 +249,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
-          "offset": "56",
-        },
-      ],
-      "targetType": "yaml",
-    },
-    {
-      "code": "CKV_K8S_37",
-      "column": "1",
-      "file": "test_data/basic_kubernetes.in.yaml",
-      "isSecurity": true,
-      "level": "LEVEL_HIGH",
-      "line": "2",
-      "linter": "checkov",
-      "message": "Minimize the admission of containers with capabilities assigned",
-      "ranges": [
-        {
-          "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -285,7 +267,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -303,7 +285,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -321,7 +303,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -339,7 +321,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],
@@ -357,7 +339,7 @@ exports[`Testing linter checkov test basic_kubernetes 1`] = `
       "ranges": [
         {
           "filePath": "test_data/basic_kubernetes.in.yaml",
-          "length": "105",
+          "length": "173",
           "offset": "56",
         },
       ],

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -88,6 +88,7 @@ export class GenericTrunkDriver {
    */
   async setUp() {
     this.sandboxPath = fs.realpathSync(fs.mkdtempSync(path.resolve(os.tmpdir(), TEMP_PREFIX)));
+    fs.mkdirSync(path.resolve(this.sandboxPath, TEMP_SUBDIR));
     this.debug("Created sandbox path %s from %s", this.sandboxPath, this.testDir);
     if (!this.sandboxPath) {
       return;


### PR DESCRIPTION
When a checkov issue is ignored, it shows up as suppressed in the sarif output. We just fixed our sarif parsing in the CLI, so this adds additional test coverage of this case.