### PR TITLE
Ignore trufflehog launch darkly detection

### DIFF
--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -28,7 +28,7 @@ lint:
           output: sarif
           run:
             trufflehog filesystem --json --fail --no-verification --no-update
-            --exclude-detectors=PagerDutyApiKey ${target}
+            --exclude-detectors=PagerDutyApiKey,LaunchDarkly ${target}
           read_output_from: stdout
           success_codes: [0, 183]
           is_security: true


### PR DESCRIPTION
Much like PagerDutyApiKey, this can trigger a lot of false positives from seemingly innocuous lines when running with `--no-verification`. We will want to audit post-release if we can turn verification on with batching.