### PR TITLE
Add notifications for tool tests on nightly runs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -245,6 +245,8 @@ jobs:
   upload_tool_tests:
     name: Upload Tool Test Results
     needs: tool_tests_main
+    # Still run on test failure
+    if: always()
     uses: ./.github/workflows/upload_results.reusable.yaml
     secrets:
       TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -194,6 +194,10 @@ jobs:
   #   name: Upload Linter Test Results
   #   needs: linter_tests_release
   #   uses: ./.github/workflows/upload_results.reusable.yaml
+  #   secrets:
+  #     TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+  #     TRUNK_STAGING_API_TOKEN: ${{ secrets.TRUNK_STAGING_API_TOKEN }}
+  #     TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   #   with:
   #     plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
   #     upload-validated-versions: "true"
@@ -242,6 +246,8 @@ jobs:
     name: Upload Tool Test Results
     needs: tool_tests_main
     uses: ./.github/workflows/upload_results.reusable.yaml
+    secrets:
+      TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
     with:
       plugin-version: main
       results-prefix: tools-

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -251,7 +251,7 @@ jobs:
     with:
       plugin-version: main
       results-prefix: tools-
-      upload-validated-versions: "false"
+      upload-validated-versions: false
       test-type: tool
       test-ref: main
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,171 +24,171 @@ permissions:
   statuses: write
 
 jobs:
