### PR TITLE
Fix for ruff 0.1.0

### DIFF
--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -12,6 +12,16 @@ lint:
       files: [python]
       commands:
         - name: lint
+          # As of ruff v0.1.0, --format is replaced with --output-format
+          version: ">=0.1.0"
+          run: ruff check --cache-dir ${cachedir} --output-format json ${target}
+          output: sarif
+          parser:
+            runtime: python
+            run: python3 ${cwd}/ruff_to_sarif.py 0
+          batch: true
+          success_codes: [0, 1]
+        - name: lint
           # As of ruff v0.0.266, column edits are 1-indexed
           version: ">=0.0.266"
           run: ruff check --cache-dir ${cachedir} --format json ${target}

--- a/linters/ruff/test_data/ruff_nbqa_v0.1.0_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.1.0_basic_nb.check.shot
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
+{
+  "issues": [
+    {
+      "code": "error",
+      "file": "test_data/basic_nb.in.ipynb",
+      "level": "LEVEL_HIGH",
+      "linter": "ruff-nbqa",
+      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused
+Found 1 error.
+[*] 1 fixable with the \`--fix\` option.",
+      "targetType": "jupyter",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff-nbqa",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/test_data/ruff_v0.1.0_basic.check.shot
+++ b/linters/ruff/test_data/ruff_v0.1.0_basic.check.shot
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "E402",
+      "column": "1",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#E402",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "ruff",
+      "message": "Module level import not at top of file",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "10",
+          "offset": "83",
+        },
+      ],
+      "targetType": "python",
+    },
+    {
+      "autofixOptions": [
+        {
+          "message": "Remove unused import: \`sys\`",
+          "replacements": [
+            {
+              "filePath": "test_data/basic.in.py",
+              "length": "11",
+              "offset": "83",
+            },
+          ],
+        },
+      ],
+      "code": "F401",
+      "column": "8",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "ruff",
+      "message": "\`sys\` imported but unused",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "3",
+          "offset": "90",
+        },
+      ],
+      "targetType": "python",
+    },
+    {
+      "code": "E402",
+      "column": "1",
+      "file": "test_data/basic.in.py",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#E402",
+      "level": "LEVEL_HIGH",
+      "line": "9",
+      "linter": "ruff",
+      "message": "Module level import not at top of file",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "11",
+          "offset": "120",
+        },
+      ],
+      "targetType": "python",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Ruff just released [`v0.1.0`](https://github.com/astral-sh/ruff/releases/tag/v0.1.0). This includes a lot of changes, but namely deprecating the `--format` option in favor of `--output-format`.

I plan to make a new release after this lands.