### PR TITLE
Update jq definition to handle release label including jq-

### DIFF
--- a/tools/jq/plugin.yaml
+++ b/tools/jq/plugin.yaml
@@ -1,3 +1,4 @@
+version: 0.1
 downloads:
   - name: jq
     args:

--- a/tools/jq/plugin.yaml
+++ b/tools/jq/plugin.yaml
@@ -1,26 +1,24 @@
-version: 0.1
 downloads:
   - name: jq
+    args:
+      semver: ${version}=>(?:jq-|)?(?P<semver>.*)
     executable: true
     downloads:
       - os:
           linux: linux
         cpu:
           x86_64: amd64
-        url: https://github.com/jqlang/jq/releases/download/jq-${version}/jq-linux64
-        version: <=1.6.0
+        url: https://github.com/jqlang/jq/releases/download/jq-${semver}/jq-linux64
       - os:
           macos: darwin
-        url: https://github.com/jqlang/jq/releases/download/jq-${version}/jq-osx-amd64
-        version: <=1.6.0
+        url: https://github.com/jqlang/jq/releases/download/jq-${semver}/jq-osx-amd64
       - os:
           windows: win
-        url: https://github.com/jqlang/jq/releases/download/jq-${version}/jq-win64.exe
-        version: <=1.6.0
+        url: https://github.com/jqlang/jq/releases/download/jq-${semver}/jq-win64.exe
 tools:
   definitions:
     - name: jq
-      known_good_version: 1.6
+      known_good_version: 1.7
       download: jq
       shims:
         - name: jq


### PR DESCRIPTION
JQ was not properly defined with semver parsing from GH release data. Fixed now. And removed the version check