### PR TITLE
Encapsulate detekt-gradle JAVA_HOME logic

### DIFF
--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -5,14 +5,12 @@ import * as os from "os";
 import path from "path";
 import * as git from "simple-git";
 import { SetupSettings } from "tests/driver";
-import { ARGS, REPO_ROOT, TEST_DATA } from "tests/utils";
+import { ARGS, DOWNLOAD_CACHE, REPO_ROOT, TEMP_PREFIX, TEST_DATA } from "tests/utils";
 import { getTrunkConfig, newTrunkYamlContents } from "tests/utils/trunk_config";
 import * as util from "util";
 import YAML from "yaml";
 
 const execFilePromise = util.promisify(execFile);
-
-const TEMP_PREFIX = "plugins_";
 
 const TEMP_SUBDIR = "tmp";
 
@@ -25,10 +23,7 @@ export const executionEnv = (sandbox: string) => {
   return {
     ...strippedEnv,
     // This keeps test downloads separate from manual trunk invocations
-    TRUNK_DOWNLOAD_CACHE: path.resolve(
-      fs.realpathSync(os.tmpdir()),
-      `${TEMP_PREFIX}testing_download_cache`,
-    ),
+    TRUNK_DOWNLOAD_CACHE: DOWNLOAD_CACHE,
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
   };

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,11 +1,17 @@
 import Debug from "debug";
 import fs from "fs";
+import * as os from "os";
 import path from "path";
 import semver from "semver";
 import { CheckType, LandingState, LinterVersion, TaskFailure, TestingArguments } from "tests/types";
 
 export const REPO_ROOT = path.resolve(__dirname, "../..");
 export const TEST_DATA = "test_data";
+export const TEMP_PREFIX = "plugins_";
+export const DOWNLOAD_CACHE = path.resolve(
+  fs.realpathSync(os.tmpdir()),
+  `${TEMP_PREFIX}testing_download_cache`,
+);
 
 // As this file and folder increase in complexity, extract out functionality into other categories.
 // Avoid overpolluting a `utils` folder.
@@ -216,6 +222,24 @@ export const getVersionsForTest = (
     return [ARGS.linterVersion];
   }
   return [undefined];
+};
+
+/**
+ * Helper function to step N directories into a path. Throws if unavailable
+ */
+export const recurseLevels = (starterPath: string, n: number) => {
+  let currentPath = starterPath;
+  for (let i = 0; i < n; i++) {
+    const contents = fs.readdirSync(currentPath);
+    for (const file of contents) {
+      if (fs.lstatSync(path.resolve(currentPath, file)).isDirectory()) {
+        currentPath = path.resolve(currentPath, file);
+        break;
+      }
+      throw new Error(`Could not find directory inside of ${currentPath}`);
+    }
+  }
+  return currentPath;
 };
 
 /**


### PR DESCRIPTION
Ensure we use our hermetic install of Java for detekt-gradle tests, without having to specify it at the workflow level. Tested successfully in the cross-repo workflow.