### PR TITLE
Make sourcery work on all platforms

### DIFF
--- a/linters/sourcery/plugin.yaml
+++ b/linters/sourcery/plugin.yaml
@@ -5,20 +5,16 @@ lint:
       files: [python]
       commands:
         - name: lint
-          platforms: [linux, macos]
           output: regex
-          run: bash -c "ln -s ${REPO_DIR}/.git .git; sourcery review  --no-summary --csv ${target}"
+          run: sourcery review  --no-summary --csv ${target}
           parse_regex: ((?P<path>.*),(?P<line>\d+),(?P<code>.*),(?P<message>.*))
           success_codes: [0]
           read_output_from: stdout
           batch: true
           cache_results: true
         - name: fix
-          platforms: [linux, macos]
           output: rewrite
-          run:
-            bash -c "ln -s ${REPO_DIR}/.git .git || true; sourcery review  --no-summary --csv --fix
-            ${target}"
+          run: sourcery review  --no-summary --csv --fix ${target}
           success_codes: [0]
           batch: true
           # NOTE(Tyler): Autofixes will show up as complete "formatting-like" diagnostics. However, strictly speaking, this isn't a formatter, so we don't want to set formatter: true
@@ -42,3 +38,6 @@ lint:
       version_command:
         parse_regex: sourcery ${semver}
         run: sourcery --version
+      symlinks:
+        - from: ${workspace}/.git
+          to: ${run_from}/.git

--- a/linters/sourcery/sourcery.test.ts
+++ b/linters/sourcery/sourcery.test.ts
@@ -38,9 +38,6 @@ linterCheckTest({
       );
       return true;
     }
-    return skipCPUOS([
-      { os: "linux", cpu: "arm64" },
-      { os: "win32", cpu: "x64" },
-    ])(version);
+    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
   },
 });

--- a/linters/sourcery/test_data/_plugin.yaml
+++ b/linters/sourcery/test_data/_plugin.yaml
@@ -5,10 +5,8 @@ lint:
     - name: sourcery
       commands:
         - name: lint
-          platforms: [linux, macos]
           prepare_run: bash -c "sourcery login --token=${SOURCERY_TOKEN}"
         - name: fix
-          platforms: [linux, macos]
           prepare_run: bash -c "sourcery login --token=${SOURCERY_TOKEN}"
       environment:
         - name: PATH


### PR DESCRIPTION
Use additional template resolution for symlinks in order to better support the creation of sandboxes for the open source sourcery license.

This will require a CLI version bump in order to pass tests (this causes a linter runtime error on existing versions).