### PR TITLE
Upgrade trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.15.0
+  version: 1.15.1-beta.9
 
 api:
   address: api.trunk-staging.io:8443

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -24,7 +24,6 @@ export const executionEnv = (sandbox: string) => {
     ...strippedEnv,
     // This keeps test downloads separate from manual trunk invocations
     TRUNK_DOWNLOAD_CACHE: DOWNLOAD_CACHE,
-    TRUNK_TELEMETRY: "off",
     // This is necessary to prevent launcher collision of non-atomic operations
     TMPDIR: path.resolve(sandbox, TEMP_SUBDIR),
   };


### PR DESCRIPTION
This uses the latest version with the MacOS fixes, so we should be able to use crashpad again.