### PR TITLE
Fix Nightly linter cli integration tests

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -45,6 +45,7 @@ runs:
       run: |
         case "$RUNNER_OS" in
           Linux)
+            sudo apt-get update
             sudo apt-get -y install libperl-critic-perl perltidy
             ;;
           macOS)


### PR DESCRIPTION
I think it's only missing an apt update in the nightly linter/cli integration test