### PR TITLE
Add `--ini` to bandit command

### DIFF
--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -11,7 +11,7 @@ lint:
         - name: lint
           # Custom parser type defined in the trunk cli to handle bandit's JSON output.
           output: bandit
-          run: bandit --exit-zero --format json --output ${tmpfile} -r ${target}
+          run: bandit --exit-zero --ini .bandit --format json --output ${tmpfile} ${target}
           success_codes: [0]
           read_output_from: tmp_file
           batch: true

--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -11,7 +11,7 @@ lint:
         - name: lint
           # Custom parser type defined in the trunk cli to handle bandit's JSON output.
           output: bandit
-          run: bandit --exit-zero --format json --output ${tmpfile} ${target}
+          run: bandit -r --exit-zero --format json --output ${tmpfile} ${target}
           success_codes: [0]
           read_output_from: tmp_file
           batch: true

--- a/linters/bandit/plugin.yaml
+++ b/linters/bandit/plugin.yaml
@@ -11,7 +11,7 @@ lint:
         - name: lint
           # Custom parser type defined in the trunk cli to handle bandit's JSON output.
           output: bandit
-          run: bandit -r --exit-zero --format json --output ${tmpfile} ${target}
+          run: bandit --exit-zero --format json --output ${tmpfile} -r ${target}
           success_codes: [0]
           read_output_from: tmp_file
           batch: true


### PR DESCRIPTION
The [docs](https://bandit.readthedocs.io/en/latest/config.html) state:

```
Note that Bandit will look for .bandit file only if it is invoked with -r option. If you do not use -r or the INI file’s name is not .bandit, you can specify the file’s path explicitly with –ini option, e.g.
```
So without this value, there is no way to edit the bandit config