### PR TITLE
Fix tool tests

### DIFF
--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -283,8 +283,8 @@ export abstract class GenericTrunkDriver {
    * Return the yaml result of parsing the output of `trunk config print` in the test sandbox.
    */
   getFullTrunkConfig = (): any => {
-    const [path, args, options] = this.buildExecArgs(["config", "print"]);
-    const printConfig = execSync([path, ...args].join(" "), options);
+    const [executable, args, options] = this.buildExecArgs(["config", "print"]);
+    const printConfig = execSync([executable, ...args].join(" "), options);
     return YAML.parse(printConfig.toString().replaceAll("\r\n", "\n"));
   };
 

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -283,10 +283,8 @@ export abstract class GenericTrunkDriver {
    * Return the yaml result of parsing the output of `trunk config print` in the test sandbox.
    */
   getFullTrunkConfig = (): any => {
-    const printConfig = execSync(`${ARGS.cliPath ?? "trunk"} config print`, {
-      cwd: this.sandboxPath,
-      env: executionEnv(this.sandboxPath ?? ""),
-    });
+    const [path, args, options] = this.buildExecArgs(["config", "print"]);
+    const printConfig = execSync([path, ...args].join(" "), options);
     return YAML.parse(printConfig.toString().replaceAll("\r\n", "\n"));
   };
 


### PR DESCRIPTION
Use the correct invocation when running `trunk config print`. This change in conjunction with https://github.com/trunk-io/trunk/pull/10695 makes tool tests pass on Windows.