### PR TITLE
Legacy yarn can be directly downloaded. Newer yarn > 1.22.19 is shipped with other tooling.

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -74,6 +74,3 @@ actions:
     - remove-release-snapshots
     - repo-tests
     - tool-test-helper
-tools:
-  enabled:
-    - yarn@1.23.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,7 +15,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.6
+      ref: v0.0.7
 
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -74,3 +74,6 @@ actions:
     - remove-release-snapshots
     - repo-tests
     - tool-test-helper
+tools:
+  enabled:
+    - yarn@1.23.0

--- a/tools/yarn/plugin.yaml
+++ b/tools/yarn/plugin.yaml
@@ -1,0 +1,20 @@
+version: 0.1
+downloads:
+  - name: yarn
+    downloads:
+      - os:
+          linux: linux
+          macos: darwin
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://github.com/yarnpkg/yarn/releases/download/v${version}/yarn-${version}.js
+        version: <=1.22.19
+tools:
+  definitions:
+    - name: yarn
+      download: yarn
+      known_good_version: 1.22.19
+      shims:
+        - name: yarn
+          target: yarn

--- a/tools/yarn/yarn.test.ts
+++ b/tools/yarn/yarn.test.ts
@@ -1,5 +1,4 @@
 import { makeToolTestConfig, toolTest } from "tests";
-import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "yarn",

--- a/tools/yarn/yarn.test.ts
+++ b/tools/yarn/yarn.test.ts
@@ -1,0 +1,13 @@
+import { makeToolTestConfig, toolTest } from "tests";
+import { skipOS } from "tests/utils";
+
+toolTest({
+  toolName: "yarn",
+  toolVersion: "1.22.19",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["yarn", "--version"],
+      expectedOut: "1.22.19",
+    }),
+  ],
+});

--- a/tools/yarn/yarn.test.ts
+++ b/tools/yarn/yarn.test.ts
@@ -1,4 +1,5 @@
 import { makeToolTestConfig, toolTest } from "tests";
+import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "yarn",
@@ -9,4 +10,5 @@ toolTest({
       expectedOut: "1.22.19",
     }),
   ],
+  skipTestIf: skipOS(["win32"]),
 });


### PR DESCRIPTION
Support for legacy yarn. trunk tools eanble yarn@1.22.19