### PR TITLE
Add new snapshots for remark-lint and actionlint

### DIFF
--- a/linters/actionlint/test_data/actionlint_v1.6.26_CUSTOM.check.shot
+++ b/linters/actionlint/test_data/actionlint_v1.6.26_CUSTOM.check.shot
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter actionlint test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "code": "events",
+      "column": "13",
+      "file": ".github/workflows/bad.in.yaml",
+      "issueClass": "ISSUE_CLASS_NEW",
+      "issueUrl": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "actionlint",
+      "message": "invalid CRON format "0 */3 * *" in schedule event: expected exactly 5 fields, found 4: [0 */3 * *]",
+      "targetType": "github-workflow",
+    },
+    {
+      "code": "events",
+      "column": "13",
+      "file": ".github/workflows/bad.in.yaml",
+      "issueClass": "ISSUE_CLASS_NEW",
+      "issueUrl": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "actionlint",
+      "message": "scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes",
+      "targetType": "github-workflow",
+    },
+    {
+      "code": "syntax-check",
+      "column": "1",
+      "file": ".github/workflows/empty.in.yaml",
+      "issueClass": "ISSUE_CLASS_NEW",
+      "issueUrl": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "actionlint",
+      "message": "workflow is empty",
+      "targetType": "github-workflow",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "github-workflow",
+      "linter": "actionlint",
+      "paths": [
+        ".github/workflows/bad.in.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "github-workflow",
+      "linter": "actionlint",
+      "paths": [
+        ".github/workflows/empty.in.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/remark-lint/test_data/remark_lint_v12.0.0_basic.check.shot
+++ b/linters/remark-lint/test_data/remark_lint_v12.0.0_basic.check.shot
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter remark-lint test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "list-item-indent",
+      "column": "4",
+      "file": "test_data/basic.in.md",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "remark-lint",
+      "message": "Incorrect list-item indent: add 1 space",
+      "targetType": "markdown",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "fmt",
+      "fileGroupName": "markdown",
+      "linter": "remark-lint",
+      "paths": [
+        "test_data/basic.in.md",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "markdown",
+      "linter": "remark-lint",
+      "paths": [
+        "test_data/basic.in.md",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
+      "column": "1",
+      "file": "test_data/basic.in.md",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "remark-lint",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
+}
+`;

--- a/linters/remark-lint/test_data/remark_lint_v12.0.0_basic.fmt.shot
+++ b/linters/remark-lint/test_data/remark_lint_v12.0.0_basic.fmt.shot
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter remark-lint test basic 1`] = `
+"* this is a list item
+  indented with tabs
+
+* this is a list item
+  indented with spaces
+
+Code:
+
+\`\`\`
+this code block is indented by one tab
+\`\`\`
+
+And:
+
+\`\`\`
+	this code block is indented by two tabs
+\`\`\`
+
+And:
+
+\`\`\`
+	+ this is an example list item
+		indented with tabs
+
++   this is an example list item
+    indented with spaces
+\`\`\`
+"
+`;


### PR DESCRIPTION
Both released new versions. Notably the formatting result for remark-lint changed, but it seems fine enough.

Note that this will introduce conflicts with #481, but that won't be able to land/release until the relevant CLI changes have released.