### PR TITLE
Support taplo on windows

### DIFF
--- a/linters/taplo/plugin.yaml
+++ b/linters/taplo/plugin.yaml
@@ -22,10 +22,10 @@ downloads:
         version: ">=0.8.0"
         url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-darwin-aarch64.gz
       # https://github.com/tamasfe/taplo/issues/397
-      # - os: windows
-      #   cpu: x86_64
-      #   version: ">=0.8.0"
-      #   url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-windows-x86_64.zip
+      - os: windows
+        cpu: x86_64
+        version: ">=0.8.0"
+        url: https://github.com/tamasfe/taplo/releases/download/${semver}/taplo-windows-x86_64.zip
 
       # Versions >=0.6.7
       - os: linux

--- a/linters/taplo/taplo.test.ts
+++ b/linters/taplo/taplo.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import semver from "semver";
 import { customLinterCheckTest } from "tests";
-import { skipOS, TEST_DATA } from "tests/utils";
+import { TEST_DATA } from "tests/utils";
 
 // taplo doesn't use semver versioning
 // Examples of taplo versions include release-cli-0.6.0, release-taplo-cli-0.7.0, 0.8.0
@@ -17,5 +17,4 @@ customLinterCheckTest({
   args: "-a -y",
   pathsToSnapshot: [path.join(TEST_DATA, "basic.toml")],
   versionGreaterThanOrEqual,
-  skipTestIf: skipOS(["win32"]),
 });


### PR DESCRIPTION
We can now run taplo. Minimum version needs to be 0.8.0 fyi so that we can correctly query latest (we need a download to be present for `known_good_version`--this is a shortcoming of our querying mechanism in the context of multiple platforms).