### PR TITLE
Fix ruby-build version

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.13.1-beta.36
+  version: 1.14.0
 
 api:
   address: api.trunk-staging.io:8443

--- a/runtimes/ruby/plugin.yaml
+++ b/runtimes/ruby/plugin.yaml
@@ -1,12 +1,12 @@
 version: 0.1
 downloads:
   - name: ruby-build
-    version: 20230124
+    version: 20230717
     downloads:
       - os:
           linux: linux
           macos: macos
-        url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230124.tar.gz
+        url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230717.tar.gz
         strip_components: 1
   - name: ruby-install
     version: 3.2.2

--- a/runtimes/ruby/plugin.yaml
+++ b/runtimes/ruby/plugin.yaml
@@ -1,15 +1,15 @@
 version: 0.1
 downloads:
   - name: ruby-build
-    version: 20230717
+    version: 20230330
     downloads:
       - os:
           linux: linux
           macos: macos
-        url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230717.tar.gz
+        url: https://github.com/rbenv/ruby-build/archive/refs/tags/v20230330.tar.gz
         strip_components: 1
   - name: ruby-install
-    version: 3.2.2
+    version: 3.1.4
     downloads:
       # Functionally a separate download used for Windows only. Runs OOTB and does not require a prepare build step.
       - os: windows
@@ -44,7 +44,7 @@ runtimes:
         - name: SYSTEMDRIVE
           value: ${env.SYSTEMDRIVE}
           optional: true
-      known_good_version: 3.2.2
+      known_good_version: 3.1.4
       version_commands:
         - run: ruby --version
           parse_regex: ruby ([0-9\.]+)(p+.*)

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -89,7 +89,7 @@ runtimes:
     - go@1.19.5
     - node@18.12.1
     - python@3.10.8
-    - ruby@3.1.3
+    - ruby@3.2.2
 plugins:
   sources:
   - id: trunk

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -89,7 +89,7 @@ runtimes:
     - go@1.19.5
     - node@18.12.1
     - python@3.10.8
-    - ruby@3.2.2
+    - ruby@3.1.4
 plugins:
   sources:
   - id: trunk


### PR DESCRIPTION
Fix ruby versions to use 3.1.4. The ruby-build version we had didn't support 3.2.2, and building 3.2.2 also requires additional deps on Linux. 

This was obscured in testing because we were overriding it with the version dumped in the `lint_driver.ts`. 