### PR TITLE
Separate functional eponymous tools into their own directories

### DIFF
--- a/linters/ansible-lint/plugin.yaml
+++ b/linters/ansible-lint/plugin.yaml
@@ -1,6 +1,7 @@
 version: 0.1
 tools:
   definitions:
+    # TODO(Tyler): Once we can make ansible its own tool without breaking upgrade, this should be extracted into its own tool directory
     - name: ansible-lint
       runtime: python
       package: ansible-lint

--- a/linters/buf/plugin.yaml
+++ b/linters/buf/plugin.yaml
@@ -1,5 +1,6 @@
 version: 0.1
 lint:
+  # TODO(Tyler): This should be its own tool if we can avoid the eponymous pitfall
   downloads:
     - name: buf
       version: 1.0.0-rc11

--- a/linters/circleci/plugin.yaml
+++ b/linters/circleci/plugin.yaml
@@ -1,33 +1,4 @@
 version: 0.1
-downloads:
-  - name: circleci
-    downloads:
-      - os: macos
-        cpu: arm_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
-        strip_components: 1
-      - os: macos
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
-        strip_components: 1
-      - os: linux
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_amd64.tar.gz
-        strip_components: 1
-      - os: linux
-        cpu: arm_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_arm64.tar.gz
-        strip_components: 1
-      - os: windows
-        cpu: x86_64
-        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_windows_amd64.zip
-        strip_components: 1
-tools:
-  definitions:
-    - name: circleci
-      download: circleci
-      shims: [circleci]
-      known_good_version: 0.1.22770
 lint:
   files:
     - name: circleci-config

