### PR TITLE
Support ruby linters on Windows

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.13.1-beta.8
+  version: 1.13.1-beta.14
 
 api:
   address: api.trunk-staging.io:8443
@@ -15,7 +15,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.4
+      ref: v0.0.6
 
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin

--- a/linters/brakeman/brakeman.test.ts
+++ b/linters/brakeman/brakeman.test.ts
@@ -7,5 +7,5 @@ jest.setTimeout(300000 * osTimeoutMultiplier); // 300s or 900s
 customLinterCheckTest({
   linterName: "brakeman",
   args: TEST_DATA,
-  skipTestIf: skipOS(["darwin", "win32"]),
+  skipTestIf: skipOS(["darwin"]),
 });

--- a/linters/cspell/test_data/cspell_v6.13.1_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.13.1_basic.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter cspell test basic 1`] = `
 {

--- a/linters/cspell/test_data/cspell_v6.24.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.24.0_basic.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter cspell test basic 1`] = `
 {

--- a/linters/cspell/test_data/cspell_v6.26.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.26.0_basic.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter cspell test basic 1`] = `
 {

--- a/linters/cspell/test_data/cspell_v6.5.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.5.0_basic.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter cspell test basic 1`] = `
 {

--- a/linters/haml-lint/haml_lint.test.ts
+++ b/linters/haml-lint/haml_lint.test.ts
@@ -5,5 +5,5 @@ import { skipOS } from "tests/utils";
 customLinterCheckTest({
   linterName: "haml-lint",
   args: "-a",
-  skipTestIf: skipOS(["darwin", "win32"]),
+  skipTestIf: skipOS(["darwin"]),
 });

--- a/linters/rubocop/rubocop.test.ts
+++ b/linters/rubocop/rubocop.test.ts
@@ -5,11 +5,14 @@ import { skipOS, TEST_DATA } from "tests/utils";
 
 const preCheck = (driver: TrunkLintDriver) => {
   if (process.platform == "win32") {
-    driver.writeFile(".rubocop.yml", `Layout/EndOfLine:
+    driver.writeFile(
+      ".rubocop.yml",
+      `Layout/EndOfLine:
   Enabled: false
-`);
+`,
+    );
   }
-}
+};
 
 // Ruby build is quite slow on Mac, so only run tests on linux for now
 customLinterCheckTest({

--- a/linters/rubocop/rubocop.test.ts
+++ b/linters/rubocop/rubocop.test.ts
@@ -5,7 +5,7 @@ import { skipOS, TEST_DATA } from "tests/utils";
 
 const preCheck = (driver: TrunkLintDriver) => {
   if (process.platform == "win32") {
-    driver.writeFileSync(".rubocop.yml", `Layout/EndOfLine:
+    driver.writeFile(".rubocop.yml", `Layout/EndOfLine:
   Enabled: false
 `);
   }

--- a/linters/rubocop/rubocop.test.ts
+++ b/linters/rubocop/rubocop.test.ts
@@ -1,13 +1,23 @@
 import path from "path";
 import { customLinterCheckTest, customLinterFmtTest } from "tests";
+import { TrunkLintDriver } from "tests/driver";
 import { skipOS, TEST_DATA } from "tests/utils";
+
+const preCheck = (driver: TrunkLintDriver) => {
+  if (process.platform == "win32") {
+    driver.writeFileSync(".rubocop.yml", `Layout/EndOfLine:
+  Enabled: false
+`);
+  }
+}
 
 // Ruby build is quite slow on Mac, so only run tests on linux for now
 customLinterCheckTest({
   linterName: "rubocop",
   testName: "basic",
   args: "-a",
-  skipTestIf: skipOS(["darwin", "win32"]),
+  preCheck,
+  skipTestIf: skipOS(["darwin"]),
 });
 
 customLinterFmtTest({
@@ -15,5 +25,6 @@ customLinterFmtTest({
   testName: "basic",
   args: "-a",
   pathsToSnapshot: [path.join(TEST_DATA, "basic.rb")],
-  skipTestIf: skipOS(["darwin", "win32"]),
+  preCheck,
+  skipTestIf: skipOS(["darwin"]),
 });

--- a/linters/rufo/rufo.test.ts
+++ b/linters/rufo/rufo.test.ts
@@ -11,7 +11,7 @@ customLinterCheckTest({
   linterName: "rufo",
   testName: "empty",
   args: "-a",
-  skipTestIf: skipOS(["darwin", "win32"]),
+  skipTestIf: skipOS(["darwin"]),
 });
 
 customLinterFmtTest({
@@ -19,5 +19,5 @@ customLinterFmtTest({
   testName: "basic",
   args: "-a",
   pathsToSnapshot: [path.join(TEST_DATA, "basic.rb")],
-  skipTestIf: skipOS(["darwin", "win32"]),
+  skipTestIf: skipOS(["darwin"]),
 });

--- a/linters/standardrb/standardrb.test.ts
+++ b/linters/standardrb/standardrb.test.ts
@@ -1,9 +1,20 @@
 import { customLinterCheckTest } from "tests";
+import { TrunkLintDriver } from "tests/driver";
 import { skipOS } from "tests/utils";
+
+const preCheck = (driver: TrunkLintDriver) => {
+  if (process.platform == "win32") {
+    driver.writeFile(".standard.yml", `ignore:
+  - '**/*':
+    - Layout/EndOfLine
+`);
+}
+}
 
 // Ruby build is quite slow on Mac, so only run tests on linux for now
 customLinterCheckTest({
   linterName: "standardrb",
   args: "-a",
-  skipTestIf: skipOS(["darwin", "win32"]),
+  preCheck,
+  skipTestIf: skipOS(["darwin"]),
 });

--- a/linters/standardrb/standardrb.test.ts
+++ b/linters/standardrb/standardrb.test.ts
@@ -4,12 +4,15 @@ import { skipOS } from "tests/utils";
 
 const preCheck = (driver: TrunkLintDriver) => {
   if (process.platform == "win32") {
-    driver.writeFile(".standard.yml", `ignore:
+    driver.writeFile(
+      ".standard.yml",
+      `ignore:
   - '**/*':
     - Layout/EndOfLine
-`);
-}
-}
+`,
+    );
+  }
+};
 
 // Ruby build is quite slow on Mac, so only run tests on linux for now
 customLinterCheckTest({

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.13.1-beta.8"
+required_trunk_version: ">=1.13.1-beta.14"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/readme.md
+++ b/readme.md
@@ -33,53 +33,53 @@ Enable the following tools via:
 trunk check enable {linter}
 ```
 
-| Technology      | Linters                                                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------------------------------- |
-| All             | [codespell], [cspell], [gitleaks], [git-diff-check]                                                                 |
-| Ansible         | [ansible-lint]                                                                                                      |
-| Apex            | [pmd]                                                                                                               |
-| Bash            | [shellcheck], [shfmt]                                                                                               |
-| Bazel, Starlark | [buildifier]                                                                                                        |
-| C, C++          | [clang-format], [clang-tidy], [include-what-you-use], [pragma-once]                                                 |
-| CircleCI Config | [circleci]                                                                                                          |
-| Cloudformation  | [cfnlint], [checkov]                                                                                                |
-| CSS, SCSS       | [stylelint]                                                                                                         |
-| Cue             | [cue-fmt]                                                                                                           |
-| Docker          | [hadolint], [checkov]                                                                                               |
-| Dotenv          | [dotenv-linter]                                                                                                     |
-| GitHub          | [actionlint]                                                                                                        |
-| Go              | [gofmt], [gofumpt], [goimports], [gokart], [golangci-lint], [golines], [semgrep]                                    |
-| GraphQL         | [graphql-schema-linter]                                                                                             |
-| HAML            | [haml-lint]                                                                                                         |
-| HTML Templates  | [djlint]                                                                                                            |
-| Java            | [google-java-format], [pmd], [semgrep]                                                                              |
-| Javascript      | [eslint], [prettier], [rome], [semgrep]                                                                             |
-| JSON            | [eslint], [prettier], [semgrep]                                                                                     |
-| Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>, [ktlint]                                                           |
-| Kubernetes      | [kube-linter]                                                                                                       |
-| Lua             | [stylua]                                                                                                            |
-| Markdown        | [markdownlint], [remark-lint]                                                                                       |
-| Nix             | [nixpkgs-fmt]                                                                                                       |
-| package.json    | [sort-package-json]                                                                                                 |
-| Perl            | [perlcritic], [perltidy]                                                                                            |
-| PNG             | [oxipng]                                                                                                            |
-| Prisma          | [prisma]                                                                                                            |
-| Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                                                    |
-| Python          | [autopep8], [bandit], [black], [flake8], [isort], [mypy], [pylint], [pyright] [semgrep], [yapf], [ruff], [sourcery] |
-| Renovate        | [renovate]                                                                                                          |
-| Ruby            | [brakeman], [rubocop], [rufo], [semgrep], [standardrb]                                                              |
-| Rust            | [clippy], [rustfmt]                                                                                                 |
-| Scala           | [scalafmt]                                                                                                          |
-| Security        | [checkov], [dustilock], [nancy], [osv-scanner], [tfsec], [trivy], [trufflehog], [terrascan]                         |
-| SQL             | [sqlfluff], [sqlfmt], [sql-formatter]                                                                               |
-| SVG             | [svgo]                                                                                                              |
-| Swift           | [stringslint], [swiftlint], [swiftformat]                                                                           |
-| Terraform       | [terraform] (validate and fmt), [checkov], [tflint]<sup><a href="#note-tflint">2</a></sup>, [tfsec], [terrascan]    |
-| Terragrunt      | [terragrunt]                                                                                                        |
-| Textproto       | [txtpbfmt]                                                                                                          |
-| TOML            | [taplo]                                                                                                             |
-| Typescript      | [eslint], [prettier], [rome], [semgrep]                                                                             |
-| YAML            | [prettier], [semgrep], [yamllint]                                                                                   |
+| Technology      | Linters                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| All             | [codespell], [cspell], [gitleaks], [git-diff-check]                                                                  |
+| Ansible         | [ansible-lint]                                                                                                       |
+| Apex            | [pmd]                                                                                                                |
+| Bash            | [shellcheck], [shfmt]                                                                                                |
+| Bazel, Starlark | [buildifier]                                                                                                         |
+| C, C++          | [clang-format], [clang-tidy], [include-what-you-use], [pragma-once]                                                  |
+| CircleCI Config | [circleci]                                                                                                           |
+| Cloudformation  | [cfnlint], [checkov]                                                                                                 |
+| CSS, SCSS       | [stylelint]                                                                                                          |
+| Cue             | [cue-fmt]                                                                                                            |
+| Docker          | [hadolint], [checkov]                                                                                                |
+| Dotenv          | [dotenv-linter]                                                                                                      |
+| GitHub          | [actionlint]                                                                                                         |
+| Go              | [gofmt], [gofumpt], [goimports], [gokart], [golangci-lint], [golines], [semgrep]                                     |
+| GraphQL         | [graphql-schema-linter]                                                                                              |
+| HAML            | [haml-lint]                                                                                                          |
+| HTML Templates  | [djlint]                                                                                                             |
+| Java            | [google-java-format], [pmd], [semgrep]                                                                               |
+| Javascript      | [eslint], [prettier], [rome], [semgrep]                                                                              |
+| JSON            | [eslint], [prettier], [semgrep]                                                                                      |
+| Kotlin          | [detekt]<sup><a href="#note-detekt">1</a></sup>, [ktlint]                                                            |
+| Kubernetes      | [kube-linter]                                                                                                        |
+| Lua             | [stylua]                                                                                                             |
+| Markdown        | [markdownlint], [remark-lint]                                                                                        |
+| Nix             | [nixpkgs-fmt]                                                                                                        |
+| package.json    | [sort-package-json]                                                                                                  |
+| Perl            | [perlcritic], [perltidy]                                                                                             |
+| PNG             | [oxipng]                                                                                                             |
+| Prisma          | [prisma]                                                                                                             |
+| Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                                                     |
+| Python          | [autopep8], [bandit], [black], [flake8], [isort], [mypy], [pylint], [pyright], [semgrep], [yapf], [ruff], [sourcery] |
+| Renovate        | [renovate]                                                                                                           |
+| Ruby            | [brakeman], [rubocop], [rufo], [semgrep], [standardrb]                                                               |
+| Rust            | [clippy], [rustfmt]                                                                                                  |
+| Scala           | [scalafmt]                                                                                                           |
+| Security        | [checkov], [dustilock], [nancy], [osv-scanner], [tfsec], [trivy], [trufflehog], [terrascan]                          |
+| SQL             | [sqlfluff], [sqlfmt], [sql-formatter]                                                                                |
+| SVG             | [svgo]                                                                                                               |
+| Swift           | [stringslint], [swiftlint], [swiftformat]                                                                            |
+| Terraform       | [terraform] (validate and fmt), [checkov], [tflint]<sup><a href="#note-tflint">2</a></sup>, [tfsec], [terrascan]     |
+| Terragrunt      | [terragrunt]                                                                                                         |
+| Textproto       | [txtpbfmt]                                                                                                           |
+| TOML            | [taplo]                                                                                                              |
+| Typescript      | [eslint], [prettier], [rome], [semgrep]                                                                              |
+| YAML            | [prettier], [semgrep], [yamllint]                                                                                    |
 
 [actionlint]: https://github.com/rhysd/actionlint#readme
 [ansible-lint]: https://github.com/ansible/ansible-lint#readme

--- a/runtimes/ruby/plugin.yaml
+++ b/runtimes/ruby/plugin.yaml
@@ -3,13 +3,23 @@ downloads:
   - name: ruby-build
     version: 20230124
     downloads:
-      - url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230124.tar.gz
+      - os:
+          linux: linux
+          macos: macos
+        url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230124.tar.gz
+        strip_components: 1
+  - name: ruby-install
+    version: 3.2.2
+    downloads:
+      # Functionally a separate download used for Windows only. Runs OOTB and does not require a prepare build step.
+      - os: windows
+        url: https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${version}-1/rubyinstaller-${version}-1-x86.7z
         strip_components: 1
 
 runtimes:
   definitions:
     - type: ruby
-      supported_platforms: [linux, macos]
+      # implicitly changed to ruby-install when running on Windows
       download: ruby-build
       runtime_environment:
         - name: HOME
@@ -31,7 +41,10 @@ runtimes:
           value: ${linter}
         - name: GEM_PATH
           value: ${linter}
-      known_good_version: 3.1.0
+        - name: SYSTEMDRIVE
+          value: ${env.SYSTEMDRIVE}
+          optional: true
+      known_good_version: 3.2.2
       version_commands:
         - run: ruby --version
           parse_regex: ruby ([0-9\.]+)(p+.*)

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -23,7 +23,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.13.1-beta.8",
+    trunkVersion: "1.13.1-beta.14",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
Adds config changes to support ruby linters. Some notes:
- `haml-lint` and `standardrb` require two install invocations at the moment when installing with docs
- `rubocop` and `standardrb` require some test setup in order to avoid noisy diagnostics about carriage returns
- Use a separate download of `ruby` that gets implicitly set during config loading on Windows.

Requires a CLI version bump. Also tagged cspell snapshots for release.