### PR TITLE
DRAFT: Make commitlint into a linter

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,9 @@ plugins:
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin
 
+  enabled:
+    - codespell@2.2.6
+    - commitlint@18.4.3
   disabled:
     - pylint # pylint diagnostics are too strict
 
@@ -70,6 +73,7 @@ actions:
 
   enabled:
     # enabled actions inherited from github.com/trunk-io/configs plugin
+    - pre-commit-register
     - linter-test-helper
     - npm-check-pre-push
     - remove-release-snapshots

--- a/linters/commitlint/commitlint_to_sarif.py
+++ b/linters/commitlint/commitlint_to_sarif.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import sys
+
+
+def to_result_sarif(rule_id: str, message: str):
+    workspace = sys.argv[-1]
+    return {
+        "level": "error",
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": f"{workspace}/.git/COMMIT_EDITMSG",
+                    },
+                    "region": {
+                        "startColumn": 0,
+                        "startLine": 0,
+                    },
+                }
+            }
+        ],
+        "message": {
+            "text": message,
+        },
+        "ruleId": rule_id,
+    }
+
+
+def main():
+    results = []
+
+    for line in sys.stdin.readlines():
+        pattern = r"(?P<symbol>\S+)\s+(?P<message>.+)\s\[(?P<code>.+)\]"
+        match = re.match(pattern, line)
+
+        if match:
+            result = match.groupdict()
+            results.append(to_result_sarif(result["code"], result["message"]))
+
+    sarif = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{"results": results}],
+    }
+
+    print(json.dumps(sarif, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/linters/commitlint/plugin.yaml
+++ b/linters/commitlint/plugin.yaml
@@ -1,0 +1,42 @@
+version: 0.1
+tools:
+  definitions:
+    - name: commitlint
+      runtime: node
+      package: "@commitlint/cli"
+      extra_packages: ["@commitlint/config-conventional"]
+      known_good_version: 18.4.3
+      shims: [commitlint]
+lint:
+  files:
+    - name: pre-commit-registry
+      filenames:
+        - TRUNK-PRE-COMMIT-FILE
+  definitions:
+    - name: commitlint
+      files: [pre-commit-registry]
+      main_tool: commitlint
+      known_good_version: 18.4.3
+      commands:
+        - name: lint-scm
+          output: sarif
+          run: commitlint --format --edit ${workspace}/.git/COMMIT_EDITMSG
+          disable_upstream: true
+          success_codes: [0, 1]
+          parser:
+            runtime: python
+            run: python ${plugin}/linters/commitlint/commitlint_to_sarif.py ${workspace}
+  # triggers:
+  #   - linters:
+  #       - commitlint
+  #     paths:
+  #       - .git/COMMIT_EDITMSG
+  #       - TRUNK-PRE-COMMIT-FILE
+  #     targets:
+  #       - TRUNK-PRE-COMMIT-FILE
+actions:
+  definitions:
+    - id: pre-commit-register
+      run: echo "pre-commit" > TRUNK-PRE-COMMIT-FILE
+      triggers:
+        - git_hooks: [pre-commit]


### PR DESCRIPTION
Primarily to support VSCode SCM. Note that we don't support running on files in `.git/` right now, so this is just a prototype.