### PR TITLE
Set hadolint timeout

### DIFF
--- a/linters/hadolint/plugin.yaml
+++ b/linters/hadolint/plugin.yaml
@@ -38,6 +38,7 @@ lint:
           run: hadolint ${target} -f json --no-fail
           success_codes: [0]
           cache_results: true
+      run_timeout: 20s
       direct_configs:
         - .hadolint.yaml
         - .hadolint.yml

--- a/linters/hadolint/plugin.yaml
+++ b/linters/hadolint/plugin.yaml
@@ -38,7 +38,7 @@ lint:
           run: hadolint ${target} -f json --no-fail
           success_codes: [0]
           cache_results: true
-      run_timeout: 20s
+      run_timeout: 1m
       direct_configs:
         - .hadolint.yaml
         - .hadolint.yml


### PR DESCRIPTION
We should lower our global timeout as well, but 20s is a generous timeout we can use for hadolint to avoid the macos issues.