### PR TITLE
Fix nightly runs by including config files

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -81,6 +81,7 @@ jobs:
           cp package-lock.json package-lock.json.bak
           cp -r .github/actions .github/actions.bak
           cp -r .trunk .trunk.bak
+          cp tsconfig.json .tsconfig.json.bak
           # Include any newly generated snapshots that have been marked release-ready
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
         continue-on-error: true
@@ -113,6 +114,7 @@ jobs:
           mv .github/actions.bak .github/actions
           rm -rf .trunk
           mv .trunk.bak .trunk
+          mv tsconfig.json.bak tsconfig.json
           # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
         continue-on-error: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -83,7 +83,6 @@ jobs:
           cp -r .trunk .trunk.bak
           cp tsconfig.json .tsconfig.json.bak
           cp jest.config.json jest.config.json.bak
-          cp jest_setup.ts jest_setup.ts.bak
           # Include any newly generated snapshots that have been marked release-ready
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
         continue-on-error: true
@@ -118,7 +117,6 @@ jobs:
           mv .trunk.bak .trunk
           mv tsconfig.json.bak tsconfig.json
           mv jest.config.json.bak jest.config.json
-          mv jest_setup.ts.bak jest_setup.ts
           # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
         continue-on-error: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -82,6 +82,8 @@ jobs:
           cp -r .github/actions .github/actions.bak
           cp -r .trunk .trunk.bak
           cp tsconfig.json .tsconfig.json.bak
+          cp jest.config.json jest.config.json.bak
+          cp jest_setup.ts jest_setup.ts.bak
           # Include any newly generated snapshots that have been marked release-ready
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
         continue-on-error: true
@@ -115,6 +117,8 @@ jobs:
           rm -rf .trunk
           mv .trunk.bak .trunk
           mv tsconfig.json.bak tsconfig.json
+          mv jest.config.json.bak jest.config.json
+          mv jest_setup.ts.bak jest_setup.ts
           # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
         continue-on-error: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -81,7 +81,7 @@ jobs:
           cp package-lock.json package-lock.json.bak
           cp -r .github/actions .github/actions.bak
           cp -r .trunk .trunk.bak
-          cp tsconfig.json .tsconfig.json.bak
+          cp tsconfig.json tsconfig.json.bak
           cp jest.config.json jest.config.json.bak
           # Include any newly generated snapshots that have been marked release-ready
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -83,6 +83,7 @@ jobs:
           cp -r .trunk .trunk.bak
           cp tsconfig.json tsconfig.json.bak
           cp jest.config.json jest.config.json.bak
+          cp .gitattributes .gitattributes.bak
           # Include any newly generated snapshots that have been marked release-ready
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
         continue-on-error: true
@@ -117,6 +118,7 @@ jobs:
           mv .trunk.bak .trunk
           mv tsconfig.json.bak tsconfig.json
           mv jest.config.json.bak jest.config.json
+          mv .gitattributes.bak .gitattributes
           # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
           grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
         continue-on-error: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "es2021",
     "module": "commonjs",
     "moduleResolution": "Node",
-    "lib": ["es2019", "dom", "ES2021.String"],
+    "lib": ["es2021", "dom"],
     "jsx": "preserve",
     "sourceMap": true,
     "outDir": "out",


### PR DESCRIPTION
Includes jest and TS config files in order to make sure they are synced with the `tests/` dir when we run tests on the latest release. Tested this with a nightly run, see [here](https://github.com/trunk-io/plugins/actions/runs/5626846276/job/15248423685).