### PR TITLE
Bump workflow timeouts

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,7 @@ jobs:
   linter_tests_main:
     name: Plugin Tests Main
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -51,13 +51,14 @@ jobs:
         with:
           linter-version: ${{ matrix.linter-version }}
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
   # Run tests against all linters for snapshots and latest version as they exist in latest release
   # This job is used to update the list of validated versions
   linter_tests_release:
     name: Plugin Tests Release
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +151,7 @@ jobs:
           linter-version: ${{ matrix.linter-version }}
           append-args: linters -- --json --outputFile=${{ matrix.os }}-res.json
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
       # TODO(lauri): For now this just runs on the hardcoded versions. We should configure this
       # akin to the linter_tests job.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,7 +92,7 @@ jobs:
       needs.detect_changes.outputs.linters == 'true' || needs.detect_changes.outputs.all-linters ==
       'linters' || needs.detect_changes.outputs.tools == 'true' ||
       needs.detect_changes.outputs.all-tools == 'tools'
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/repo_tests.reusable.yaml
+++ b/.github/workflows/repo_tests.reusable.yaml
@@ -19,7 +19,7 @@ jobs:
   plugins_test:
     name: Plugin Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- Bump nightly timeouts to 120 ([timeout here](https://github.com/trunk-io/plugins/actions/runs/5782590508) and [here](https://github.com/trunk-io/plugins/actions/runs/5794365457/job/15705637567)). This is likely an overestimate, but the test times could inflate soon due to additional tools
- Preemptively bump PR and repo test timeouts as well. This isn't a problem yet, and will only be a problem in the worst case in the future as more tool tests are added

It may soon be time for investigating faster runners or better impacted target detection to reduce PR test times.