### PR TITLE
Use new `run_from` syntax

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.15.0
+  version: 1.15.1-beta.15
 
 api:
   address: api.trunk-staging.io:8443

--- a/linters/ansible-lint/plugin.yaml
+++ b/linters/ansible-lint/plugin.yaml
@@ -22,7 +22,7 @@ lint:
           run: ansible-lint -f sarif
           # ansible-lint >=6.15.0 return exit code 5 when no files matched
           success_codes: [0, 2, 5]
-          run_from: ${directory}
+          run_from: ${target_directory}
         - name: lint
           version: ">=5.1.3"
           # Custom parser type defined in the trunk cli to handle ansible-lint's output.
@@ -30,7 +30,7 @@ lint:
           # parseable-severity was removed after 5.4.0
           run: ansible-lint --parseable-severity
           success_codes: [0, 2]
-          run_from: ${directory}
+          run_from: ${target_directory}
       tools: [ansible-lint]
       suggest_if: never
       direct_configs: [.ansible-lint]

--- a/linters/ansible-lint/plugin.yaml
+++ b/linters/ansible-lint/plugin.yaml
@@ -22,7 +22,7 @@ lint:
           run: ansible-lint -f sarif
           # ansible-lint >=6.15.0 return exit code 5 when no files matched
           success_codes: [0, 2, 5]
-          run_linter_from: directory
+          run_from: ${directory}
         - name: lint
           version: ">=5.1.3"
           # Custom parser type defined in the trunk cli to handle ansible-lint's output.
@@ -30,7 +30,7 @@ lint:
           # parseable-severity was removed after 5.4.0
           run: ansible-lint --parseable-severity
           success_codes: [0, 2]
-          run_linter_from: directory
+          run_from: ${directory}
       tools: [ansible-lint]
       suggest_if: never
       direct_configs: [.ansible-lint]

--- a/linters/brakeman/plugin.yaml
+++ b/linters/brakeman/plugin.yaml
@@ -18,15 +18,14 @@ lint:
           target: ${parent_with(app)}
           run: brakeman -f sarif --no-pager
           success_codes: [0, 1, 3]
-          run_linter_from: directory
+          run_from: ${directory}
         - name: lint
           # Custom parser type defined in the trunk cli to handle brakeman's JSON output.
           output: brakeman
           target: ${parent_with(app)}
           run: brakeman -p ${target} -f json --no-pager
           success_codes: [0, 1, 3]
-          run_linter_from: root_directory
-          run_from_root_target: apps
+          run_from: apps
       direct_configs: [brakeman.ignore]
       suggest_if: files_present
       tools: [brakeman]

--- a/linters/brakeman/plugin.yaml
+++ b/linters/brakeman/plugin.yaml
@@ -18,7 +18,7 @@ lint:
           target: ${parent_with(app)}
           run: brakeman -f sarif --no-pager
           success_codes: [0, 1, 3]
-          run_from: ${directory}
+          run_from: ${target_directory}
         - name: lint
           # Custom parser type defined in the trunk cli to handle brakeman's JSON output.
           output: brakeman

--- a/linters/buf/plugin.yaml
+++ b/linters/buf/plugin.yaml
@@ -65,8 +65,7 @@ lint:
           output: buf
           run: buf lint --path ${target} --error-format json
           success_codes: [0, 100]
-          run_linter_from: root_file
-          run_from_root_target: buf.yaml
+          run_from: ${root_or_parent_with(buf.yaml)}
       direct_configs: [buf.yaml]
       suggest_if: config_present
       environment:
@@ -97,11 +96,10 @@ lint:
             buf breaking --against .git#branch=${upstream-ref} --error-format json
             --disable-symlinks
           success_codes: [0, 1, 100]
-          run_linter_from: root_file
+          run_from: ${root_or_parent_with(buf.work.yaml)}
           # buf is configured to not follow symlinks, and relies on git state, so don't cache results
           sandbox_type: copy_targets
           cache_results: false
-          run_from_root_target: buf.work.yaml
       direct_configs: [buf.yaml, buf.work.yaml]
       environment:
         - name: PATH

--- a/linters/clang-tidy/plugin.yaml
+++ b/linters/clang-tidy/plugin.yaml
@@ -40,7 +40,7 @@ lint:
           run: clang-tidy --export-fixes=${tmpfile} ${target} -p ${compile_commands_dir}
           success_codes: [0, 1]
           cache_results: true
-          run_linter_from: compile_command
+          run_from: ${compile_command}
           read_output_from: tmp_file
       tools: [clang-tidy]
       suggest_if: config_present

--- a/linters/clippy/plugin.yaml
+++ b/linters/clippy/plugin.yaml
@@ -16,7 +16,7 @@ lint:
           target: ${parent_with(Cargo.toml)}
           run: cargo clippy --message-format json --locked -- --cap-lints=warn --no-deps
           success_codes: [0, 101, 383]
-          run_from: ${directory}
+          run_from: ${target_directory}
           disable_upstream: true
       affects_cache:
         - Cargo.toml

--- a/linters/clippy/plugin.yaml
+++ b/linters/clippy/plugin.yaml
@@ -16,7 +16,7 @@ lint:
           target: ${parent_with(Cargo.toml)}
           run: cargo clippy --message-format json --locked -- --cap-lints=warn --no-deps
           success_codes: [0, 101, 383]
-          run_linter_from: directory
+          run_from: ${directory}
           disable_upstream: true
       affects_cache:
         - Cargo.toml

