### PR TITLE
refactor(tfsec): add direct config files for tfsec

### DIFF
--- a/linters/tfsec/plugin.yaml
+++ b/linters/tfsec/plugin.yaml
@@ -47,3 +47,9 @@ lint:
       version_command:
         parse_regex: v${semver}
         run: tfsec --version
+      direct_configs:
+        - tfsec.yml
+        - tfsec.yaml
+        - .tfsec/config.json
+        - .tfsec/config.yml
+        - .tfsec/config.yaml


### PR DESCRIPTION
Add tfsec config variations as direct config files.

The tool supports specifing these via `--config-file`.
I wasn't certain of how to map that if it was required, so left just the direct mapping.

[tfsec documentation](https://aquasecurity.github.io/tfsec/v1.28.4/guides/configuration/config/)
