### PR TITLE
osv-scanner wants to know where GO is located so it can scan it

### DIFF
--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -45,7 +45,7 @@ lint:
       suggest_if: files_present
       environment:
         - name: PATH
-          list: ["${linter}"]    
+          list: ["${linter}"]
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -28,6 +28,7 @@ lint:
       files: [lockfile]
       tools: [osv-scanner]
       known_good_version: 1.3.6
+      runtime: go
       commands:
         - name: scan
           output: sarif
@@ -44,10 +45,7 @@ lint:
       suggest_if: files_present
       environment:
         - name: PATH
-          list: ["${linter}"]
-        - name: GOROOT
-          value: ${env.GOROOT}
-          optional: true          
+          list: ["${linter}"]    
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -45,6 +45,9 @@ lint:
       environment:
         - name: PATH
           list: ["${linter}"]
+        - name: GOROOT
+          value: ${env.GOROOT}
+          optional: true          
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version


### PR DESCRIPTION
osv-scanner wants to be able to scan the go version for security issues. Need to pass that along now for scanning. 

This makes a dep on go in definition for the linter so we pull in go. Really we'd want to add go to path if it exists on the system. 