### PR TITLE
Fix tfsec for trivy migration

### DIFF
--- a/linters/tfsec/parse.py
+++ b/linters/tfsec/parse.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 
+# trunk-ignore-begin(ruff)
 """
 as of 1.28.2, sarif output looks like this
 ======================================================
-    +         tfsec is joining the Trivy family
-    +
-    +         tfsec will continue to remain available
-    +         for the time being, although our engineering
-    +         attention will be directed at Trivy going forward.
-    +
-    +         You can read more here:
-    +         https://github.com/aquasecurity/tfsec/discussions/1994
-    +         ======================================================
-    +         {
-    +           "version": "2.1.0",
+tfsec is joining the Trivy family
+
+tfsec will continue to remain available
+for the time being, although our engineering
+attention will be directed at Trivy going forward.
+You can read more here:
+https://github.com/aquasecurity/tfsec/discussions/1994
+======================================================
+{
+  "version": "2.1.0",
+  ...
 """
+# trunk-ignore-end(ruff)
 
 import sys
 

--- a/linters/tfsec/parse.py
+++ b/linters/tfsec/parse.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+"""
+as of 1.28.2, sarif output looks like this
+======================================================
+    +         tfsec is joining the Trivy family
+    +
+    +         tfsec will continue to remain available
+    +         for the time being, although our engineering
+    +         attention will be directed at Trivy going forward.
+    +
+    +         You can read more here:
+    +         https://github.com/aquasecurity/tfsec/discussions/1994
+    +         ======================================================
+    +         {
+    +           "version": "2.1.0",
+"""
+
+import sys
+
+
+def main():
+    original_input = sys.stdin.read()
+    try:
+        index = original_input.index("{")
+        print(original_input[index:])
+    except ValueError:
+        print(original_input)
+
+
+if __name__ == "__main__":
+    main()

--- a/linters/tfsec/plugin.yaml
+++ b/linters/tfsec/plugin.yaml
@@ -38,6 +38,9 @@ lint:
           is_security: true
           success_codes: [0, 1]
           read_output_from: stdout
+          parser:
+            runtime: python
+            run: python3 ${cwd}/parse.py
       environment:
         - name: PATH
           list: ["${linter}"]

--- a/linters/tfsec/test_data/tfsec_v1.28.2_aws.check.shot
+++ b/linters/tfsec/test_data/tfsec_v1.28.2_aws.check.shot
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter tfsec test aws 1`] = `
+{
+  "issues": [
+    {
+      "code": "aws-ec2-enable-at-rest-encryption",
+      "column": "1",
+      "file": "test_data/aws.in.tf",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "tfsec",
+      "message": "Root block device is not encrypted.",
+      "ranges": [
+        {
+          "filePath": "test_data/aws.in.tf",
+          "length": "63",
+        },
+      ],
+      "targetType": "terraform",
+    },
+    {
+      "code": "aws-ec2-enforce-http-token-imds",
+      "column": "1",
+      "file": "test_data/aws.in.tf",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "tfsec",
+      "message": "Instance does not require IMDS access to require a token",
+      "ranges": [
+        {
+          "filePath": "test_data/aws.in.tf",
+          "length": "63",
+        },
+      ],
+      "targetType": "terraform",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "terraform",
+      "linter": "tfsec",
+      "paths": [
+        "test_data",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
`tfsec` added a note that they're migrating to trivy, but this shows up even with sarif output. Adds a simple parser that strips this leading text. We do not want to mark the snapshot as release-ready since the release tests won't have the parser.