### PR TITLE
Upgrade CLI and handle eslint batching

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.18.0
+  version: 1.18.1-beta.5
   shell_hooks:
     enforce: true
 

--- a/linters/ansible-lint/test_data/ansible_lint_v6.22.1_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.22.1_FQCN.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter ansible-lint test FQCN 1`] = `
 {

--- a/linters/ansible-lint/test_data/ansible_lint_v6.22.1_non_FQCN.check.shot
+++ b/linters/ansible-lint/test_data/ansible_lint_v6.22.1_non_FQCN.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter ansible-lint test non_FQCN 1`] = `
 {

--- a/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter eslint test bad_install 1`] = `
 {
@@ -7,12 +8,42 @@ exports[`Testing linter eslint test bad_install 1`] = `
   "taskFailures": [
     {
       "details": StringMatching /\\.\\*\\$/m,
-      "message": "test_data/eof_autofix.ts... (4 files)",
+      "message": "test_data/eof_autofix.ts",
       "name": "eslint",
     },
     {
       "details": StringMatching /\\.\\*\\$/m,
-      "message": "test_data/eof_autofix.ts... (4 files)",
+      "message": "test_data/eof_autofix.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/format_imports.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/format_imports.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/non_ascii.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/non_ascii.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/null_rule_id.ts",
+      "name": "eslint",
+    },
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/null_rule_id.ts",
       "name": "eslint",
     },
   ],

--- a/linters/mypy/test_data/mypy_v1.7.0_CUSTOM.check.shot
+++ b/linters/mypy/test_data/mypy_v1.7.0_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter mypy test CUSTOM 1`] = `
 {

--- a/linters/pyright/test_data/pyright_v1.1.334_basic.check.shot
+++ b/linters/pyright/test_data/pyright_v1.1.334_basic.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter pyright test basic 1`] = `
 {


### PR DESCRIPTION
Upgrade CLI and clear release snapshot marks.

Recent changes to retry batching cause eslint to output several failures for one of the test instead of just 1. We will fix this in a future version and update the snapshot and mark for release.

Also note that this upgrade should resolve go install issues.