### PR TITLE
Mark bad pmd version 7.0.0-rc4

### DIFF
--- a/linters/pmd/plugin.yaml
+++ b/linters/pmd/plugin.yaml
@@ -49,6 +49,7 @@ lint:
       suggest_if: never
       known_good_version: 6.55.0
       known_bad_versions:
+        - pmd_releases/7.0.0-rc4
         - pmd_releases/7.0.0-rc3
         - pmd_releases/7.0.0-rc2
         - pmd_releases/7.0.0-rc1


### PR DESCRIPTION
We mark their rc versions as bad versions, mainly because we consider their syntax to be malformed semver (we expect `7.0.0-rc.4`)