### PR TITLE
aws-amplify tool integration + some fixes to tool driver

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.14.2-beta.1
+  version: 1.14.2-beta.18
 
 api:
   address: api.trunk-staging.io:8443

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.14.2-beta.18
+  version: 1.14.2
 
 api:
   address: api.trunk-staging.io:8443

--- a/linters/trivy/trivy.test.ts
+++ b/linters/trivy/trivy.test.ts
@@ -42,7 +42,7 @@ fuzzyLinterCheckTest({
   linterName: "trivy",
   testName: "fs-vuln",
   args: "-a",
-  fileIssueAssertionCallback: createFuzzyMatcher(() => vulnExpectedFileIssues, 44),
+  fileIssueAssertionCallback: createFuzzyMatcher(() => vulnExpectedFileIssues, 30),
   preCheck: callbackGenerator("fs-vuln"),
 });
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.14.2-beta.18"
+required_trunk_version: ">=1.14.2"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.13.1-beta.25"
+required_trunk_version: ">=1.14.2-beta.18"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -24,6 +24,7 @@ export const executionEnv = (sandbox: string) => {
     ...strippedEnv,
     // This keeps test downloads separate from manual trunk invocations
     TRUNK_DOWNLOAD_CACHE: DOWNLOAD_CACHE,
+    TRUNK_TELEMETRY: "off",
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
   };

--- a/tests/driver/tool_driver.ts
+++ b/tests/driver/tool_driver.ts
@@ -103,21 +103,23 @@ lint:
       }
 
       // Sync the tool to ensure it's available
-      await this.runTrunk(["tools", "install", "--ci"]);
+      await this.runTrunk(["tools", "install", this.tool, "--ci"]);
       const tools_subdir = fs.existsSync(path.resolve(this.sandboxPath ?? "", ".trunk/dev-tools"))
         ? "dev-tools"
         : "tools";
-      if (
-        !fs.existsSync(
-          path.resolve(
-            this.sandboxPath,
-            ".trunk",
-            tools_subdir,
-            `${this.tool}${process.platform == "win32" ? ".bat" : ""}`,
-          ),
-        )
-      ) {
-        throw new Error(`Could not install or find installed ${this.tool}`);
+      for (const shim of this.getShims()) {
+        if (
+          !fs.existsSync(
+            path.resolve(
+              this.sandboxPath,
+              ".trunk",
+              tools_subdir,
+              `${shim}${process.platform == "win32" ? ".bat" : ""}`,
+            ),
+          )
+        ) {
+          throw new Error(`Could not install or find installed ${shim}`);
+        }
       }
     } catch (error) {
       console.warn(`Failed to enable ${this.tool}`, error);
@@ -193,5 +195,17 @@ lint:
       };
       // trunk-ignore-end(eslint/@typescript-eslint/no-unsafe-member-access)
     }
+  }
+
+  getShims(): string[] {
+    // get the full trunk config
+    const fullTrunkConfig = this.getFullTrunkConfig();
+    // get the tool definition
+    const toolDefinition = fullTrunkConfig.tools.definitions.find(
+      ({ name }: { name: string }) => name === this.tool,
+    );
+    // get the shims
+    const shims = toolDefinition?.shims ?? [];
+    return shims.map(({ name }: { name: string }) => name);
   }
 }

--- a/tests/driver/tool_driver.ts
+++ b/tests/driver/tool_driver.ts
@@ -199,6 +199,8 @@ lint:
 
   getShims(): string[] {
     // get the full trunk config
+    // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-assignment)
+    // trunk-ignore-begin(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)
     const fullTrunkConfig = this.getFullTrunkConfig();
     // get the tool definition
     const toolDefinition = fullTrunkConfig.tools.definitions.find(
@@ -206,6 +208,8 @@ lint:
     );
     // get the shims
     const shims = toolDefinition?.shims ?? [];
-    return shims.map(({ name }: { name: string }) => name);
+    return shims.map(({ name }: { name: string }) => name) as string[];
+    // trunk-ignore-end(eslint/@typescript-eslint/no-unsafe-assignment)
+    // trunk-ignore-end(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-call)
   }
 }

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -23,7 +23,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.13.1-beta.25",
+    trunkVersion: "1.14.2-beta.18",
     // ThenChange plugin.yaml
   });
 

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -23,7 +23,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.14.2-beta.18",
+    trunkVersion: "1.14.2",
     // ThenChange plugin.yaml
   });
 

--- a/tools/aws-amplify/aws_amplify.test.ts
+++ b/tools/aws-amplify/aws_amplify.test.ts
@@ -1,0 +1,11 @@
+import { makeToolTestConfig, toolTest } from "tests";
+toolTest({
+  toolName: "aws-amplify",
+  toolVersion: "12.3.0",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["amplify", "version"],
+      expectedOut: "12.3.0",
+    }),
+  ],
+});

--- a/tools/aws-amplify/plugin.yaml
+++ b/tools/aws-amplify/plugin.yaml
@@ -1,0 +1,11 @@
+version: 0.1
+tools:
+  definitions:
+    - name: aws-amplify
+      runtime: node
+      package: "@aws-amplify/cli"
+      known_good_version: 12.3.0
+      shims: [amplify]
+      health_checks:
+        - command: amplify version
+          parse_regex: ${semver}


### PR DESCRIPTION
I am going to follow up with modifying the test framework with install-only health-check based tests.

follow up:  https://linear.app/trunk/issue/TRUNK-8604/convert-most-tools-to-health-check-based-tests