### PR TITLE
Fix autopep8 by pinning pycodestyle version

### DIFF
--- a/linters/autopep8/plugin.yaml
+++ b/linters/autopep8/plugin.yaml
@@ -14,6 +14,7 @@ lint:
           formatter: true
       runtime: python
       package: autopep8
+      extra_packages: [pycodestyle@2.10.0]
       suggest_if: config_present
       direct_configs: [.pep8]
       affects_cache:


### PR DESCRIPTION
`pycodestyle` [released](https://pypi.org/project/pycodestyle/#history) a breaking version on Saturday that breaks all new installs of autopep8. We can pin an older version in order to temporarily resolve this for our users. I know we said we want to avoid this sort of a fix, but I don't think we have a fix for now other than pinning.