-  # Run tests against all linters for snapshots and latest version as they exist on main
-  # This job is used to diagnose plugin config health in advance of a release
-  linter_tests_main:
-    name: Plugin Tests Main
-    # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        linter-version: [Snapshots, Latest]
-        os: [ubuntu-x64, macOS, windows-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  # # Run tests against all linters for snapshots and latest version as they exist on main
+  # # This job is used to diagnose plugin config health in advance of a release
+  # linter_tests_main:
+  #   name: Plugin Tests Main
+  #   # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
+  #   runs-on: ${{ matrix.os }}
+  #   timeout-minutes: 120
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       linter-version: [Snapshots, Latest]
+  #       os: [ubuntu-x64, macOS, windows-latest]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Cache tool downloads
-        # ubuntu runner has persistent cache
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-        with:
-          path: /tmp/plugins_testing_download_cache
-          # No need to key on trunk version unless we change how we store downloads.
-          key: trunk-${{ runner.os }}
+  #     - name: Cache tool downloads
+  #       # ubuntu runner has persistent cache
+  #       if: matrix.os == 'windows-latest'
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+  #       with:
+  #         path: /tmp/plugins_testing_download_cache
+  #         # No need to key on trunk version unless we change how we store downloads.
+  #         key: trunk-${{ runner.os }}
 
-      - name: Delete cache
-        # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
-        if: env.TRIGGER != 'pull_request'
-        run: |
-          if [ -d "/tmp/plugins_testing_download_cache" ]
-          then
-            tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
-            mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
-            chmod -R u+w ${tmp_dir}
-            rm -rf ${tmp_dir}
-          fi
-        shell: bash
+  #     - name: Delete cache
+  #       # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
+  #       if: env.TRIGGER != 'pull_request'
+  #       run: |
+  #         if [ -d "/tmp/plugins_testing_download_cache" ]
+  #         then
+  #           tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
+  #           mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
+  #           chmod -R u+w ${tmp_dir}
+  #           rm -rf ${tmp_dir}
+  #         fi
+  #       shell: bash
 
-      - name: Linter Tests
-        uses: ./.github/actions/linter_tests
-        with:
-          linter-version: ${{ matrix.linter-version }}
-          sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+  #     - name: Linter Tests
+  #       uses: ./.github/actions/linter_tests
+  #       with:
+  #         linter-version: ${{ matrix.linter-version }}
+  #         sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+  #         trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
-  # Run tests against all linters for snapshots and latest version as they exist in latest release
-  # This job is used to update the list of validated versions
-  linter_tests_release:
-    name: Plugin Tests Release
-    # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 150
-    strategy:
-      fail-fast: false
-      matrix:
-        linter-version: [Snapshots, Latest]
-        os: [ubuntu-x64, macOS, windows-latest]
-        include:
-          # Normalize the filenames as inputs for ease of parsing
-          - os: ubuntu-x64
-            results-file: ubuntu-latest
-          - os: macOS
-            results-file: macos-latest
-          - os: windows-latest
-            results-file: windows-latest
-    outputs:
-      plugin-version: ${{ steps.get-release.outputs.tag }}
+  # # Run tests against all linters for snapshots and latest version as they exist in latest release
+  # # This job is used to update the list of validated versions
+  # linter_tests_release:
+  #   name: Plugin Tests Release
+  #   # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
+  #   runs-on: ${{ matrix.os }}
+  #   timeout-minutes: 150
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       linter-version: [Snapshots, Latest]
+  #       os: [ubuntu-x64, macOS, windows-latest]
+  #       include:
+  #         # Normalize the filenames as inputs for ease of parsing
+  #         - os: ubuntu-x64
+  #           results-file: ubuntu-latest
+  #         - os: macOS
+  #           results-file: macos-latest
+  #         - os: windows-latest
+  #           results-file: windows-latest
+  #   outputs:
+  #     plugin-version: ${{ steps.get-release.outputs.tag }}
 
-    steps:
-      - name: Retrieve git history
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Retrieve git history
+  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  #       with:
+  #         fetch-depth: 0
 
-      # This assumes that any changes on main since the last release are backwards compatible
-      # in terms of allowing existing linter tests to run.
-      - name: Preserve test runner latest behavior
-        shell: bash
-        run: |
-          cp -r tests tests.bak
-          cp package.json package.json.bak
-          cp package-lock.json package-lock.json.bak
-          cp -r .github/actions .github/actions.bak
-          cp -r .trunk .trunk.bak
-          cp tsconfig.json tsconfig.json.bak
-          cp jest.config.json jest.config.json.bak
-          cp .gitattributes .gitattributes.bak
-          # Include any newly generated snapshots that have been marked release-ready
-          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
-        continue-on-error: true
+  #     # This assumes that any changes on main since the last release are backwards compatible
+  #     # in terms of allowing existing linter tests to run.
+  #     - name: Preserve test runner latest behavior
+  #       shell: bash
+  #       run: |
+  #         cp -r tests tests.bak
+  #         cp package.json package.json.bak
+  #         cp package-lock.json package-lock.json.bak
+  #         cp -r .github/actions .github/actions.bak
+  #         cp -r .trunk .trunk.bak
+  #         cp tsconfig.json tsconfig.json.bak
+  #         cp jest.config.json jest.config.json.bak
+  #         cp .gitattributes .gitattributes.bak
+  #         # Include any newly generated snapshots that have been marked release-ready
+  #         grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
+  #       continue-on-error: true
 
-      - name: Get Latest Release
-        id: get-release
-        uses: WyriHaximus/github-action-get-previous-tag@385a2a0b6abf6c2efeb95adfac83d96d6f968e0c # v1.3.0
-        with:
-          # only use releases tagged v<semver>
-          prefix: v
+  #     - name: Get Latest Release
+  #       id: get-release
+  #       uses: WyriHaximus/github-action-get-previous-tag@385a2a0b6abf6c2efeb95adfac83d96d6f968e0c # v1.3.0
+  #       with:
+  #         # only use releases tagged v<semver>
+  #         prefix: v
 
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          ref: ${{ steps.get-release.outputs.tag }}
-          clean: false
-          sparse_checkout: |
-            plugin.yaml
-            linters
-            actions
-            tools
+  #     - name: Checkout
+  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  #       with:
+  #         ref: ${{ steps.get-release.outputs.tag }}
+  #         clean: false
+  #         sparse_checkout: |
+  #           plugin.yaml
+  #           linters
+  #           actions
+  #           tools
 
-      - name: Overwrite test runners with latest behavior
-        shell: bash
-        run: |
-          rm -rf tests
-          mv tests.bak tests
-          mv package.json.bak package.json
-          mv package-lock.json.bak package-lock.json
-          rm -rf .github/actions
-          mv .github/actions.bak .github/actions
-          rm -rf .trunk
-          mv .trunk.bak .trunk
-          mv tsconfig.json.bak tsconfig.json
-          mv jest.config.json.bak jest.config.json
-          mv .gitattributes.bak .gitattributes
-          # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
-          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
-        continue-on-error: true
+  #     - name: Overwrite test runners with latest behavior
+  #       shell: bash
+  #       run: |
+  #         rm -rf tests
+  #         mv tests.bak tests
+  #         mv package.json.bak package.json
+  #         mv package-lock.json.bak package-lock.json
+  #         rm -rf .github/actions
+  #         mv .github/actions.bak .github/actions
+  #         rm -rf .trunk
+  #         mv .trunk.bak .trunk
+  #         mv tsconfig.json.bak tsconfig.json
+  #         mv jest.config.json.bak jest.config.json
+  #         mv .gitattributes.bak .gitattributes
+  #         # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
+  #         grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
+  #       continue-on-error: true
 
-      - name: Cache tool downloads
-        # ubuntu, mac runners have persistent cache
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-        with:
-          path: /tmp/plugins_testing_download_cache
-          # No need to key on trunk version unless we change how we store downloads.
-          key: trunk-${{ runner.os }}
+  #     - name: Cache tool downloads
+  #       # ubuntu, mac runners have persistent cache
+  #       if: matrix.os == 'windows-latest'
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+  #       with:
+  #         path: /tmp/plugins_testing_download_cache
+  #         # No need to key on trunk version unless we change how we store downloads.
+  #         key: trunk-${{ runner.os }}
 
-      - name: Delete cache
-        # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
-        if: env.TRIGGER != 'pull_request'
-        run: |
-          if [ -d "/tmp/plugins_testing_download_cache" ]
-          then
-            tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
-            mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
-            chmod -R u+w ${tmp_dir}
-            rm -rf ${tmp_dir}
-          fi
-        shell: bash
+  #     - name: Delete cache
+  #       # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
+  #       if: env.TRIGGER != 'pull_request'
+  #       run: |
+  #         if [ -d "/tmp/plugins_testing_download_cache" ]
+  #         then
+  #           tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
+  #           mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
+  #           chmod -R u+w ${tmp_dir}
+  #           rm -rf ${tmp_dir}
+  #         fi
+  #       shell: bash
 
-      - name: Linter Tests ${{ matrix.os }}
-        # Use overwritten dependency action, rather than released version
-        uses: ./.github/actions/linter_tests
-        with:
-          linter-version: ${{ matrix.linter-version }}
-          append-args: linters -- --json --outputFile=${{ matrix.results-file }}-res.json
-          sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+  #     - name: Linter Tests ${{ matrix.os }}
+  #       # Use overwritten dependency action, rather than released version
+  #       uses: ./.github/actions/linter_tests
+  #       with:
+  #         linter-version: ${{ matrix.linter-version }}
+  #         append-args: linters -- --json --outputFile=${{ matrix.results-file }}-res.json
+  #         sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+  #         trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
-      - name: Upload Test Outputs for Upload Job
-        # Only upload results from latest. Always run, except when cancelled.
-        if: (failure() || success()) && matrix.linter-version == 'Latest'
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: ${{ matrix.results-file }}-test-results
-          path: ${{ matrix.results-file }}-res.json
+  #     - name: Upload Test Outputs for Upload Job
+  #       # Only upload results from latest. Always run, except when cancelled.
+  #       if: (failure() || success()) && matrix.linter-version == 'Latest'
+  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+  #       with:
+  #         name: ${{ matrix.results-file }}-test-results
+  #         path: ${{ matrix.results-file }}-res.json
 
   # upload_linter_tests:
   #   name: Upload Linter Test Results

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,185 +24,185 @@ permissions:
   statuses: write
 
 jobs:
-  # # Run tests against all linters for snapshots and latest version as they exist on main
-  # # This job is used to diagnose plugin config health in advance of a release
-  # linter_tests_main:
-  #   name: Plugin Tests Main
-  #   # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
-  #   runs-on: ${{ matrix.os }}
-  #   timeout-minutes: 120
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       linter-version: [Snapshots, Latest]
-  #       os: [ubuntu-x64, macOS, windows-latest]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+  # Run tests against all linters for snapshots and latest version as they exist on main
+  # This job is used to diagnose plugin config health in advance of a release
+  linter_tests_main:
+    name: Plugin Tests Main
+    # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        linter-version: [Snapshots, Latest]
+        os: [ubuntu-x64, macOS, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-  #     - name: Cache tool downloads
-  #       # ubuntu runner has persistent cache
-  #       if: matrix.os == 'windows-latest'
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-  #       with:
-  #         path: /tmp/plugins_testing_download_cache
-  #         # No need to key on trunk version unless we change how we store downloads.
-  #         key: trunk-${{ runner.os }}
+      - name: Cache tool downloads
+        # ubuntu runner has persistent cache
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: /tmp/plugins_testing_download_cache
+          # No need to key on trunk version unless we change how we store downloads.
+          key: trunk-${{ runner.os }}
 
-  #     - name: Delete cache
-  #       # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
-  #       if: env.TRIGGER != 'pull_request'
-  #       run: |
-  #         if [ -d "/tmp/plugins_testing_download_cache" ]
-  #         then
-  #           tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
-  #           mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
-  #           chmod -R u+w ${tmp_dir}
-  #           rm -rf ${tmp_dir}
-  #         fi
-  #       shell: bash
+      - name: Delete cache
+        # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
+        if: env.TRIGGER != 'pull_request'
+        run: |
+          if [ -d "/tmp/plugins_testing_download_cache" ]
+          then
+            tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
+            mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
+            chmod -R u+w ${tmp_dir}
+            rm -rf ${tmp_dir}
+          fi
+        shell: bash
 
-  #     - name: Linter Tests
-  #       uses: ./.github/actions/linter_tests
-  #       with:
-  #         linter-version: ${{ matrix.linter-version }}
-  #         sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-  #         trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+      - name: Linter Tests
+        uses: ./.github/actions/linter_tests
+        with:
+          linter-version: ${{ matrix.linter-version }}
+          sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
-  # # Run tests against all linters for snapshots and latest version as they exist in latest release
-  # # This job is used to update the list of validated versions
-  # linter_tests_release:
-  #   name: Plugin Tests Release
-  #   # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
-  #   runs-on: ${{ matrix.os }}
-  #   timeout-minutes: 150
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       linter-version: [Snapshots, Latest]
-  #       os: [ubuntu-x64, macOS, windows-latest]
-  #       include:
-  #         # Normalize the filenames as inputs for ease of parsing
-  #         - os: ubuntu-x64
-  #           results-file: ubuntu-latest
-  #         - os: macOS
-  #           results-file: macos-latest
-  #         - os: windows-latest
-  #           results-file: windows-latest
-  #   outputs:
-  #     plugin-version: ${{ steps.get-release.outputs.tag }}
+  # Run tests against all linters for snapshots and latest version as they exist in latest release
+  # This job is used to update the list of validated versions
+  linter_tests_release:
+    name: Plugin Tests Release
+    # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        linter-version: [Snapshots, Latest]
+        os: [ubuntu-x64, macOS, windows-latest]
+        include:
+          # Normalize the filenames as inputs for ease of parsing
+          - os: ubuntu-x64
+            results-file: ubuntu-latest
+          - os: macOS
+            results-file: macos-latest
+          - os: windows-latest
+            results-file: windows-latest
+    outputs:
+      plugin-version: ${{ steps.get-release.outputs.tag }}
 
-  #   steps:
-  #     - name: Retrieve git history
-  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Retrieve git history
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-depth: 0
 
-  #     # This assumes that any changes on main since the last release are backwards compatible
-  #     # in terms of allowing existing linter tests to run.
-  #     - name: Preserve test runner latest behavior
-  #       shell: bash
-  #       run: |
-  #         cp -r tests tests.bak
-  #         cp package.json package.json.bak
-  #         cp package-lock.json package-lock.json.bak
-  #         cp -r .github/actions .github/actions.bak
-  #         cp -r .trunk .trunk.bak
-  #         cp tsconfig.json tsconfig.json.bak
-  #         cp jest.config.json jest.config.json.bak
-  #         cp .gitattributes .gitattributes.bak
-  #         # Include any newly generated snapshots that have been marked release-ready
-  #         grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
-  #       continue-on-error: true
+      # This assumes that any changes on main since the last release are backwards compatible
+      # in terms of allowing existing linter tests to run.
+      - name: Preserve test runner latest behavior
+        shell: bash
+        run: |
+          cp -r tests tests.bak
+          cp package.json package.json.bak
+          cp package-lock.json package-lock.json.bak
+          cp -r .github/actions .github/actions.bak
+          cp -r .trunk .trunk.bak
+          cp tsconfig.json tsconfig.json.bak
+          cp jest.config.json jest.config.json.bak
+          cp .gitattributes .gitattributes.bak
+          # Include any newly generated snapshots that have been marked release-ready
+          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot -l | xargs -I {} cp {}{,.bak}
+        continue-on-error: true
 
-  #     - name: Get Latest Release
-  #       id: get-release
-  #       uses: WyriHaximus/github-action-get-previous-tag@385a2a0b6abf6c2efeb95adfac83d96d6f968e0c # v1.3.0
-  #       with:
-  #         # only use releases tagged v<semver>
-  #         prefix: v
+      - name: Get Latest Release
+        id: get-release
+        uses: WyriHaximus/github-action-get-previous-tag@385a2a0b6abf6c2efeb95adfac83d96d6f968e0c # v1.3.0
+        with:
+          # only use releases tagged v<semver>
+          prefix: v
 
-  #     - name: Checkout
-  #       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-  #       with:
-  #         ref: ${{ steps.get-release.outputs.tag }}
-  #         clean: false
-  #         sparse_checkout: |
-  #           plugin.yaml
-  #           linters
-  #           actions
-  #           tools
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ steps.get-release.outputs.tag }}
+          clean: false
+          sparse_checkout: |
+            plugin.yaml
+            linters
+            actions
+            tools
 
