### PR TITLE
Bump CI Debugger version

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -86,7 +86,6 @@ runs:
         shell: bash
         working-directory: ${{ inputs.path }}
         trunk-token: ${{ inputs.trunk-token  }}
-        trunk-version: 1.18.0
         org: trunk-staging-org
         run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       env:

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -80,7 +80,7 @@ runs:
     - name: Run plugin tests
       if: runner.os != 'Windows'
       # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
-      uses: trunk-io/breakpoint@v1
+      uses: trunk-io/breakpoint@v1.3.0
       with:
         breakpoint-id: trunk-plugins-linter-tests
         shell: bash

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -60,7 +60,7 @@ runs:
     - name: Run plugin tests
       if: runner.os != 'Windows'
       # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
-      uses: trunk-io/breakpoint@v1
+      uses: trunk-io/breakpoint@v1.3.0
       with:
         breakpoint-id: trunk-plugins-tool-tests
         shell: bash

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -66,7 +66,6 @@ runs:
         shell: bash
         working-directory: ${{ inputs.path }}
         trunk-token: ${{ inputs.trunk-token  }}
-        trunk-version: 1.18.0
         org: trunk-staging-org
         run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       env:

--- a/linters/golangci-lint/golangci_lint.test.ts
+++ b/linters/golangci-lint/golangci_lint.test.ts
@@ -21,7 +21,7 @@ const addEmpty = (driver: TrunkLintDriver) => {
 customLinterCheckTest({
   linterName: "golangci-lint",
   testName: "empty",
-  args: "-a --foo",
+  args: "-a",
   preCheck: addEmpty,
   skipTestIf: skipOS(["win32"]),
 });

--- a/linters/golangci-lint/golangci_lint.test.ts
+++ b/linters/golangci-lint/golangci_lint.test.ts
@@ -21,7 +21,7 @@ const addEmpty = (driver: TrunkLintDriver) => {
 customLinterCheckTest({
   linterName: "golangci-lint",
   testName: "empty",
-  args: "-a",
+  args: "-a --foo",
   preCheck: addEmpty,
   skipTestIf: skipOS(["win32"]),
 });


### PR DESCRIPTION
Reverts #581. This removes the need to specify the `trunk-version`.