### PR TITLE
fix: disable trivy fs-vuln

### DIFF
--- a/linters/trivy/README.md
+++ b/linters/trivy/README.md
@@ -1,0 +1,25 @@
+# Trivy
+
+Trivy has the following subcommands:
+
+- `config`
+  - Runs `trivy config`
+    ([docs](https://aquasecurity.github.io/trivy/latest/docs/scanner/misconfiguration/)) to scan for
+    misconfigurations in infrastructure-as-code files. Enabled by default.
+- `fs-vuln`
+  - Runs `trivy fs --scanners vuln`
+    ([docs](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/)) to scan for
+    security vulnerabilities. Disabled by default.
+- `fs-secret`
+  - Runs `trivy fs --scanners secret`
+    ([docs](https://aquasecurity.github.io/trivy/latest/docs/target/filesystem/)) to scan for
+    secrets. Disabled by default.
+
+To enable/disable these, add the subcommands you want enabled in your trunk.yaml as such:
+
+```yaml
+lint:
+  enabled:
+    - trivy@0.45.1:
+        commands: [config, fs-vuln]
+```

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -41,6 +41,7 @@ lint:
           # Trivy does not support batching
           batch: false
           is_security: true
+          enabled: false
           parser:
             runtime: python
             run: python3 ${plugin}/linters/trivy/trivy_fs_vuln_to_sarif.py


### PR DESCRIPTION
Trivy fs-vuln and osv-scanner report duplicate issues - after discussion [here](https://docs.google.com/document/d/1uS4CUtlM3MnvzTxn2iRGF9GMagVAIcVbDqKdQaDJOl4/edit), we've decided to disable trivy fs-vuln for now and potentially handle duplicate issues more robustly down the line.