### PR TITLE
Disable old gt test on CI

### DIFF
--- a/tools/gt/gt.test.ts
+++ b/tools/gt/gt.test.ts
@@ -5,7 +5,15 @@ toolTest({
   toolName: "gt",
   toolVersion: "0.20.19",
   testConfigs: [makeToolTestConfig({ command: ["gt", "--version"], expectedOut: "0.20.19" })],
-  skipTestIf: skipCPUOS([{ os: "linux", cpu: "arm64" }]),
+  skipTestIf: (version) => {
+    if (process.env.CI) {
+      console.log("Skipping gt test for CI until we have better parsing logic.");
+      return true;
+    }
+
+    // Unsupported download
+    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
+  },
 });
 
 toolTest({


### PR DESCRIPTION
This reduces notification noise since otherwise we detect this as a version mismatch on nightlies:

```
main Test Failure: [Testing latest tool gt@1.0.7](https://github.com/trunk-io/plugins/actions/runs/7135192228) STATUS: mismatch (ubuntu: 1.0.7; windows: 0.20.19)
```