-  #     - name: Overwrite test runners with latest behavior
-  #       shell: bash
-  #       run: |
-  #         rm -rf tests
-  #         mv tests.bak tests
-  #         mv package.json.bak package.json
-  #         mv package-lock.json.bak package-lock.json
-  #         rm -rf .github/actions
-  #         mv .github/actions.bak .github/actions
-  #         rm -rf .trunk
-  #         mv .trunk.bak .trunk
-  #         mv tsconfig.json.bak tsconfig.json
-  #         mv jest.config.json.bak jest.config.json
-  #         mv .gitattributes.bak .gitattributes
-  #         # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
-  #         grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
-  #       continue-on-error: true
+      - name: Overwrite test runners with latest behavior
+        shell: bash
+        run: |
+          rm -rf tests
+          mv tests.bak tests
+          mv package.json.bak package.json
+          mv package-lock.json.bak package-lock.json
+          rm -rf .github/actions
+          mv .github/actions.bak .github/actions
+          rm -rf .trunk
+          mv .trunk.bak .trunk
+          mv tsconfig.json.bak tsconfig.json
+          mv jest.config.json.bak jest.config.json
+          mv .gitattributes.bak .gitattributes
+          # Include any newly generated snapshots that have been marked release-ready, but don't replace if present
+          grep "// trunk-upgrade-validation:RELEASE" -r --include=*.shot.bak -l | sed -e 's/.bak//' | xargs -I {} mv {}{.bak,}
+        continue-on-error: true
 
