### PR TITLE
Update codespell and trufflehog snapshots

### DIFF
--- a/linters/codespell/test_data/codespell_v2.2.6_basic.check.shot
+++ b/linters/codespell/test_data/codespell_v2.2.6_basic.check.shot
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter codespell test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "misspelled",
+      "file": "codespell.test.ts",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "codespell",
+      "message": "callbak ==> callback",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "codespell.test.ts",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "codespell",
+      "message": "realy ==> really, relay",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_md.in.md",
+      "level": "LEVEL_HIGH",
+      "line": "5",
+      "linter": "codespell",
+      "message": "realy ==> really, relay",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_py.in.py",
+      "level": "LEVEL_HIGH",
+      "line": "20",
+      "linter": "codespell",
+      "message": "callbak ==> callback",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_py.in.py",
+      "level": "LEVEL_HIGH",
+      "line": "20",
+      "linter": "codespell",
+      "message": "lamda ==> lambda",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_py.in.py",
+      "level": "LEVEL_HIGH",
+      "line": "22",
+      "linter": "codespell",
+      "message": "anme ==> name, anime",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_ts.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "17",
+      "linter": "codespell",
+      "message": "callbakc ==> callback",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_ts.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "18",
+      "linter": "codespell",
+      "message": "callbak ==> callback",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_ts.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "19",
+      "linter": "codespell",
+      "message": "asnyc ==> async",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        ".trunk/trunk.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "codespell.test.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "codespell_to_sarif.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "plugin.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "result.json",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_md.in.md",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_py.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_ts.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/empty.in.txt",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/codespell/test_data/codespell_v2.2.6_dictionary.check.shot
+++ b/linters/codespell/test_data/codespell_v2.2.6_dictionary.check.shot
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter codespell test dictionary 1`] = `
+{
+  "issues": [
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_py.in.py",
+      "level": "LEVEL_HIGH",
+      "line": "20",
+      "linter": "codespell",
+      "message": "lamda ==> lambda",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_py.in.py",
+      "level": "LEVEL_HIGH",
+      "line": "22",
+      "linter": "codespell",
+      "message": "anme ==> name, anime",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_ts.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "17",
+      "linter": "codespell",
+      "message": "callbakc ==> callback",
+      "targetType": "ALL",
+    },
+    {
+      "code": "misspelled",
+      "file": "test_data/basic_ts.in.ts",
+      "level": "LEVEL_HIGH",
+      "line": "19",
+      "linter": "codespell",
+      "message": "asnyc ==> async",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        ".codespellrc",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        ".trunk/trunk.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "codespell.test.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "codespell_to_sarif.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "plugin.yaml",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "result.json",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_md.in.md",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_py.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/basic_ts.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "codespell",
+      "paths": [
+        "test_data/empty.in.txt",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_git_v3.59.0_CUSTOM.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_git_v3.59.0_CUSTOM.check.shot
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog-git test CUSTOM 1`] = `
+{
+  "issues": [
+    {
+      "code": "AWS",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:2: Secret detected: AKIAXYZDQCEN4EXAMPLE on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:6: Secret detected on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "PrivateKey",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:11: Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": ".",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "trufflehog-git",
+      "message": "secrets.in.py:8: Secret detected: https://admin:********@the-internet.herokuapp.com on commit <hash> (file since deleted)",
+      "targetType": "ALL",
+    },
+    {
+      "code": "PrivateKey",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "11",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "AWS",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: AKIAXYZDQCEN4EXAMPLE on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "trufflehog-git",
+      "message": "Secret detected on commit <hash>",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "secrets2.in.py",
+      "isSecurity": true,
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "line": "8",
+      "linter": "trufflehog-git",
+      "message": "Secret detected: https://admin:********@the-internet.herokuapp.com on commit <hash>",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog-git",
+      "paths": [
+        ".",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.59.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.59.0_buff_size.check.shot
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog test buff_size 1`] = `
+{
+  "issues": [
+    {
+      "code": "URI",
+      "file": "test_data/buff_size.in.cc",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "232",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://gitlab-ci-token:********@gitlab.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/buff_size.in.cc",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trufflehog/test_data/trufflehog_v3.59.0_secrets.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.59.0_secrets.check.shot
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter trufflehog test secrets 1`] = `
+{
+  "issues": [
+    {
+      "code": "PrivateKey",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "11",
+      "linter": "trufflehog",
+      "message": "Secret detected: -----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFl",
+      "targetType": "ALL",
+    },
+    {
+      "code": "AWS",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "trufflehog",
+      "message": "Secret detected: AKIAXYZDQCEN4EXAMPLE",
+      "targetType": "ALL",
+    },
+    {
+      "code": "Github",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "trufflehog",
+      "message": "Secret detected",
+      "targetType": "ALL",
+    },
+    {
+      "code": "URI",
+      "file": "test_data/secrets.in.py",
+      "isSecurity": true,
+      "level": "LEVEL_HIGH",
+      "line": "8",
+      "linter": "trufflehog",
+      "message": "Secret detected: https://admin:********@the-internet.herokuapp.com",
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trufflehog",
+      "paths": [
+        "test_data/secrets.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
New releases of each that each differ by 1 diagnostic from the previous. Existing snapshot tests are fine