### PR TITLE
Use Go Install for bazel-differ

### DIFF
--- a/tools/bazel-differ/plugin.yaml
+++ b/tools/bazel-differ/plugin.yaml
@@ -4,8 +4,14 @@ downloads:
     executable: true
     downloads:
       - os:
-          linux: linux
           macos: darwin
+        cpu:
+          x86_64: x86_64
+          arm_64: arm64
+        url: https://github.com/ewhauser/bazel-differ/releases/download/v${version}/bazel-differ-${os}-${cpu}
+        version: "<=0.0.6"
+      - os:
+          linux: linux
         cpu:
           x86_64: x86_64
           arm_64: arm64

--- a/tools/bazel-differ/plugin.yaml
+++ b/tools/bazel-differ/plugin.yaml
@@ -7,4 +7,4 @@ tools:
       known_good_version: 0.0.5
       shims:
         - name: bazel-differ
-          target: bazel-differ
+          target: cli

--- a/tools/bazel-differ/plugin.yaml
+++ b/tools/bazel-differ/plugin.yaml
@@ -9,7 +9,7 @@ downloads:
           x86_64: x86_64
           arm_64: arm64
         url: https://github.com/ewhauser/bazel-differ/releases/download/v${version}/bazel-differ-${os}-${cpu}
-        version: "<=0.0.6"
+        version: <=0.0.6
       - os:
           linux: linux
         cpu:

--- a/tools/bazel-differ/plugin.yaml
+++ b/tools/bazel-differ/plugin.yaml
@@ -1,26 +1,9 @@
 version: 0.1
-downloads:
-  - name: bazel-differ
-    executable: true
-    downloads:
-      - os:
-          macos: darwin
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://github.com/ewhauser/bazel-differ/releases/download/v${version}/bazel-differ-${os}-${cpu}
-        version: <=0.0.6
-      - os:
-          linux: linux
-        cpu:
-          x86_64: x86_64
-          arm_64: arm64
-        url: https://github.com/ewhauser/bazel-differ/releases/download/v${version}/bazel-differ-${os}-${cpu}
-      # no windows download
 tools:
   definitions:
     - name: bazel-differ
-      download: bazel-differ
+      package: github.com/ewhauser/bazel-differ/cli
+      runtime: go
       known_good_version: 0.0.5
       shims:
         - name: bazel-differ


### PR DESCRIPTION
No bazel-differ for mac at 0.0.7

https://github.com/ewhauser/bazel-differ/releases

Filed issue:
https://github.com/ewhauser/bazel-differ/issues/16