### PR TITLE
Trufflehog ignore rule

### DIFF
--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -26,7 +26,9 @@ lint:
       commands:
         - name: lint
           output: sarif
-          run: trufflehog filesystem --json --fail --no-verification --no-update ${target}
+          run:
+            trufflehog filesystem --json --fail --no-verification --no-update
+            --exclude-detectors=PagerDutyApiKey ${target}
           read_output_from: stdout
           success_codes: [0, 183]
           is_security: true


### PR DESCRIPTION
Ignore the PagerDutyApiKey detector as it has shown a lot of false positive with `--no-verification`, particularly in lock files.