### PR TITLE
Allow actionlint to run shellcheck on run blocks

### DIFF
--- a/linters/actionlint/plugin.yaml
+++ b/linters/actionlint/plugin.yaml
@@ -28,7 +28,7 @@ lint:
     - name: actionlint
       files: [github-workflow]
       # Custom parser/trigger type defined in the trunk cli.
-      tools: [actionlint]
+      tools: [actionlint, shellcheck]
       commands:
         - name: lint
           output: actionlint


### PR DESCRIPTION
actionlint will run shellcheck on run blocks as long as it is in path.