### PR TITLE
Find line/col information from markdown-link-check

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,8 +20,6 @@ plugins:
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin
 
-  enabled:
-    - markdown-link-check@3.11.2
   disabled:
     - pylint # pylint diagnostics are too strict
 

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,8 @@ plugins:
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin
 
+  enabled:
+    - markdown-link-check@3.11.2
   disabled:
     - pylint # pylint diagnostics are too strict
 

--- a/linters/markdown-link-check/plugin.yaml
+++ b/linters/markdown-link-check/plugin.yaml
@@ -21,7 +21,7 @@ lint:
           read_output_from: stdout
           parser:
             runtime: python
-            run: python3 ${plugin}/linters/markdown-link-check/parse.py
+            run: python3 ${plugin}/linters/markdown-link-check/parse.py --target="${target}"
       suggest_if: never
       known_good_version: 3.11.2
       version_command:

--- a/linters/markdown-link-check/test_data/markdown_link_check_v3.11.2_basic.check.shot
+++ b/linters/markdown-link-check/test_data/markdown_link_check_v3.11.2_basic.check.shot
@@ -4,19 +4,23 @@ exports[`Testing linter markdown-link-check test basic 1`] = `
 {
   "issues": [
     {
-      "code": "0",
+      "code": "404",
+      "column": "12",
       "file": "test_data/basic.in.md",
       "level": "LEVEL_HIGH",
+      "line": "3",
       "linter": "markdown-link-check",
-      "message": "https://nowhere.com/bad-link",
+      "message": "#bad-header",
       "targetType": "markdown",
     },
     {
-      "code": "404",
+      "code": "0",
+      "column": "12",
       "file": "test_data/basic.in.md",
       "level": "LEVEL_HIGH",
+      "line": "4",
       "linter": "markdown-link-check",
-      "message": "#bad-header",
+      "message": "https://nowhere.com/bad-link",
       "targetType": "markdown",
     },
   ],


### PR DESCRIPTION
markdown-link-check kind of sucks since it doesn't have a sarif output - but for now we can find line/col ourselves and report if we can get it.