### PR TITLE
fix(trufflehog): linter name referenced by --filter

### DIFF
--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -80,7 +80,7 @@ actions:
     - id: trufflehog-pre-commit
       description: Don't allow secrets in commits (via Trufflehog)
       display_name: Trufflehog Pre-Commit Hook
-      run: trunk check -t "git-commit" --upstream=HEAD --filter=trufflehog-git
+      run: trunk check -t "git-commit" --upstream=HEAD --filter=trufflehog
       interactive: optional
       triggers:
         - git_hooks: [pre-commit]


### PR DESCRIPTION
I am unable to commit to my repo after enabling the `trufflehog-pre-commit` action.

`.trunk/logs/cli.log` is showing:

```
[10-04 20:50:00] [client.cc:19] GRPC Failed (error code INTERNAL): [--filter] 'trufflehog-git' is not enabled
```

It looks like the `--filter` option of the `trunk check` command in the actions definition is incorrectly referencing the `trufflehog` linter...

Running this in the CLI:
```
trunk check -t "git-commit" --upstream=HEAD --filter=trufflehog-git
```

Results in:
```
✖ [--filter] 'trufflehog-git' is not enabled
```

This runs fine in the CLI:
```
trunk check -t "git-commit" --upstream=HEAD --filter=trufflehog
```