### PR TITLE
Fix eslint and nixpkgs-fmt tests

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -93,4 +93,4 @@ runs:
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
         SOURCERY_TOKEN: ${{ inputs.sourcery-token }}
-        DEBUG: Driver:nixpkgs-fmt:*
+        DEBUG: Driver:nixpkgs-fmt:*, Driver:eslint:*

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.17.2
+  version: 1.17.3-beta.13
 
 api:
   address: api.trunk-staging.io:8443
@@ -79,3 +79,6 @@ tools:
   enabled:
     - clangd-indexing-tools@16.0.2
     - clangd@16.0.2
+  runtimes:
+    # expose shims in .trunk/tools
+    - node

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.17.3-beta.13
+  version: 1.17.3-beta.15
 
 api:
   address: api.trunk-staging.io:8443

--- a/linters/eslint/eslint.test.ts
+++ b/linters/eslint/eslint.test.ts
@@ -57,6 +57,10 @@ const preCheck = (driver: TrunkLintDriver) => {
       },
     );
     driver.debug(install);
+    if (install.status !== 0) {
+      driver.debug(install.stdout.toString());
+      driver.debug(install.stderr.toString());
+    }
   } catch (err: any) {
     console.warn("Error installing eslint deps");
     console.warn(err);

--- a/linters/eslint/eslint.test.ts
+++ b/linters/eslint/eslint.test.ts
@@ -18,6 +18,14 @@ const preCheck = (driver: TrunkLintDriver) => {
   moveConfig(driver);
   // TODO(Tyler): Cache node_modules between runs
   try {
+    const trunkYamlPath = ".trunk/trunk.yaml";
+    const currentContents = driver.readFile(trunkYamlPath);
+    const newContents = currentContents.concat(`tools:
+    runtimes:
+      - node
+  `);
+    driver.writeFile(trunkYamlPath, newContents);
+
     // NOTE(Tyler): It is slower to use the hermetic Trunk installation of the npm shim, but it is safer for more platforms
     // and avoids unhelpful circular JSON error messages.
     driver.debug("About to install shims");

--- a/linters/nixpkgs-fmt/nixpkgs_fmt.test.ts
+++ b/linters/nixpkgs-fmt/nixpkgs_fmt.test.ts
@@ -10,7 +10,7 @@ const preCheck: TestCallback = (driver) => {
   const currentContents = driver.readFile(trunkYamlPath);
   const newContents = currentContents.concat(`runtimes:
   enabled:
-    - rust@1.65.0
+    - rust@1.71.1
 `);
   driver.writeFile(trunkYamlPath, newContents);
 };

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -94,10 +94,6 @@ plugins:
   sources:
   - id: trunk
     local: ${REPO_ROOT}
-tools:
-  runtimes:
-    # Supports eslint test npm install and additional debugging
-    - node
 lint:
   ignore:
     - linters: [ALL]

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -94,6 +94,10 @@ plugins:
   sources:
   - id: trunk
     local: ${REPO_ROOT}
+tools:
+  runtimes:
+    # Supports eslint test npm install and additional debugging
+    - node
 lint:
   ignore:
     - linters: [ALL]


### PR DESCRIPTION
- Eslint: new `tools.runtimes` functionality requires explicitly specifying runtime shims
- nixpkgs-fmt: transitive dependencies were no longer compatible with the pinned runtime version. Bumped to KGV, see #436
- Adds additional debug logs since eslint has been failing more frequently lately

This should fix the cross-repo tests since the new CLI versions will require these changes.

**These tests will not pass until we get a new staging release with Windows shim fixes. Will bump version and land after that's out.**