### PR TITLE
Disable sourcery tests

### DIFF
--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -19,6 +19,10 @@ lint:
           batch: true
           # NOTE(Tyler): Autofixes will show up as complete "formatting-like" diagnostics. However, strictly speaking, this isn't a formatter, so we don't want to set formatter: true
           in_place: true
+      environment:
+        - name: PATH
+          # needs system path for license verification
+          list: ["${linter}", "${env.PATH}"]
       tools: [sourcery]
       suggest_if: never
       direct_configs:

--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -23,14 +23,18 @@ lint:`,
 linterCheckTest({
   linterName: "sourcery",
   preCheck,
-  skipTestIf: (version) => {
-    if (!process.env.SOURCERY_TOKEN) {
-      // NOTE(Tyler): This is the simplest approach in order to streamline local development and running from forks.
-      console.log(
-        "Skipping sourcery test. Must provide SOURCERY_TOKEN environment variable in order to run.",
-      );
-      return true;
-    }
-    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
-  },
+  // TODO(Tyler): Sourcery's new pricing model means that we can no longer run trunk+sourcery
+  // in sandboxes with their open source tier. Disable this test until we have a robust solution.
+  skipTestIf: () => true,
+  // skipTestIf: (version) => {
+  //   return true;
+  //   if (!process.env.SOURCERY_TOKEN) {
+  //     // NOTE(Tyler): This is the simplest approach in order to streamline local development and running from forks.
+  //     console.log(
+  //       "Skipping sourcery test. Must provide SOURCERY_TOKEN environment variable in order to run.",
+  //     );
+  //     return true;
+  //   }
+  //   return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
+  // },
 });

--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { linterCheckTest } from "tests";
 import { TrunkLintDriver } from "tests/driver";
-import { skipCPUOS, TEST_DATA } from "tests/utils";
+import { TEST_DATA } from "tests/utils";
 
 // // You must login in order to use sourcery
 const preCheck = (driver: TrunkLintDriver) => {

--- a/linters/sourcery/test_data/_plugin.yaml
+++ b/linters/sourcery/test_data/_plugin.yaml
@@ -9,8 +9,7 @@ lint:
         - name: fix
           prepare_run: bash -c "sourcery login --token=${SOURCERY_TOKEN}"
       environment:
-        # TODO(Tyler): Once prepare_run supports proper environment template resolution, remove PATH and bash
         - name: PATH
-          list: ["${env.PATH}"]
+          list: ["${linter}", "${env.PATH}"]
         - name: SOURCERY_TOKEN
           value: ${env.SOURCERY_TOKEN}


### PR DESCRIPTION
Due to changes in sourcery's pricing model, sourcery can no longer be run with Trunk in their free tier. I'm disabling the tests until we have a more robust solution.