### PR TITLE
Support sourcery open source license

### DIFF
--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -5,6 +5,7 @@ lint:
       files: [python]
       commands:
         - name: lint
+          platforms: [linux, macos]
           output: regex
           run: bash -c "ln -s ${REPO_DIR}/.git .git; sourcery review  --no-summary --csv ${target}"
           parse_regex: ((?P<path>.*),(?P<line>\d+),(?P<code>.*),(?P<message>.*))
@@ -13,6 +14,7 @@ lint:
           batch: true
           cache_results: true
         - name: fix
+          platforms: [linux, macos]
           output: rewrite
           run:
             bash -c "ln -s ${REPO_DIR}/.git .git || true; sourcery review  --no-summary --csv --fix

--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -6,7 +6,7 @@ lint:
       commands:
         - name: lint
           output: regex
-          run: sourcery review  --no-summary --csv ${target}
+          run: bash -c "ln -s ${REPO_DIR}/.git .git; sourcery review  --no-summary --csv ${target}"
           parse_regex: ((?P<path>.*),(?P<line>\d+),(?P<code>.*),(?P<message>.*))
           success_codes: [0]
           read_output_from: stdout
@@ -14,7 +14,9 @@ lint:
           cache_results: true
         - name: fix
           output: rewrite
-          run: sourcery review  --no-summary --csv --fix ${target}
+          run:
+            bash -c "ln -s ${REPO_DIR}/.git .git || true; sourcery review  --no-summary --csv --fix
+            ${target}"
           success_codes: [0]
           batch: true
           # NOTE(Tyler): Autofixes will show up as complete "formatting-like" diagnostics. However, strictly speaking, this isn't a formatter, so we don't want to set formatter: true
@@ -23,6 +25,8 @@ lint:
         - name: PATH
           # needs system path for license verification
           list: ["${linter}", "${env.PATH}"]
+        - name: REPO_DIR
+          value: "${workspace}"
       tools: [sourcery]
       suggest_if: never
       direct_configs:

--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -38,6 +38,9 @@ linterCheckTest({
       );
       return true;
     }
-    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
+    return skipCPUOS([
+      { os: "linux", cpu: "arm64" },
+      { os: "win32", cpu: "x64" },
+    ])(version);
   },
 });

--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import path from "path";
 import { linterCheckTest } from "tests";
 import { TrunkLintDriver } from "tests/driver";
-import { REPO_ROOT, TEST_DATA, skipCPUOS } from "tests/utils";
+import { REPO_ROOT, skipCPUOS, TEST_DATA } from "tests/utils";
 
 // // You must login in order to use sourcery
 const preCheck = (driver: TrunkLintDriver) => {
@@ -23,6 +23,7 @@ lint:`,
   // TODO(Tyler): Sourcery relies on checking if the repo is open source for its pricing model.
   // The sandbox tests run on a subset of the main repo, and it neesd access to the repo root .git folder in order to run.
   driver.deleteFile(".git");
+  // trunk-ignore(semgrep): This path is safe.
   fs.symlinkSync(path.join(REPO_ROOT, ".git"), path.join(driver.getSandbox(), ".git"));
 };
 

--- a/linters/sourcery/test_data/_plugin.yaml
+++ b/linters/sourcery/test_data/_plugin.yaml
@@ -13,3 +13,5 @@ lint:
           list: ["${linter}", "${env.PATH}"]
         - name: SOURCERY_TOKEN
           value: ${env.SOURCERY_TOKEN}
+        - name: REPO_DIR
+          value: "${workspace}"

--- a/linters/sourcery/test_data/_plugin.yaml
+++ b/linters/sourcery/test_data/_plugin.yaml
@@ -5,8 +5,10 @@ lint:
     - name: sourcery
       commands:
         - name: lint
+          platforms: [linux, macos]
           prepare_run: bash -c "sourcery login --token=${SOURCERY_TOKEN}"
         - name: fix
+          platforms: [linux, macos]
           prepare_run: bash -c "sourcery login --token=${SOURCERY_TOKEN}"
       environment:
         - name: PATH


### PR DESCRIPTION
The sandbox needs to have a symlink to the repo root .git in order to be able to work for the open source license. This is what we use and should unblock any users who use trunk+sourcery with sourcery's open source license.

As a result of the need to create this symlink, we also necessarily can't support Windows for the near term (anyone on Windows with a paid token can still run it with some minor overrides).