### PR TITLE
Support querying latest on Windows

### DIFF
--- a/linters/cspell/test_data/cspell_v6.13.1_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.13.1_basic.check.shot
@@ -5,6 +5,16 @@ exports[`Testing linter cspell test basic 1`] = `
   "issues": [
     {
       "code": "error",
+      "column": "1",
+      "file": ".trunk/trunk.yaml",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "cspell",
+      "message": "Unknown word (runtimes) Suggestions: [runtime, runtiness, runtiest, runtier, rutiles]",
+      "targetType": "ALL",
+    },
+    {
+      "code": "error",
       "column": "6",
       "file": "cspell.test.ts",
       "level": "LEVEL_HIGH",

--- a/linters/cspell/test_data/cspell_v6.24.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.24.0_basic.check.shot
@@ -5,6 +5,16 @@ exports[`Testing linter cspell test basic 1`] = `
   "issues": [
     {
       "code": "error",
+      "column": "1",
+      "file": ".trunk/trunk.yaml",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "cspell",
+      "message": "Unknown word (runtimes) Suggestions: [runtime, runtiness, runtiest, runtier, rutiles]",
+      "targetType": "ALL",
+    },
+    {
+      "code": "error",
       "column": "6",
       "file": "cspell.test.ts",
       "level": "LEVEL_HIGH",

--- a/linters/cspell/test_data/cspell_v6.26.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.26.0_basic.check.shot
@@ -5,6 +5,16 @@ exports[`Testing linter cspell test basic 1`] = `
   "issues": [
     {
       "code": "error",
+      "column": "1",
+      "file": ".trunk/trunk.yaml",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "cspell",
+      "message": "Unknown word (runtimes) Suggestions: [runtime, runtiness, runtiest, runtier, rutiles]",
+      "targetType": "ALL",
+    },
+    {
+      "code": "error",
       "column": "6",
       "file": "cspell.test.ts",
       "level": "LEVEL_HIGH",

--- a/linters/cspell/test_data/cspell_v6.5.0_basic.check.shot
+++ b/linters/cspell/test_data/cspell_v6.5.0_basic.check.shot
@@ -5,6 +5,16 @@ exports[`Testing linter cspell test basic 1`] = `
   "issues": [
     {
       "code": "error",
+      "column": "1",
+      "file": ".trunk/trunk.yaml",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "cspell",
+      "message": "Unknown word (runtimes) Suggestions: [runtime, runtiness, runtiest, runtier, rutiles]",
+      "targetType": "ALL",
+    },
+    {
+      "code": "error",
       "column": "6",
       "file": "cspell.test.ts",
       "level": "LEVEL_HIGH",

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -40,7 +40,7 @@ const testCreationFilter = (topLevelDir: string) => (file: string) => {
 
   const { base, dir } = path.parse(file);
   // If top-level, only copy plugin.yaml, test file, test_data, and parsers
-  if (base !== TEST_DATA && dir === topLevelDir) {
+  if (base !== TEST_DATA && dir.endsWith(topLevelDir)) {
     return (
       base === "plugin.yaml" ||
       base.endsWith(".test.ts") ||

--- a/tests/utils/trunk_config.ts
+++ b/tests/utils/trunk_config.ts
@@ -40,6 +40,13 @@ plugins:
   sources:
   - id: trunk
     local: ${REPO_ROOT}
+runtimes:
+  enabled:
+    # required in order to query latest
+    - go@1.19.5
+    - node@18.12.1
+    - python@3.10.8
+    - ruby@3.1.3
 lint:
   ignore:
     - linters: [ALL]

--- a/tests/utils/trunk_config.ts
+++ b/tests/utils/trunk_config.ts
@@ -36,10 +36,6 @@ export const getTrunkVersion = (): string => {
 export const newTrunkYamlContents = (trunkVersion?: string): string => `version: 0.1
 cli:
   version: ${trunkVersion ?? getTrunkVersion()}
-plugins:
-  sources:
-  - id: trunk
-    local: ${REPO_ROOT}
 runtimes:
   enabled:
     # required in order to query latest
@@ -47,6 +43,10 @@ runtimes:
     - node@18.12.1
     - python@3.10.8
     - ruby@3.1.3
+plugins:
+  sources:
+  - id: trunk
+    local: ${REPO_ROOT}
 lint:
   ignore:
     - linters: [ALL]


### PR DESCRIPTION
We need to have the runtime in the PATH in order to query latest. On most of the Linux setups, we inherit the system PATH intentionally for these queries, which usually resolves npm/node. But on Windows (and for hermeticity), we need to use our managed runtimes to query. Setup every test with these runtimes enabled and downloaded so that we can query.

This is a bandaid but should be sufficient since in most cases this command is invoked with runtimes already enabled and/or just for the plugins testing.

Also fixes cspell tests on Windows by modifying the `testCreationFilter`.