### PR TITLE
Ripgrep integration + rust runtime fixes

### DIFF
--- a/linters/nixpkgs-fmt/plugin.yaml
+++ b/linters/nixpkgs-fmt/plugin.yaml
@@ -13,7 +13,4 @@ lint:
           stdin: true
           formatter: true
       suggest_if: files_present
-      environment:
-        - name: PATH
-          list: ["${linter}/bin"]
       known_good_version: 1.3.0

--- a/repo-tools/tool-test-helper/generate
+++ b/repo-tools/tool-test-helper/generate
@@ -9,7 +9,7 @@ INITIAL_PLUGIN_CONTENTS = """version: 0.1
 # Tools can be either runtime package-based or
 # download-based. This boilerplate assumes the (far more verbose) latter case.
 downloads:
-  - name: NAME_HERE
+  - name: *{}*
     # executable: true
     # NOTE: These are (common) sample values. Please replace with real values.
     downloads:
@@ -23,20 +23,21 @@ downloads:
         url: https://URL_HERE/${version}/${os}-${cpu}-NAME_HERE
 tools:
   definitions:
-    - name: NAME_HERE
+    - name: *{}*
       # RUNTIME_OR_DOWNLOAD_INFO_HERE
-      # download: NAME_HERE
+      # download: *{}*
       known_good_version: VERSION_HERE
-      shims: [NAME_HERE]
+      # NOTE: shim may differ from tool name
+      shims: [*{}*]
 """
 
 INITIAL_TEST_CONTENTS = """import { makeToolTestConfig, toolTest } from "tests";
 toolTest({
-  toolName: "NAME_HERE",
+  toolName: "*{}*",
   toolVersion: "VERSION_HERE",
   testConfigs: [
     makeToolTestConfig({
-      command: ["TOOL_NAME", ...args],
+      command: ["SHIM_NAME", "COMMAND_HERE"],
       expectedOut: "OUTPUT_HERE",
     }),
   ],
@@ -78,7 +79,7 @@ def scan(workspace):
             generated_files = True
             # Write plugin.yaml
             with open(os.path.join(subdir_path, "plugin.yaml"), "w") as plugin_file:
-                plugin_file.write(INITIAL_PLUGIN_CONTENTS)
+                plugin_file.write(INITIAL_PLUGIN_CONTENTS.replace("*{}*", tool_name))
 
             # Write test file
             with open(

--- a/runtimes/rust/plugin.yaml
+++ b/runtimes/rust/plugin.yaml
@@ -32,7 +32,10 @@ runtimes:
         - name: https_proxy
           value: ${env.https_proxy}
           optional: true
-      known_good_version: 1.67.0
+      linter_environment:
+        - name: PATH
+          list: ["${linter}/bin"]
+      known_good_version: 1.71.1
       version_commands:
         - run: rustc --version
           parse_regex: ${semver}

--- a/tools/ripgrep/plugin.yaml
+++ b/tools/ripgrep/plugin.yaml
@@ -1,0 +1,9 @@
+version: 0.1
+# NOTE: This only works if rust runtime version >=1.70.0
+tools:
+  definitions:
+    - name: ripgrep
+      package: ripgrep
+      runtime: rust
+      known_good_version: 13.0.0
+      shims: [rg]

--- a/tools/ripgrep/ripgrep.test.ts
+++ b/tools/ripgrep/ripgrep.test.ts
@@ -1,0 +1,20 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "ripgrep",
+  toolVersion: "13.0.0",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["rg", "--version"],
+      expectedOut: "ripgrep 13.0.0",
+    }),
+  ],
+});
+
+// Guidelines for configuring tests:
+//  - Usually, just a version or help text command is sufficient
+//  - add a test for each command that is used in the plugin.yaml
+//  - exit code 0 is assumed, so set expectedExitCode if it is different
+//  - expectedOut/expectedErr do a substring match, so you can just put a portion of the output
+//
+// If you are unable to write a test for this tool, please document why in your PR, and add
+// it to the list in tests/repo_tests/test_coverage_test.ts

--- a/tools/ripgrep/ripgrep.test.ts
+++ b/tools/ripgrep/ripgrep.test.ts
@@ -9,12 +9,3 @@ toolTest({
     }),
   ],
 });
-
-// Guidelines for configuring tests:
-//  - Usually, just a version or help text command is sufficient
-//  - add a test for each command that is used in the plugin.yaml
-//  - exit code 0 is assumed, so set expectedExitCode if it is different
-//  - expectedOut/expectedErr do a substring match, so you can just put a portion of the output
-//
-// If you are unable to write a test for this tool, please document why in your PR, and add
-// it to the list in tests/repo_tests/test_coverage_test.ts


### PR DESCRIPTION
- make the trunk tools generate template a little bit smarter
- bump the rust runtime version so it supports ripgrep
- integrate ripgrep (39.4K stars)
- fix environment spec for rust runtime