### PR TITLE
Update ktlint snapshots

### DIFF
--- a/linters/ktlint/test_data/ktlint_v1.0.0_basic.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v1.0.0_basic.fmt.shot
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter ktlint test basic 1`] = `
+"class MainActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState) // note the spacing
+    setContentView(R.layout.activity_main)
+  }
+}
+"
+`;

--- a/linters/ktlint/test_data/ktlint_v1.0.0_complex.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v1.0.0_complex.fmt.shot
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter ktlint test complex 1`] = `
+"class TestBaselineExtraErrorFile {
+  { }}
+}
+"
+`;

--- a/linters/ktlint/test_data/ktlint_v1.0.0_utf8.fmt.shot
+++ b/linters/ktlint/test_data/ktlint_v1.0.0_utf8.fmt.shot
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter ktlint test utf8 1`] = `
+"package demo
+
+fun main(args: Array<String>) {
+  println(
+    """
+    ┌───────────┬───────────┬────────────┐
+    │   BLOCK   │   FORM    │ ADDED_DATE │
+    ├───────────┼───────────┼────────────┤
+    │ 1.1.1.1/1 │ trunca…   │ 1111-01-01 │
+    │ 2.2.2.2/2 │ OtherForm │ 1212-12-12 │
+    └───────────┴───────────┴────────────┘
+    """.trimIndent(),
+  )
+}
+"
+`;


### PR DESCRIPTION
Ktlint released version 1.0.0 this morning, and some of the formatting preferences changed. Everything else works swimmingly. Marked snapshots as release-ready.