--- a/linters/circleci/test_data/circleci_v0.1.28811_CUSTOM.check.shot
+++ b/linters/circleci/test_data/circleci_v0.1.28811_CUSTOM.check.shot
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter circleci test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "code": "error",
+      "file": "test_data/bad_version/.circleci/config.yml",
+      "level": "LEVEL_HIGH",
+      "linter": "circleci",
+      "message": "Error: config compilation contains errors: config compilation contains errors:
+	- Cannot find circleci/node@2.99 in the orb registry. Check that the namespace, orb name and version are correct.",
+      "targetType": "circleci-config",
+    },
+    {
+      "code": "error",
+      "file": "test_data/malformed/.circleci/config.yml",
+      "level": "LEVEL_HIGH",
+      "linter": "circleci",
+      "message": "Error: config compilation contains errors: config compilation contains errors:
+	- ERROR IN CONFIG FILE:
+	- [#/jobs/install-node-example] 0 subschemas matched instead of one
+	- 1. [#/jobs/install-node-example] only 1 subschema matches out of 2
+	- |   1. [#/jobs/install-node-example] 6 schema violations found
+	- |   |   1. [#/jobs/install-node-example/docker/1] 2 schema violations found
+	- |   |   |   1. [#/jobs/install-node-example/docker/1] extraneous key [foo] is not permitted
+	- |   |   |   |   Permitted keys:
+	- |   |   |   |     - image
+	- |   |   |   |     - name
+	- |   |   |   |     - entrypoint
+	- |   |   |   |     - command
+	- |   |   |   |     - user
+	- |   |   |   |     - environment
+	- |   |   |   |     - aws_auth
+	- |   |   |   |     - auth
+	- |   |   |   |   Passed keys:
+	- |   |   |   |     - foo
+	- |   |   |   2. [#/jobs/install-node-example/docker/1] required key [image] not found
+	- |   |   2. [#/jobs/install-node-example/steps/3] 0 subschemas matched instead of one
+	- |   |   |   1. [#/jobs/install-node-example/steps/3] expected type: String, found: Mapping
+	- |   |   |   |   Shorthand commands, like \`checkout\`
+	- |   |   |   |   SCHEMA:
+	- |   |   |   |     type: string
+	- |   |   |   |   INPUT:
+	- |   |   |   |     rerun:
+	- |   |   |   |     - true
+	- |   |   |   2. [#/jobs/install-node-example/steps/3] extraneous key [rerun] is not permitted
+	- |   |   |   |   \`when\`/\`unless\` step
+	- |   |   |   |   Permitted keys:
+	- |   |   |   |     - when
+	- |   |   |   |     - unless
+	- |   |   |   |   Passed keys:
+	- |   |   |   |     - rerun
+	- |   |   |   3. [#/jobs/install-node-example/steps/3/rerun] no subschema matched out of the total 2 subschemas
+	- |   |   |   |   1. [#/jobs/install-node-example/steps/3/rerun] expected type: Mapping, found: Sequence
+	- |   |   |   |   |   SCHEMA:
+	- |   |   |   |   |     type:
+	- |   |   |   |   |     - object
+	- |   |   |   |   |     - string
+	- |   |   |   |   |   INPUT:
+	- |   |   |   |   |     - true
+	- |   |   |   |   2. [#/jobs/install-node-example/steps/3/rerun] expected type: String, found: Sequence
+	- |   |   |   |   |   SCHEMA:
+	- |   |   |   |   |     type:
+	- |   |   |   |   |     - object
+	- |   |   |   |   |     - string
+	- |   |   |   |   |   INPUT:
+	- |   |   |   |   |     - true
+	- 2. [#/jobs/install-node-example] expected type: String, found: Mapping
+	- |   Job may be a string reference to another job",
+      "targetType": "circleci-config",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/bad_version/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/basic/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "validate",
+      "fileGroupName": "circleci-config",
+      "linter": "circleci",
+      "paths": [
+        "test_data/malformed/.circleci/config.yml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/renovate/plugin.yaml
+++ b/linters/renovate/plugin.yaml
@@ -1,11 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: renovate
-      runtime: node
-      package: renovate
-      shims: [renovate]
-      known_good_version: 34.122.0
 lint:
   files:
     - name: renovate-config
@@ -17,8 +10,7 @@ lint:
   definitions:
     - name: renovate
       files: [renovate-config]
-      runtime: node
-      package: renovate
+      tools: [renovate]
       commands:
         - name: validate
           run: renovate-config-validator ${target}

--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -1,11 +1,4 @@
 version: 0.1
-tools:
-  definitions:
-    - name: sourcery
-      runtime: python
-      package: sourcery
-      shims: [sourcery]
-      known_good_version: 1.2.0
 lint:
   definitions:
     - name: sourcery

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -1,26 +1,4 @@
 version: 0.1
-downloads:
-  - name: terraform
-    version: 1.1.4
-    downloads:
-      # macos arm64 was introduced after this version.
-      - os: macos
-        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_darwin_amd64.zip
-        version: <1.0.2
-      - os:
-          linux: linux
-          macos: darwin
-          windows: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${cpu}.zip
-tools:
-  definitions:
-    - name: terraform
-      download: terraform
-      shims: [terraform]
-      known_good_version: 1.1.4
 lint:
   definitions:
     - name: terraform

--- a/repo-tools/tool-test-helper/generate
+++ b/repo-tools/tool-test-helper/generate
@@ -32,11 +32,11 @@ tools:
 
 INITIAL_TEST_CONTENTS = """import { makeToolTestConfig, toolTest } from "tests";
 toolTest({
-  toolName: "NAME_HERE",
+  toolName: "*{}*",
   toolVersion: "VERSION_HERE",
   testConfigs: [
     makeToolTestConfig({
-      command: ["TOOL_NAME", ...args],
+      command: ["*{}*", ...args],
       expectedOut: "OUTPUT_HERE",
     }),
   ],

--- a/tests/repo_tests/valid_package_download.test.ts
+++ b/tests/repo_tests/valid_package_download.test.ts
@@ -4,7 +4,13 @@ import { REPO_ROOT } from "tests/utils";
 import { parseYaml } from "tests/utils/trunk_config";
 
 // These linters use go or rust downloads.
-const excludedLinters: string[] = ["clippy", "gofmt", "rustfmt"];
+const excludedLinters: string[] = [
+  "clippy",
+  "gofmt",
+  "rustfmt",
+  "terraform-fmt",
+  "terraform-validate",
+];
 
 // This test asserts that all linters that have a `download` specified (as opposed to custom run command or package)
 // Must also define that download in its same file. Otherwise, this would be a runtime error.
@@ -25,7 +31,7 @@ describe("Validate linter download/package setup", () => {
 
       yamlContents.lint?.definitions?.forEach((definition: any) => {
         // All linters that have downloads must define them
-        if (definition.download && !excludedLinters.includes(linter)) {
+        if (definition.download && !excludedLinters.includes(definition.name)) {
           const downloads: string[] = [];
           if (yamlContents.lint?.downloads) {
             yamlContents.lint?.downloads.forEach((download: any) => {

--- a/tools/circleci/circleci.test.ts
+++ b/tools/circleci/circleci.test.ts
@@ -1,0 +1,11 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "circleci",
+  toolVersion: "0.1.22770",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["circleci", "version"],
+      expectedOut: "0.1.22770",
+    }),
+  ],
+});

--- a/tools/circleci/plugin.yaml
+++ b/tools/circleci/plugin.yaml
@@ -1,0 +1,30 @@
+version: 0.1
+downloads:
+  - name: circleci
+    downloads:
+      - os: macos
+        cpu: arm_64
+        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
+        strip_components: 1
+      - os: macos
+        cpu: x86_64
+        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_darwin_amd64.tar.gz
+        strip_components: 1
+      - os: linux
+        cpu: x86_64
+        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_amd64.tar.gz
+        strip_components: 1
+      - os: linux
+        cpu: arm_64
+        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_linux_arm64.tar.gz
+        strip_components: 1
+      - os: windows
+        cpu: x86_64
+        url: https://github.com/CircleCI-Public/circleci-cli/releases/download/v${version}/circleci-cli_${version}_windows_amd64.zip
+        strip_components: 1
+tools:
+  definitions:
+    - name: circleci
+      download: circleci
+      shims: [circleci]
+      known_good_version: 0.1.22770

--- a/tools/renovate/plugin.yaml
+++ b/tools/renovate/plugin.yaml
@@ -1,0 +1,8 @@
+version: 0.1
+tools:
+  definitions:
+    - name: renovate
+      runtime: node
+      package: renovate
+      shims: [renovate, renovate-config-validator]
+      known_good_version: 34.122.0

--- a/tools/renovate/renovate.test.ts
+++ b/tools/renovate/renovate.test.ts
@@ -1,0 +1,11 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "renovate",
+  toolVersion: "34.122.0",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["renovate", "--version"],
+      expectedOut: "34.122.0",
+    }),
+  ],
+});

--- a/tools/sourcery/plugin.yaml
+++ b/tools/sourcery/plugin.yaml
@@ -1,0 +1,8 @@
+version: 0.1
+tools:
+  definitions:
+    - name: sourcery
+      runtime: python
+      package: sourcery
+      shims: [sourcery]
+      known_good_version: 1.2.0

--- a/tools/sourcery/sourcery.test.ts
+++ b/tools/sourcery/sourcery.test.ts
@@ -1,0 +1,11 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "sourcery",
+  toolVersion: "1.2.0",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["sourcery", "--version"],
+      expectedOut: "1.2.0",
+    }),
+  ],
+});

--- a/tools/terraform/plugin.yaml
+++ b/tools/terraform/plugin.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+downloads:
+  - name: terraform
+    version: 1.1.4
+    downloads:
+      # macos arm64 was introduced after this version.
+      - os: macos
+        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_darwin_amd64.zip
+        version: <1.0.2
+      - os:
+          linux: linux
+          macos: darwin
+          windows: windows
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://releases.hashicorp.com/terraform/${version}/terraform_${version}_${os}_${cpu}.zip
+tools:
+  definitions:
+    - name: terraform
+      download: terraform
+      shims: [terraform]
+      known_good_version: 1.1.4

--- a/tools/terraform/terraform.test.ts
+++ b/tools/terraform/terraform.test.ts
@@ -1,0 +1,11 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "terraform",
+  toolVersion: "1.1.4",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["terraform", "--version"],
+      expectedOut: "Terraform v1.1.4",
+    }),
+  ],
+});


### PR DESCRIPTION
The following tools were moved because they constitute their own semantic "tools" outside of just being linters/formatters:
- circleci (also added a snapshot for its latest release)
- renovate
- sourcery
- terraform

The following tools were left for a later date:
- ansible/ansible-lint (upgrade concerns)
- buf (non-eponymous naming concerns)

Also made some small testing and generating improvements