### PR TITLE
Fix terrascan

### DIFF
--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -51,5 +51,5 @@ lint:
         run: terrascan version
       environment:
         - name: PATH
-          list: ["${linter}"]
+          list: ["${linter}", "${env.PATH}"]
       direct_configs: [terrascan_config.toml]

--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -51,5 +51,5 @@ lint:
         run: terrascan version
       environment:
         - name: PATH
-          list: ["${linter}", "${env.PATH}"]
+          list: ["${linter}"]
       direct_configs: [terrascan_config.toml]

--- a/linters/terrascan/terrascan.test.ts
+++ b/linters/terrascan/terrascan.test.ts
@@ -1,3 +1,11 @@
 import { linterCheckTest } from "tests";
+import { TrunkLintDriver } from "tests/driver";
 
-linterCheckTest({ linterName: "terrascan" });
+// NOTE(Tyler): Terrascan will sometimes fail due to a git error:
+// "failed to fetch references from git repo. error: 'some refs were not updated'"
+// Add a remote in order to avoid this error.
+const preCheck = async (driver: TrunkLintDriver) => {
+  await driver.gitDriver?.addRemote("origin", driver.getSandbox());
+};
+
+linterCheckTest({ linterName: "terrascan", preCheck });


### PR DESCRIPTION
Terrascan is failing tests on [MacOS nightly](https://github.com/trunk-io/plugins/actions/runs/6585061572/job/17890774904) and Windows but not on Linux. They haven't released an update in a while, so this is likely a slight regression due to our PATH changes. Nevertheless, this is the only linter that's having a problem, and since terrascan appears to need to be git aware, we simply will add the SYSTEM path here.