### PR TITLE
run trunk check action on PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,21 +1,7 @@
 name: Pull Request
 on: [pull_request, workflow_dispatch]
 
-# needs read-all + checks: write, but there's no shorthand for that
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  deployments: read
-  id-token: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -185,6 +171,8 @@ jobs:
     name: Trunk Check runner [linux]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      checks: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,9 @@
 name: Pull Request
 on: [pull_request, workflow_dispatch]
 
-permissions: write-all
+permissions:
+  contents: read
+  checks: write
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -181,9 +183,6 @@ jobs:
       - name: Trunk Check
         # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
         uses: trunk-io/trunk-action@main
-        with:
-          debug: true
-          arguments: --debug
         env:
           TRUNK_GITHUB_CHECK_RUN_TITLE: Trunk Check
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,21 @@
 name: Pull Request
 on: [pull_request, workflow_dispatch]
 
+# needs read-all + checks: write, but there's no shorthand for that
 permissions:
-  contents: read
+  actions: read
   checks: write
+  contents: read
+  deployments: read
+  id-token: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -181,6 +181,9 @@ jobs:
       - name: Trunk Check
         # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
         uses: trunk-io/trunk-action@main
+        with:
+          debug: true
+          arguments: --debug
         env:
           TRUNK_GITHUB_CHECK_RUN_TITLE: Trunk Check
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -179,6 +179,7 @@ jobs:
           lfs: true
 
       - name: Trunk Check
+        # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
         uses: trunk-io/trunk-action@main
         env:
           TRUNK_GITHUB_CHECK_RUN_TITLE: Trunk Check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -167,6 +167,22 @@ jobs:
             needs.detect_changes.outputs.tools-files }}
           trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
+  trunk_check_runner:
+    name: Trunk Check runner [linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@main
+        env:
+          TRUNK_GITHUB_CHECK_RUN_TITLE: Trunk Check
+
   # Run Windows tests for modified linters and tools
   # TODO(Tyler): When this is more stabilized and we want to gate on it, we can make it part of the matrix above.
   windows_linter_tests:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 on: [pull_request, workflow_dispatch]
 
-permissions: read-all
+permissions: write-all
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
As we no longer run check-on-PRs on forks, we're going back to the legacy trunk action for checks in this PR.

After this merges, we will set the new job as required and remove the required status from check-on-PRs.