### PR TITLE
Fix ci flag in workflows

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -66,7 +66,7 @@ runs:
 
     - name: Run plugin tests
       if: runner.os == 'Windows'
-      run: npm test --ci ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }}
+      run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       shell: bash
       working-directory: ${{ inputs.path }}
       env:
@@ -87,7 +87,7 @@ runs:
         working-directory: ${{ inputs.path }}
         trunk-token: ${{ inputs.trunk-token  }}
         org: trunk-staging-org
-        run: npm test --ci ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }}
+        run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       env:
         PLUGINS_TEST_LINTER_VERSION: ${{ inputs.linter-version }}
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -50,7 +50,7 @@ runs:
 
     - name: Run plugin tests
       if: runner.os == 'Windows'
-      run: npm test --ci ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }}
+      run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       shell: bash
       working-directory: ${{ inputs.path }}
       env:
@@ -67,7 +67,7 @@ runs:
         working-directory: ${{ inputs.path }}
         trunk-token: ${{ inputs.trunk-token  }}
         org: trunk-staging-org
-        run: npm test --ci ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }}
+        run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       env:
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}

--- a/.github/workflows/repo_tests.reusable.yaml
+++ b/.github/workflows/repo_tests.reusable.yaml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci
 
       - name: Run repo tests
-        run: npm test --ci tests/repo_tests
+        run: npm test tests/repo_tests --ci
         env:
           PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
           PLUGINS_TEST_CLI_PATH: ${{ inputs.cli-path }}


### PR DESCRIPTION
Arm runners were parsing the `--ci` flag differently, causing positionals to not get passed to jest. Fix to put `--ci` at the end, which is safer anyway since it gets set implicitly if not detected, and it should really be showing up after `--` anyway.