### PR TITLE
Fix OSV scanner env

### DIFF
--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -44,7 +44,7 @@ lint:
       suggest_if: files_present
       environment:
         - name: PATH
-          list: ["${linter}"]
+          list: ["${env.PATH}"]
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -1,9 +1,25 @@
 version: 0.1
+downloads:
+  - name: osv-scanner
+    version: 1.3.6
+    executable: true
+    downloads:
+      - os:
+          linux: linux
+          macos: darwin
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_${os}_${cpu}
+      - os: windows
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_windows_${cpu}.exe
 tools:
   definitions:
     - name: osv-scanner
-      runtime: go
-      package: github.com/google/osv-scanner/cmd/osv-scanner
+      download: osv-scanner
       shims: [osv-scanner]
       known_good_version: 1.3.6
 lint:
@@ -28,7 +44,7 @@ lint:
       suggest_if: files_present
       environment:
         - name: PATH
-          list: ["${env.PATH}"]
+          list: ["${linter}"]
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -1,25 +1,9 @@
 version: 0.1
-downloads:
-  - name: osv-scanner
-    version: 1.3.6
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-          macos: darwin
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_${os}_${cpu}
-      - os: windows
-        cpu:
-          x86_64: amd64
-          arm_64: arm64
-        url: https://github.com/google/osv-scanner/releases/download/v${version}/osv-scanner_${version}_windows_${cpu}.exe
 tools:
   definitions:
     - name: osv-scanner
-      download: osv-scanner
+      runtime: go
+      package: github.com/google/osv-scanner/cmd/osv-scanner
       shims: [osv-scanner]
       known_good_version: 1.3.6
 lint:

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -44,7 +44,7 @@ lint:
       suggest_if: files_present
       environment:
         - name: PATH
-          list: ["${linter}"]
+          list: ["${linter}", "${env.PATH}"]
       version_command:
         parse_regex: "version: ${version}"
         run: osv-scanner --version


### PR DESCRIPTION
Needs to access system path for go sometimes. also, having ${linter} in the path is redundant if you have a tool.