### PR TITLE
Disable new tool tests on Windows

### DIFF
--- a/tools/gulp/gulp.test.ts
+++ b/tools/gulp/gulp.test.ts
@@ -1,4 +1,5 @@
 import { makeToolTestConfig, toolTest } from "tests";
+import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "gulp",
@@ -9,4 +10,7 @@ toolTest({
       expectedOut: "Local version: 4.0.2",
     }),
   ],
+  // On Windows, the shim is gulp.cmd, and we don't support platform-specific shims yet.
+  // To use on Windows, override the shim with gulp.cmd.
+  skipTestIf: skipOS(["win32"]),
 });

--- a/tools/tailwindcss/tailwindcss.test.ts
+++ b/tools/tailwindcss/tailwindcss.test.ts
@@ -1,4 +1,5 @@
 import { makeToolTestConfig, toolTest } from "tests";
+import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "tailwindcss",
@@ -9,4 +10,7 @@ toolTest({
       expectedOut: "tailwindcss v3.3.5",
     }),
   ],
+  // On Windows, the shim is tailwindcss.cmd, and we don't support platform-specific shims yet.
+  // To use on Windows, override the shim with tailwindcss.cmd.
+  skipTestIf: skipOS(["win32"]),
 });

--- a/tools/webpack/webpack.test.ts
+++ b/tools/webpack/webpack.test.ts
@@ -1,4 +1,5 @@
 import { makeToolTestConfig, toolTest } from "tests";
+import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "webpack",
@@ -9,4 +10,7 @@ toolTest({
       expectedOut: "Binaries:",
     }),
   ],
+  // On Windows, the shim is webpack.cmd, and we don't support platform-specific shims yet.
+  // To use on Windows, override the shim with webpack.cmd.
+  skipTestIf: skipOS(["win32"]),
 });


### PR DESCRIPTION
Because of weirdness of node shims, we don't support this at the moment. Disable these tests.