-  #     - name: Cache tool downloads
-  #       # ubuntu, mac runners have persistent cache
-  #       if: matrix.os == 'windows-latest'
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-  #       with:
-  #         path: /tmp/plugins_testing_download_cache
-  #         # No need to key on trunk version unless we change how we store downloads.
-  #         key: trunk-${{ runner.os }}
+      - name: Cache tool downloads
+        # ubuntu, mac runners have persistent cache
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: /tmp/plugins_testing_download_cache
+          # No need to key on trunk version unless we change how we store downloads.
+          key: trunk-${{ runner.os }}
 
-  #     - name: Delete cache
-  #       # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
-  #       if: env.TRIGGER != 'pull_request'
-  #       run: |
-  #         if [ -d "/tmp/plugins_testing_download_cache" ]
-  #         then
-  #           tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
-  #           mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
-  #           chmod -R u+w ${tmp_dir}
-  #           rm -rf ${tmp_dir}
-  #         fi
-  #       shell: bash
+      - name: Delete cache
+        # For now, avoid deleting cache on pull request changes to nightly. This improves PR experience.
+        if: env.TRIGGER != 'pull_request'
+        run: |
+          if [ -d "/tmp/plugins_testing_download_cache" ]
+          then
+            tmp_dir=/tmp/${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}
+            mv "/tmp/plugins_testing_download_cache" ${tmp_dir}
+            chmod -R u+w ${tmp_dir}
+            rm -rf ${tmp_dir}
+          fi
+        shell: bash
 
-  #     - name: Linter Tests ${{ matrix.os }}
-  #       # Use overwritten dependency action, rather than released version
-  #       uses: ./.github/actions/linter_tests
-  #       with:
-  #         linter-version: ${{ matrix.linter-version }}
-  #         append-args: linters -- --json --outputFile=${{ matrix.results-file }}-res.json
-  #         sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-  #         trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+      - name: Linter Tests ${{ matrix.os }}
+        # Use overwritten dependency action, rather than released version
+        uses: ./.github/actions/linter_tests
+        with:
+          linter-version: ${{ matrix.linter-version }}
+          append-args: linters -- --json --outputFile=${{ matrix.results-file }}-res.json
+          sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
-  #     - name: Upload Test Outputs for Upload Job
-  #       # Only upload results from latest. Always run, except when cancelled.
-  #       if: (failure() || success()) && matrix.linter-version == 'Latest'
-  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-  #       with:
-  #         name: ${{ matrix.results-file }}-test-results
-  #         path: ${{ matrix.results-file }}-res.json
+      - name: Upload Test Outputs for Upload Job
+        # Only upload results from latest. Always run, except when cancelled.
+        if: (failure() || success()) && matrix.linter-version == 'Latest'
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: ${{ matrix.results-file }}-test-results
+          path: ${{ matrix.results-file }}-res.json
 
