### PR TITLE
Fix trufflehog tests

### DIFF
--- a/linters/eslint/eslint.test.ts
+++ b/linters/eslint/eslint.test.ts
@@ -2,9 +2,9 @@ import { execSync } from "child_process";
 import path from "path";
 import { customLinterCheckTest } from "tests";
 import { TrunkLintDriver } from "tests/driver";
-import { TEST_DATA } from "tests/utils";
+import { osTimeoutMultiplier, TEST_DATA } from "tests/utils";
 
-const INSTALL_TIMEOUT = 60000;
+const INSTALL_TIMEOUT = 90000 * osTimeoutMultiplier;
 
 const moveConfig = (driver: TrunkLintDriver) => {
   [".eslintrc.yaml", "package.json"].forEach((file) => {

--- a/linters/trufflehog/test_data/buff_size.in.cc
+++ b/linters/trufflehog/test_data/buff_size.in.cc
@@ -1,0 +1,232 @@
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+TEST_F(BasicTest, BasicBasicBasicBasicTest) {
+  // empty
+}
+
+std::string uri = "https://gitlab-ci-token:password@gitlab.com/org/repo.git";

--- a/linters/trufflehog/test_data/trufflehog_git_v3.49.0_CUSTOM.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_git_v3.49.0_CUSTOM.check.shot
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog-git test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "code": "AWS",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:2: Secret detected: AKIAXYZDQCEN4EXAMPLE on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:6: Secret detected on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "PrivateKey",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:11: Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:8: Secret detected: https://admin:********@the-internet.herokuapp.com on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "PrivateKey",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "11",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "AWS",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: AKIAXYZDQCEN4EXAMPLE on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "trufflehog-git",
+      "message": "Secret detected on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "8",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: https://admin:********@the-internet.herokuapp.com on commit <hash>",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog-git",
+      "paths": [
+        ".",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.31.3_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.31.3_buff_size.check.shot
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter trufflehog test buff_size 1`] = `
+{
+  "issues": [
+    {
+      "code": "URI",
+      "file": "test_data/buff_size.in.cc",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://gitlab-ci-token:********@gitlab.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/buff_size.in.cc",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.40.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.40.0_buff_size.check.shot
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter trufflehog test buff_size 1`] = `
+{
+  "issues": [],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/buff_size.in.cc",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.49.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.49.0_buff_size.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test buff_size 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.49.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.49.0_buff_size.check.shot
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog test buff_size 1`] = `
+{
+  "issues": [
+    {
+      "code": "URI",
+      "file": "test_data/buff_size.in.cc",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "200",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://gitlab-ci-token:********@gitlab.com",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "test_data/buff_size.in.cc",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "232",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://gitlab-ci-token:********@gitlab.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/buff_size.in.cc",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.49.0_secrets.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.49.0_secrets.check.shot
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog test secrets 1`] = `
+{
+  "issues": [
+    {
+      "code": "PrivateKey",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "11",
+      "linter": "trufflehog",
+      "message": "Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl",
+      "targetType": "ALL",
+    },
+    {
+      "code": "AWS",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "trufflehog",
+      "message": "Secret detected: AKIAXYZDQCEN4EXAMPLE",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "trufflehog",
+      "message": "Secret detected",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "8",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://admin:********@the-internet.herokuapp.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/secrets.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Trufflehog 3.49.0 fixed some of the longstanding issues related to line numbers and missing issues (https://github.com/trufflesecurity/trufflehog/issues/1537). However, there are still some duplicate issues showing up. This is strictly an improvement, but I've added another test input file to reflect this. Note the changes from:
- linters/trufflehog/test_data/trufflehog_v3.31.3_buff_size.check.shot
- linters/trufflehog/test_data/trufflehog_v3.40.0_buff_size.check.shot
- linters/trufflehog/test_data/trufflehog_v3.49.0_buff_size.check.shot

Also marked snapshot as release