### PR TITLE
Remove python docstrings from ruff default rules

### DIFF
--- a/linters/ruff/ruff.toml
+++ b/linters/ruff/ruff.toml
@@ -1,5 +1,5 @@
 # Generic, formatter-friendly config.
-select = ["B", "D3", "D4", "E", "F"]
+select = ["B", "D3", "E", "F"]
 
 # Never enforce `E501` (line length violations). This should be handled by formatters.
 ignore = ["E501"]


### PR DESCRIPTION
Ruff's primary offering is more than just docstrings, and this can be really noisy on init. Let's remove it and users can always add it back in. This will effect users on init and `trunk check enable ruff` and the default config we dump. See https://github.com/trunk-io/configs/pull/30