### PR TITLE
Support pmd on Windows

### DIFF
--- a/linters/pmd/plugin.yaml
+++ b/linters/pmd/plugin.yaml
@@ -12,6 +12,15 @@ lint:
       download: pmd
       commands:
         - name: lint-apex
+          platforms: [windows]
+          output: sarif
+          # Override this in your repo if you have a custom rulesets
+          run: pmd.bat -R rulesets/apex/quickstart.xml -f sarif -d ${target}
+          success_codes: [0, 4]
+          read_output_from: stdout
+          files:
+            - apex
+        - name: lint-apex
           output: sarif
           # Override this in your repo if you have a custom rulesets
           run: run.sh pmd -R rulesets/apex/quickstart.xml -f sarif -d ${target}
@@ -19,6 +28,15 @@ lint:
           read_output_from: stdout
           files:
             - apex
+        - name: lint-java
+          platforms: [windows]
+          output: sarif
+          # Override this in your repo if you have a custom rulesets
+          run: pmd.bat -R rulesets/java/quickstart.xml -f sarif -d ${target}
+          success_codes: [0, 4]
+          read_output_from: stdout
+          files:
+            - java
         - name: lint-java
           output: sarif
           # Override this in your repo if you have a custom rulesets


### PR DESCRIPTION
Requires a separate platform subcommand, which resolves to the batch script. Note that until we fix overrides, this will break the ability to override run commands here.