--- a/linters/flake8/plugin.yaml
+++ b/linters/flake8/plugin.yaml
@@ -18,7 +18,7 @@ lint:
             "((?P<path>.*):(?P<line>-?\\d+):(?P<col>-?\\d+): (?P<code>\\S+) (?P<message>.+))"
           batch: true
           read_output_from: tmp_file
-          run_linter_from: parent_directory
+          run_from: ${parent}
           success_codes: [0]
           cache_results: true
       tools: [flake8]

--- a/linters/golangci-lint/plugin.yaml
+++ b/linters/golangci-lint/plugin.yaml
@@ -36,8 +36,7 @@ lint:
           # 6 - no config file detected
           # 7 - error logged
           success_codes: [0, 2, 7]
-          run_linter_from: root_file
-          run_from_root_target: go.mod
+          run_from: ${root_or_parent_with(go.mod)}
           disable_upstream: true # TODO(Sam): re-enable the upstream for golang (needs test coverage)
       suggest_if: files_present
       direct_configs:

--- a/linters/iwyu/iwyu.test.ts
+++ b/linters/iwyu/iwyu.test.ts
@@ -17,7 +17,7 @@ const preCheck = (driver: TrunkLintDriver) => {
     - name: include-what-you-use
       commands:
         - name: lint
-          run_linter_from: compile_command
+          run_from: compile_command
           run: include-what-you-use -Xiwyu --no_fwd_decls \${compile_command}
           disable_upstream: true
           cache_results: false

--- a/linters/iwyu/plugin.yaml
+++ b/linters/iwyu/plugin.yaml
@@ -32,7 +32,7 @@ lint:
       tools: [include-what-you-use]
       commands:
         - name: lint
-          run_linter_from: compile_command
+          run_from: compile_command
           run: include-what-you-use -Xiwyu --no_fwd_decls "${compile_command}"
           # Custom parser type defined in the trunk cli to handle iwyu's output.
           output: iwyu

--- a/linters/scalafmt/plugin.yaml
+++ b/linters/scalafmt/plugin.yaml
@@ -33,8 +33,7 @@ lint:
           output: rewrite
           run: scalafmt --stdin --stdout
           success_codes: [0]
-          run_linter_from: root_file
-          run_from_root_target: .scalafmt.conf
+          run_from: ${root_or_parent_with(.scalafmt.conf)}
           stdin: true
           cache_results: true
           formatter: true

--- a/linters/stylua/plugin.yaml
+++ b/linters/stylua/plugin.yaml
@@ -29,7 +29,6 @@ lint:
           formatter: true
           stdin: true
           success_codes: [0, 1]
-      run_linter_from: workspace
       suggest_if: config_present
       known_good_version: 0.17.0
       direct_configs:

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -10,7 +10,7 @@ lint:
           output: terraform_validate
           target: ${parent}
           run: terraform validate -json
-          run_linter_from: directory
+          run_from: ${directory}
           success_codes: [0, 1]
           enabled: false
         - name: fmt

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -10,7 +10,7 @@ lint:
           output: terraform_validate
           target: ${parent}
           run: terraform validate -json
-          run_from: ${directory}
+          run_from: ${target_directory}
           success_codes: [0, 1]
           enabled: false
         - name: fmt

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -63,7 +63,6 @@ lint:
       files: [terraform]
       type: terraform_validate
       command: [terraform, validate, -json]
-      run_linter_from: directory
       download: terraform
       success_codes: [0, 1]
       environment:

--- a/linters/tflint/plugin.yaml
+++ b/linters/tflint/plugin.yaml
@@ -33,8 +33,7 @@ lint:
           success_codes: [0, 1, 2]
           read_output_from: stdout
           target: ${parent}
-          run_linter_from: root_directory
-          run_from_root_target: .tflint.hcl
+          run_from: ${root_or_parent_with(.tflint.hcl)}
           version: ">=0.47.0"
         - name: lint
           output: sarif
@@ -42,8 +41,7 @@ lint:
           run: tflint --format=sarif ${target} --force
           success_codes: [0, 1]
           read_output_from: stdout
-          run_linter_from: root_file
-          run_from_root_target: .tflint.hcl
+          run_from: ${root_or_parent_with(.tflint.hcl)}
       suggest_if: files_present
       tools: [tflint]
       direct_configs: [.tflint.hcl]

--- a/linters/tfsec/plugin.yaml
+++ b/linters/tfsec/plugin.yaml
@@ -34,7 +34,7 @@ lint:
           output: sarif
           target: ${parent}
           run: tfsec ${target} --format=sarif --ignore-hcl-errors
-          run_linter_from: directory
+          run_from: ${directory}
           is_security: true
           success_codes: [0, 1]
           read_output_from: stdout

--- a/linters/tfsec/plugin.yaml
+++ b/linters/tfsec/plugin.yaml
@@ -34,7 +34,7 @@ lint:
           output: sarif
           target: ${parent}
           run: tfsec ${target} --format=sarif --ignore-hcl-errors
-          run_from: ${directory}
+          run_from: ${target_directory}
           is_security: true
           success_codes: [0, 1]
           read_output_from: stdout

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.14.2"
+required_trunk_version: ">=1.15.1-beta.15"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -24,7 +24,6 @@ export const executionEnv = (sandbox: string) => {
     ...strippedEnv,
     // This keeps test downloads separate from manual trunk invocations
     TRUNK_DOWNLOAD_CACHE: DOWNLOAD_CACHE,
-    TRUNK_TELEMETRY: "off",
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
   };

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -25,7 +25,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.14.2",
+    trunkVersion: "1.15.1-beta.15",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
Replaces `run_linter_from` and `run_from_root_target` and `run_from_root_file`. Bumps the required cli version