### PR TITLE
make black lint python interface files as well

### DIFF
--- a/linters/black/plugin.yaml
+++ b/linters/black/plugin.yaml
@@ -9,7 +9,7 @@ tools:
 lint:
   definitions:
     - name: black
-      files: [python, jupyter]
+      files: [python, jupyter, python-interface]
       commands:
         - name: format
           output: rewrite


### PR DESCRIPTION
Add .pyi as a file extension to lint for black