### PR TITLE
Skip sourcery linter tests

### DIFF
--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -23,5 +23,14 @@ lint:`,
 linterCheckTest({
   linterName: "sourcery",
   preCheck,
-  skipTestIf: skipCPUOS([{ os: "linux", cpu: "arm64" }]),
+  skipTestIf: (version) => {
+    if (!process.env.SOURCERY_TOKEN) {
+      // NOTE(Tyler): This is the simplest approach in order to streamline local development and running from forks.
+      console.log(
+        "Skipping sourcery test. Must provide SOURCERY_TOKEN environment variable in order to run.",
+      );
+      return true;
+    }
+    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
+  },
 });


### PR DESCRIPTION
Prevent linter sourcery tests from running when the token is not set. This is designed to make local development simpler and allow for a better experience from [forks](https://github.com/trunk-io/plugins/pull/517). Adds a log if the test is skipped.

Tested on https://github.com/trunk-io/plugins/pull/520.