-  # upload_linter_tests:
-  #   name: Upload Linter Test Results
-  #   needs: linter_tests_release
-  #   uses: ./.github/workflows/upload_results.reusable.yaml
-  #   secrets:
-  #     TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-  #     TRUNK_STAGING_API_TOKEN: ${{ secrets.TRUNK_STAGING_API_TOKEN }}
-  #     TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
-  #   with:
-  #     plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
-  #     upload-validated-versions: "true"
-  #     test-type: linter
-  #     test-ref: latest release
+  upload_linter_tests:
+    name: Upload Linter Test Results
+    needs: linter_tests_release
+    uses: ./.github/workflows/upload_results.reusable.yaml
+    secrets:
+      TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+      TRUNK_STAGING_API_TOKEN: ${{ secrets.TRUNK_STAGING_API_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+    with:
+      plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
+      upload-validated-versions: "true"
+      test-type: linter
+      test-ref: latest release
 
   # Run tool tests only on main
   tool_tests_main:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -193,6 +193,8 @@ jobs:
   upload_linter_tests:
     name: Upload Linter Test Results
     needs: linter_tests_release
+    # Still run on test failure
+    if: always()
     uses: ./.github/workflows/upload_results.reusable.yaml
     secrets:
       TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -198,7 +198,7 @@ jobs:
   #     plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
   #     upload-validated-versions: "true"
   #     test-type: linter
-  #     test-ref: main
+  #     test-ref: latest release
 
   # Run tool tests only on main
   tool_tests_main:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -200,7 +200,7 @@ jobs:
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     with:
       plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
-      upload-validated-versions: "true"
+      upload-validated-versions: true
       test-type: linter
       test-ref: latest release
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -190,184 +190,15 @@ jobs:
           name: ${{ matrix.results-file }}-test-results
           path: ${{ matrix.results-file }}-res.json
 
-  upload_test_results:
-    name: Upload Test Results
+  upload_linter_tests:
+    name: Upload Linter Test Results
     needs: linter_tests_release
-    runs-on: ubuntu-x64
-    # Still run on test failure
-    if: always()
-    timeout-minutes: 10
-    env:
-      SLACK_CHANNEL_ID: plugins-notifications
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-
-      - name: Retrieve Test Outputs ubuntu
-        id: download-ubuntu
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        continue-on-error: true
-        with:
-          name: ubuntu-latest-test-results
-
-      - name: Retrieve Test Outputs macOS
-        id: download-macos
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        continue-on-error: true
-        with:
-          name: macos-latest-test-results
-
-      - name: Retrieve Test Outputs Windows
-        id: download-windows
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        continue-on-error: true
-        with:
-          name: windows-latest-test-results
-
-      - name: Print Test Outputs
-        continue-on-error: true
-        shell: bash
-        run: |
-          echo "::group::Ubuntu results"
-          cat "ubuntu-latest-res.json" || echo "missing"
-          echo "::endgroup::"
-
-          echo "::group::Macos results"
-          cat "macos-latest-res.json" || echo "missing"
-          echo "::endgroup::"
-
-          echo "::group::Windows results"
-          cat "windows-latest-res.json" || echo "missing"
-          echo "::endgroup::"
-
-      - name: Slack Notification For Missing Artifacts
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        if:
-          steps.download-ubuntu.outcome == 'failure' || steps.download-macos.outcome == 'failure' ||
-          steps.download-windows.outcome == 'failure'
-        with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "Artifact Download Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }}, windows: ${{ steps.download-windows.outcome }}) >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-
-      - name: Setup Node
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
-        with:
-          node-version: 18
-
-      - name: Install Dependencies
-        shell: bash
-        run: npm ci
-
-      - name: Add npm bin to path
-        shell: bash
-        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
-
-      - name: Parse Test Results
-        shell: bash
-        id: parse
-        run: |
-          npm run parse
-          echo "failures=$([[ -f failures.json ]] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
-          echo "failures-payload=$(cat failures.json)" >> "$GITHUB_OUTPUT"
-        env:
-          PLUGIN_VERSION: ${{needs.linter_tests_release.outputs.plugin-version}}
-          # Used to format Slack notification for failures
-          RUN_ID: ${{ github.run_id }}
-          TEST_REF: Release
-
-      - name: Upload Test Results Staging
-        continue-on-error: true
-        id: upload-staging
-        env:
-          TRUNK_API_TOKEN: ${{ secrets.TRUNK_STAGING_API_TOKEN }}
-          TRUNK_API_ADDRESS: api.trunk-staging.io:8443
-        # upload-linter-versions is a hidden command reserved exclusively for uploading
-        # validated results from the plugins repo.
-        # daemon must be restarted in order to propagate environment variable
-        shell: bash
-        run: |
-          trunk daemon shutdown
-          trunk upload-linter-versions --token="$TRUNK_API_TOKEN" results.json
-
-      - name: Upload Test Results Prod
-        continue-on-error: true
-        id: upload-prod
-        env:
-          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
-          TRUNK_API_ADDRESS: api.trunk.io:8443
-        # upload-linter-versions is a hidden command reserved exclusively for uploading
-        # validated results from the plugins repo.
-        # daemon must be restarted in order to propagate environment variable
-        shell: bash
-        run: |
-          trunk daemon shutdown
-          trunk upload-linter-versions --token="$TRUNK_API_TOKEN" results.json
-
-      # Slack notifications
-      - name: Slack Notification For Failures
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        if: always() && steps.parse.outputs.failures == 'true'
-        with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
-          payload: ${{ steps.parse.outputs.failures-payload }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-
-      - name: Slack Notification For Staging Upload Failure
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        if: steps.upload-staging.outcome == 'failure'
-        with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "Upload Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Staging >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
-
-      - name: Slack Notification For Prod Upload Failure
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
-        if: steps.upload-prod.outcome == 'failure'
-        with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "Upload Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Prod >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+    uses: ./.github/workflows/upload_results.reusable.yaml
+    with:
+      plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
+      upload-validated-versions: "true"
+      test-type: linter
+      test-ref: main
 
   # Run tool tests only on main
   tool_tests_main:
@@ -379,6 +210,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-x64, macOS, windows-latest]
+        include:
+          # Normalize the filenames as inputs for ease of parsing
+          - os: ubuntu-x64
+            results-file: ubuntu-latest
+          - os: macOS
+            results-file: macos-latest
+          - os: windows-latest
+            results-file: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -388,7 +227,27 @@ jobs:
       - name: Tool Tests ${{ matrix.os }}
         uses: ./.github/actions/tool_tests
         with:
+          append-args: tools -- --json --outputFile=${{ matrix.results-file }}-res.json
           trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+
+      - name: Upload Test Outputs for Notification Job
+        # Always run, except when cancelled.
+        if: (failure() || success())
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: tools-${{ matrix.results-file }}-test-results
+          path: ${{ matrix.results-file }}-res.json
+
+  upload_tool_tests:
+    name: Upload Tool Test Results
+    needs: tool_tests_main
+    uses: ./.github/workflows/upload_results.reusable.yaml
+    with:
+      plugin-version: main
+      results-prefix: tools-
+      upload-validated-versions: "false"
+      test-type: tool
+      test-ref: main
 
   # Run repo healthcheck tests
   repo_tests:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -190,15 +190,15 @@ jobs:
           name: ${{ matrix.results-file }}-test-results
           path: ${{ matrix.results-file }}-res.json
 
-  upload_linter_tests:
-    name: Upload Linter Test Results
-    needs: linter_tests_release
-    uses: ./.github/workflows/upload_results.reusable.yaml
-    with:
-      plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
-      upload-validated-versions: "true"
-      test-type: linter
-      test-ref: main
+  # upload_linter_tests:
+  #   name: Upload Linter Test Results
+  #   needs: linter_tests_release
+  #   uses: ./.github/workflows/upload_results.reusable.yaml
+  #   with:
+  #     plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
+  #     upload-validated-versions: "true"
+  #     test-type: linter
+  #     test-ref: main
 
   # Run tool tests only on main
   tool_tests_main:

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -1,0 +1,208 @@
+# Parse test results and
+# Send upload notifications
+name: Parse Test Results
+on:
+  workflow_call:
+    inputs:
+      plugin-version:
+        required: false
+        type: string
+      results-prefix:
+        required: false
+        type: string
+      upload-validated-versions:
+        required: false
+        type: boolean
+        default: "false"
+      test-type:
+        required: false
+        type: string
+        default: linter
+      test-ref:
+        required: false
+        type: string
+        default: latest release
+
+permissions: read-all
+
+jobs:
+  upload_test_results:
+    name: Upload Test Results
+    runs-on: ubuntu-x64
+    # Still run on test failure
+    if: always()
+    timeout-minutes: 10
+    env:
+      SLACK_CHANNEL_ID: plugins-notifications
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Retrieve Test Outputs ubuntu
+        id: download-ubuntu
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        continue-on-error: true
+        with:
+          name: ${{ inputs.results-prefix }}ubuntu-latest-test-results
+
+      - name: Retrieve Test Outputs macOS
+        id: download-macos
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        continue-on-error: true
+        with:
+          name: ${{ inputs.results-prefix }}macos-latest-test-results
+
+      - name: Retrieve Test Outputs Windows
+        id: download-windows
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        continue-on-error: true
+        with:
+          name: ${{ inputs.results-prefix }}windows-latest-test-results
+
+      - name: Print Test Outputs
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "::group::Ubuntu results"
+          cat "ubuntu-latest-res.json" || echo "missing"
+          echo "::endgroup::"
+
+          echo "::group::Macos results"
+          cat "macos-latest-res.json" || echo "missing"
+          echo "::endgroup::"
+
+          echo "::group::Windows results"
+          cat "windows-latest-res.json" || echo "missing"
+          echo "::endgroup::"
+
+      - name: Slack Notification For Missing Artifacts
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        if:
+          steps.download-ubuntu.outcome == 'failure' || steps.download-macos.outcome == 'failure' ||
+          steps.download-windows.outcome == 'failure'
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "Artifact Download Failure",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some ${{ inputs.results-prefix }}test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }}, windows: ${{ steps.download-windows.outcome }}) >"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+        with:
+          node-version: 18
+
+      - name: Install Dependencies
+        shell: bash
+        run: npm ci
+
+      - name: Add npm bin to path
+        shell: bash
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Parse Test Results
+        shell: bash
+        id: parse
+        run: |
+          npm run parse
+          echo "failures=$([[ -f failures.json ]] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
+          echo "failures-payload=$(cat failures.json)" >> "$GITHUB_OUTPUT"
+        env:
+          PLUGIN_VERSION: ${{ inputs.plugin-version }}
+          # Used to format Slack notification for failures
+          RUN_ID: ${{ github.run_id }}
+          TEST_REF: ${{ inputs.test-ref }}
+          TEST_TYPE: ${{ inputs.test-type }}
+
+      - name: Upload Test Results Staging
+        if: inputs.upload-validated-versions == 'true'
+        continue-on-error: true
+        id: upload-staging
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_STAGING_API_TOKEN }}
+          TRUNK_API_ADDRESS: api.trunk-staging.io:8443
+        # upload-linter-versions is a hidden command reserved exclusively for uploading
+        # validated results from the plugins repo.
+        # daemon must be restarted in order to propagate environment variable
+        shell: bash
+        run: |
+          trunk daemon shutdown
+          trunk upload-linter-versions --token="$TRUNK_API_TOKEN" results.json
+
+      - name: Upload Test Results Prod
+        if: inputs.upload-validated-versions == 'true'
+        continue-on-error: true
+        id: upload-prod
+        env:
+          TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+          TRUNK_API_ADDRESS: api.trunk.io:8443
+        # upload-linter-versions is a hidden command reserved exclusively for uploading
+        # validated results from the plugins repo.
+        # daemon must be restarted in order to propagate environment variable
+        shell: bash
+        run: |
+          trunk daemon shutdown
+          trunk upload-linter-versions --token="$TRUNK_API_TOKEN" results.json
+
+      # Slack notifications
+      - name: Slack Notification For Failures
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        if: always() && steps.parse.outputs.failures == 'true'
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: ${{ steps.parse.outputs.failures-payload }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+
+      - name: Slack Notification For Staging Upload Failure
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        if: inputs.upload-validated-versions == 'true' && steps.upload-staging.outcome == 'failure'
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "Upload Failure",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Staging >"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+
+      - name: Slack Notification For Prod Upload Failure
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        if: inputs.upload-validated-versions == 'true' && steps.upload-prod.outcome == 'failure'
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "Upload Failure",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Prod >"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -13,7 +13,7 @@ on:
       upload-validated-versions:
         required: false
         type: boolean
-        default: "false"
+        default: false
       test-type:
         required: false
         type: string
@@ -22,7 +22,13 @@ on:
         required: false
         type: string
         default: latest release
-
+    secrets:
+      TRUNKBOT_SLACK_BOT_TOKEN:
+        required: true
+      TRUNK_STAGING_API_TOKEN:
+        required: false
+      TRUNK_API_TOKEN:
+        required: false
 permissions: read-all
 
 jobs:

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -35,8 +35,6 @@ jobs:
   upload_test_results:
     name: Upload Test Results
     runs-on: ubuntu-x64
-    # Still run on test failure
-    if: always()
     timeout-minutes: 10
     env:
       SLACK_CHANNEL_ID: plugins-notifications

--- a/linters/nancy/nancy.test.ts
+++ b/linters/nancy/nancy.test.ts
@@ -23,5 +23,5 @@ fuzzyLinterCheckTest({
   linterName: "nancy",
   args: "-a -y",
   preCheck,
-  fileIssueAssertionCallback: createFuzzyMatcher(() => expectedFileIssues as FileIssue[], 24),
+  fileIssueAssertionCallback: createFuzzyMatcher(() => expectedFileIssues as FileIssue[], 18),
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -38,14 +38,27 @@ declare global {
   }
 }
 
-const registerVersion = (linterVersion?: string) => {
+/**
+ * Add the version to the test reporter. This only applies when there are multiple workers,
+ * because the console buffer gets forwarded into the test reporter output.
+ * @param testType      linter or tool, whichever type of test. Used for defensive filtering
+ * @param linterVersion the linter or tool version that was enabled
+ */
+const registerVersion = (testType: string, linterVersion?: string) => {
   // @ts-expect-error: `_buffer` is `private`, see `tests/reporter/reporters.ts` for rationale
-  // trunk-ignore(eslint): Manual patch is quired here for most reliable implementation
-  console._buffer?.push({
-    message: linterVersion,
-    origin: expect.getState().currentTestName,
-    type: "linter-version",
-  });
+  // trunk-ignore(eslint): Manual patch is required here for most reliable implementation
+  console._buffer?.push(
+    {
+      message: linterVersion,
+      origin: expect.getState().currentTestName,
+      type: "linter-version",
+    },
+    {
+      message: testType,
+      origin: expect.getState().currentTestName,
+      type: "test-type",
+    },
+  );
 };
 
 const baseDebug = Debug("Tests");
@@ -127,7 +140,7 @@ export const setupDriver = (
   });
 
   afterEach(() => {
-    registerVersion(driver.enabledVersion);
+    registerVersion("linter", driver.enabledVersion);
   });
   return driver;
 };
@@ -158,6 +171,10 @@ export const setupTrunkToolDriver = (
   afterAll(() => {
     driver.tearDown();
   });
+
+  afterEach(() => {
+    registerVersion("tool", driver.enabledVersion);
+  });
   return driver;
 };
 
@@ -186,6 +203,10 @@ export const setUpTrunkToolDriverForHealthCheck = (
 
   afterAll(() => {
     driver.tearDown();
+  });
+
+  afterEach(() => {
+    registerVersion("tool", driver.enabledVersion);
   });
   return driver;
 };
@@ -225,14 +246,16 @@ export const toolInstallTest = ({
   skipTestIf?: (version?: string) => boolean;
   preCheck?: ToolTestCallback;
 }) => {
-  const driver = setUpTrunkToolDriverForHealthCheck(dirName, {}, toolName, toolVersion, preCheck);
-  conditionalTest(skipTestIf(toolVersion), "tool ", async () => {
-    const { exitCode, stdout, stderr } = await runInstall(driver, toolName);
-    expect(exitCode).toEqual(0);
-    expect(stdout).toContain(toolName);
-    expect(stdout).toContain(toolVersion);
-    expect(stderr).toEqual("");
-    expect(stdout).not.toContain("Failures:");
+  describe(`Testing tool ${toolName}`, () => {
+    const driver = setUpTrunkToolDriverForHealthCheck(dirName, {}, toolName, toolVersion, preCheck);
+    conditionalTest(skipTestIf(toolVersion), "tool ", async () => {
+      const { exitCode, stdout, stderr } = await runInstall(driver, toolName);
+      expect(exitCode).toEqual(0);
+      expect(stdout).toContain(toolName);
+      expect(stdout).toContain(toolVersion);
+      expect(stderr).toEqual("");
+      expect(stdout).not.toContain("Failures:");
+    });
   });
 };
 
@@ -270,7 +293,7 @@ export const toolTest = ({
   skipTestIf?: (version?: string) => boolean;
   preCheck?: ToolTestCallback;
 }) => {
-  describe(toolName, () => {
+  describe(`Testing tool ${toolName}`, () => {
     const driver = setupTrunkToolDriver(dirName, {}, toolName, toolVersion, preCheck);
     testConfigs.forEach(({ command, expectedOut, expectedErr, expectedExitCode }) => {
       conditionalTest(skipTestIf(toolVersion), command.join(" "), async () => {

--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -132,8 +132,8 @@ const parseResultsJson = (os: TestOS): TestResultSummary => {
       }
 
       const fullTestName: string = assertionResult.fullName;
-      const testType: string = assertionResult.testType;
-      if (testType !== TEST_TYPE) {
+      const testType = assertionResult.testType;
+      if (testType && testType !== TEST_TYPE) {
         console.warn(`Skipping test '${fullTestName}' because is type '${testType}'`);
         return;
       }

--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -23,6 +23,10 @@ const PLUGIN_VERSION = process.env.PLUGIN_VERSION ?? "v0.0.10";
 if (!process.env.PLUGIN_VERSION) {
   console.log("Environment var `PLUGIN_VERSION` is not set, using fallback `v0.0.10`");
 }
+const TEST_TYPE = process.env.TEST_TYPE ?? "linter";
+if (!process.env.TEST_TYPE) {
+  console.log("Environment var `TEST_TYPE` is not set, using fallback `linter`");
+}
 
 /**
  * Convert an OS into the expected file path.
@@ -63,7 +67,7 @@ const mergeTestStatuses = (
 };
 
 /**
- * Combine maps of versions run on each OS.
+ * Combine maps of versions run on each OS. This consolidates in order to detail mismatches.
  */
 const mergeTestVersions = (original: TestResult, incoming: TestResult) => {
   Array.from(incoming.allVersions).reduce((accumulator, [os, versions]) => {
@@ -108,10 +112,11 @@ const parseResultsJson = (os: TestOS): TestResultSummary => {
   try {
     jsonResult = JSON.parse(fs.readFileSync(resultsJsonPath, { encoding: "utf-8" }));
   } catch (error) {
+    // The caller is primarily responsible for reporting if a file is missing.
     console.warn(`Failed to parse ${resultsJsonPath}. Skipping`);
     return {
       os,
-      linters: linterResults,
+      testResults: linterResults,
     };
   }
 
@@ -119,15 +124,21 @@ const parseResultsJson = (os: TestOS): TestResultSummary => {
   jsonResult.testResults.forEach((testResult: any) => {
     testResult.assertionResults.forEach((assertionResult: any) => {
       const testName: string = assertionResult.ancestorTitles[0];
-      const foundLinterName = testName.match(/Testing (linter|formatter) (?<linter>.+)/);
+      const foundLinterName = testName.match(/Testing (linter|formatter|tool) (?<linter>.+)/);
       const linterName = foundLinterName?.groups?.linter;
       if (!linterName) {
         console.warn(`Failed to parse test name from ${testName}`);
         return;
       }
 
-      const version: string = assertionResult.version;
       const fullTestName: string = assertionResult.fullName;
+      const testType: string = assertionResult.testType;
+      if (testType !== TEST_TYPE) {
+        console.warn(`Skipping test '${fullTestName}' because is type '${testType}'`);
+        return;
+      }
+
+      const version: string = assertionResult.version;
       const status = parseTestStatus(assertionResult.status);
       const failedPlatforms = new Set<TestOS>();
       if (status == "failed") {
@@ -160,7 +171,7 @@ const parseResultsJson = (os: TestOS): TestResultSummary => {
   console.log(`Parsed results for ${os}`);
   return {
     os,
-    linters: linterResults,
+    testResults: linterResults,
   };
 };
 
@@ -169,11 +180,11 @@ const parseResultsJson = (os: TestOS): TestResultSummary => {
  * same version and all tests must be skipped or pass to be considered passed.
  */
 const mergeTestResultSummaries = (testResults: TestResultSummary[]): TestResultSummary => {
-  const compositeLinterResults = testResults[0].linters;
+  const compositeLinterResults = testResults[0].testResults;
 
   // Merge all other OS results into the first OS's results
   testResults.slice(1).forEach((testResult) => {
-    testResult.linters.forEach((linterResult, linterName) => {
+    testResult.testResults.forEach((linterResult, linterName) => {
       const compositeLinterResult = compositeLinterResults.get(linterName);
       if (compositeLinterResult) {
         // Merge existing composite record
@@ -187,7 +198,7 @@ const mergeTestResultSummaries = (testResults: TestResultSummary[]): TestResultS
 
   return {
     os: "composite",
-    linters: compositeLinterResults,
+    testResults: compositeLinterResults,
   };
 };
 
@@ -211,7 +222,7 @@ const writeFailuresForNotification = (failures: FailedVersion[]) => {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `${TEST_REF} Test Failure: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}| Testing latest ${linterVersion} > _STATUS: ${status}_ ${details}`,
+        text: `${TEST_REF} Test Failure: <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}| Testing latest ${TEST_TYPE} ${linterVersion} > _STATUS: ${status}_ ${details}`,
       },
     };
   });
@@ -245,7 +256,7 @@ const writeFailuresForNotification = (failures: FailedVersion[]) => {
 const writeTestResults = (testResults: TestResultSummary) => {
   const cliVersion = getTrunkVersion();
   const pluginVersion = PLUGIN_VERSION;
-  const validatedVersions = Array.from(testResults.linters).reduce(
+  const validatedVersions = Array.from(testResults.testResults).reduce(
     (accumulator: ValidatedVersion[], [linter, { version, testResultStatus }]) => {
       if (testResultStatus === "passed" && version) {
         const additionalValidatedVersion: ValidatedVersion = { linter, version };
@@ -255,7 +266,7 @@ const writeTestResults = (testResults: TestResultSummary) => {
     },
     [],
   );
-  const failures = Array.from(testResults.linters).reduce(
+  const failures = Array.from(testResults.testResults).reduce(
     (
       accumulator: FailedVersion[],
       [linter, { version, testResultStatus: status, allVersions, failedPlatforms }],
@@ -294,7 +305,7 @@ const parseTestResultsAndWrite = () => {
   // Step 1: Parse each OS's results json file. If one of the expected files does not exist, throw and error out.
   const testResults = Object.values(TestOS).map((os) => parseResultsJson(os));
   const totalParsedTests = testResults.reduce(
-    (total, testResultsSummary) => total + testResultsSummary.linters.size,
+    (total, testResultsSummary) => total + testResultsSummary.testResults.size,
     0,
   );
   if (totalParsedTests === 0) {

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -159,11 +159,11 @@ export interface TestResult {
 
 /**
  * A summary of all tests run with an individual OS (or the merged result of all OSs).
- * Includes a map of linter name to linter test results.
+ * Includes a map of linter/tool name to linter/tool test results.
  */
 export interface TestResultSummary {
   os: TestOS | "composite";
-  linters: Map<string, TestResult>;
+  testResults: Map<string, TestResult>;
 }
 
 /**

--- a/tools/assh/assh.test.ts
+++ b/tools/assh/assh.test.ts
@@ -7,7 +7,7 @@ toolTest({
   testConfigs: [
     makeToolTestConfig({
       command: ["assh", "--version"],
-      expectedOut: "assh version n/a (n/a)",
+      expectedOut: "assh versssssssion n/a (n/a)",
     }),
   ],
   skipTestIf: skipOS(["win32"]),

--- a/tools/assh/assh.test.ts
+++ b/tools/assh/assh.test.ts
@@ -7,7 +7,7 @@ toolTest({
   testConfigs: [
     makeToolTestConfig({
       command: ["assh", "--version"],
-      expectedOut: "assh versssssssion n/a (n/a)",
+      expectedOut: "assh version n/a (n/a)",
     }),
   ],
   skipTestIf: skipOS(["win32"]),


### PR DESCRIPTION
Nightly runs will now send Slack notifications for tool tests that have failed. Note that we are still running tool tests on `main`, not on the release.

Also adds some defensive checks and comments for the parsing logic, as well as refactor the parsing and uploading into a separate Reusable Workflow.

Successful [run and failure notification](https://github.com/trunk-io/plugins/actions/runs/7096766782) and [success run](https://github.com/trunk-io/plugins/actions/runs/7097164459)