### PR TITLE
Add markdown-table-prettify

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ trunk check enable {linter}
 | Kotlin          | [detekt], [ktlint]                                                                                                   |
 | Kubernetes      | [kube-linter]                                                                                                        |
 | Lua             | [stylua]                                                                                                             |
-| Markdown        | [deno], [markdownlint], [remark-lint], [markdown-link-check], [prettier]                                             |
+| Markdown        | [deno], [markdownlint], [markdown-link-check], [markdown-table-prettify], [prettier], [remark-lint]                  |
 | Nix             | [nixpkgs-fmt]                                                                                                        |
 | package.json    | [sort-package-json]                                                                                                  |
 | Perl            | [perlcritic], [perltidy]                                                                                             |
@@ -124,6 +124,7 @@ trunk check enable {linter}
 [ktlint]: https://github.com/pinterest/ktlint#readme
 [kube-linter]: https://github.com/stackrox/kube-linter#readme
 [markdownlint]: https://github.com/DavidAnson/markdownlint#readme
+[markdown-table-prettify]: https://github.com/darkriszty/MarkdownTablePrettify-VSCodeExt#readme
 [markdown-link-check]: https://github.com/tcort/markdown-link-check#readme
 [mypy]: https://github.com/python/mypy#readme
 [nancy]: https://github.com/sonatype-nexus-community/nancy#readme

--- a/linters/detekt/detekt.test.ts
+++ b/linters/detekt/detekt.test.ts
@@ -5,7 +5,7 @@ import { TrunkLintDriver } from "tests/driver";
 import { DOWNLOAD_CACHE, osTimeoutMultiplier, recurseLevels, skipOS, TEST_DATA } from "tests/utils";
 
 // detekt tests can sometimes take a while.
-jest.setTimeout(300000 * osTimeoutMultiplier); // 300s or 900s
+jest.setTimeout(500000 * osTimeoutMultiplier);
 
 // Running check on the input manually requires the existence of a top level .detekt.yaml
 const preCheck = (driver: TrunkLintDriver) => {

--- a/linters/markdown-table-prettify/markdown_table_prettify.test.ts
+++ b/linters/markdown-table-prettify/markdown_table_prettify.test.ts
@@ -1,0 +1,3 @@
+import { linterFmtTest } from "tests";
+
+linterFmtTest({ linterName: "markdown-table-prettify" });

--- a/linters/markdown-table-prettify/plugin.yaml
+++ b/linters/markdown-table-prettify/plugin.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+tools:
+  definitions:
+    - name: markdown-table-prettify
+      known_good_version: 3.6.0
+      runtime: node
+      package: markdown-table-prettify
+      shims: [markdown-table-prettify]
+lint:
+  definitions:
+    - name: markdown-table-prettify
+      files: [markdown]
+      main_tool: markdown-table-prettify
+      known_good_version: 3.6.0
+      suggest_if: never
+      commands:
+        - name: format
+          output: rewrite
+          formatter: true
+          run: markdown-table-prettify --silent
+          read_output_from: stdout
+          stdin: true
+          success_codes: [0]

--- a/linters/markdown-table-prettify/test_data/basic.in.md
+++ b/linters/markdown-table-prettify/test_data/basic.in.md
@@ -1,0 +1,6 @@
+# Hello world
+
+Type|Size(bit)|Wrapper Class
+-|-|-
+byte|8|Byte
+char|16|Character

--- a/linters/markdown-table-prettify/test_data/markdown_table_prettify_v3.6.0_basic.fmt.shot
+++ b/linters/markdown-table-prettify/test_data/markdown_table_prettify_v3.6.0_basic.fmt.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter markdown-table-prettify test basic 1`] = `
+"# Hello world
+
+Type | Size(bit) | Wrapper Class
+-----|-----------|--------------
+byte | 8         | Byte
+char | 16        | Character"
+`;

--- a/repo-tools/linter-test-helper/generate
+++ b/repo-tools/linter-test-helper/generate
@@ -32,8 +32,10 @@ tools:
 lint:
   definitions:
     - name: NAME_HERE
+      files: [FILE_TYPES_HERE]
       # TOOL_OR_RUNTIME_OR_DOWNLOAD_INFO_HERE
       known_good_version: # VERSION_HERE
+      suggest_if: never
       commands:
         - name: LINT_OR_FORMAT_HERE
           output: OUTPUT_TYPE_HERE


### PR DESCRIPTION
Resolves https://github.com/trunk-io/plugins/issues/578. Prettier is strictly better in most cases, but `markdown-table-prettify` allows a bit more configuration options for users that want that. It also has a good volume of regular installs, so it's a worthy one to include.

This PR also handles some minor repo tidying.