### PR TITLE
Enable more batching

### DIFF
--- a/linters/buf/plugin.yaml
+++ b/linters/buf/plugin.yaml
@@ -35,10 +35,12 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: buf format ${target}
+          run: buf format -w --path=${target}
           success_codes: [0, 100]
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       environment:
         - name: PATH
           # needs system path for `diff`

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -20,12 +20,14 @@ lint:
           success_codes: [0, 1]
           read_output_from: tmp_file
           is_security: true
+          batch: true
         - name: lint
           run: checkov -f ${target} -o sarif --output-file-path ${tmpfile},
           output: sarif_uri
           success_codes: [0, 1]
           read_output_from: tmp_file
           is_security: true
+          batch: true
       known_good_version: 2.3.75
       suggest_if: files_present
       direct_configs:

--- a/linters/clang-format/plugin.yaml
+++ b/linters/clang-format/plugin.yaml
@@ -37,9 +37,10 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: clang-format --assume-filename=${target}
-          success_codes: [0]
-          stdin: true
+          run: clang-format -i ${target}
+          success_codes: [0, 1]
+          batch: true
+          in_place: true
           cache_results: true
           formatter: true
       tools: [clang-format]

--- a/linters/cue-fmt/plugin.yaml
+++ b/linters/cue-fmt/plugin.yaml
@@ -17,6 +17,7 @@ lint:
           success_codes: [0]
           in_place: true
           formatter: true
+          batch: true
       tools: [cue-fmt]
       suggest_if: files_present
       # cue-fmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time

--- a/linters/dotenv-linter/plugin.yaml
+++ b/linters/dotenv-linter/plugin.yaml
@@ -41,6 +41,7 @@ lint:
           in_place: true
           cache_results: true
           formatter: true
+          batch: true
       suggest_if: files_present
       environment:
         - name: PATH

--- a/linters/gofmt/plugin.yaml
+++ b/linters/gofmt/plugin.yaml
@@ -6,11 +6,12 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: gofmt ${target}
+          run: gofmt -w ${target}
           success_codes: [0]
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       download: go # loaded by default with trunk
       suggest_if: files_present
       # go releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time

--- a/linters/gofumpt/plugin.yaml
+++ b/linters/gofumpt/plugin.yaml
@@ -14,11 +14,12 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: gofumpt ${target}
+          run: gofumpt -w ${target}
           success_codes: [0]
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       # gofumpt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time
       known_good_version: 0.5.0
       suggest_if: never

--- a/linters/goimports/plugin.yaml
+++ b/linters/goimports/plugin.yaml
@@ -13,11 +13,12 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: goimports ${target}
+          run: goimports -w ${target}
           success_codes: [0]
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       tools: [goimports]
       suggest_if: never
       environment:

--- a/linters/golines/plugin.yaml
+++ b/linters/golines/plugin.yaml
@@ -14,10 +14,11 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: golines ${target}
+          run: golines -w ${target}
           success_codes: [0]
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       suggest_if: never
       known_good_version: 0.11.0

--- a/linters/google-java-format/plugin.yaml
+++ b/linters/google-java-format/plugin.yaml
@@ -17,12 +17,14 @@ lint:
           success_codes: [0]
           in_place: true
           formatter: true
+          batch: true
         - name: format
           output: rewrite
           run: java -jar ${linter}/google-java-format.jar --replace ${target}
           success_codes: [0]
           in_place: true
           formatter: true
+          batch: true
       runtime: java
       suggest_if: never
       known_good_version: 1.15.0

--- a/linters/nixpkgs-fmt/plugin.yaml
+++ b/linters/nixpkgs-fmt/plugin.yaml
@@ -8,9 +8,10 @@ lint:
       files: [nix]
       commands:
         - output: rewrite
-          run: nixpkgs-fmt
+          run: nixpkgs-fmt ${target}
           success_codes: [0]
-          stdin: true
-          formatter: true
+          in_place: true
+          batch: true
+
       suggest_if: files_present
       known_good_version: 1.3.0

--- a/linters/oxipng/plugin.yaml
+++ b/linters/oxipng/plugin.yaml
@@ -30,6 +30,7 @@ lint:
           run: oxipng --strip safe ${target}
           success_codes: [0]
           in_place: true
+          batch: true
           disable_upstream: true
           fix_verb: fix
           fix_prompt: Unoptimized image

--- a/linters/perltidy/plugin.yaml
+++ b/linters/perltidy/plugin.yaml
@@ -12,6 +12,7 @@ lint:
           read_output_from: stdout
           name: format
           run: perltidy -se ${target}
+          # TODO(chris): See if we can use batching here.
       files:
         - perl
       direct_configs:

--- a/linters/remark-lint/plugin.yaml
+++ b/linters/remark-lint/plugin.yaml
@@ -28,7 +28,9 @@ lint:
           formatter: true
           success_codes: [0]
           in_place: true
+          batch: true
           cache_results: true
+
         - name: lint
           output: sarif
           run: remark ${target} --frail --output --report=vfile-reporter-json

--- a/linters/rustfmt/plugin.yaml
+++ b/linters/rustfmt/plugin.yaml
@@ -7,11 +7,12 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: rustfmt
+          run: rustfmt ${target}
           success_codes: [0]
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       affects_cache:
         - Cargo.toml
         - Cargo.lock

--- a/linters/scalafmt/plugin.yaml
+++ b/linters/scalafmt/plugin.yaml
@@ -31,12 +31,13 @@ lint:
       commands:
         - name: format
           output: rewrite
-          run: scalafmt --stdin --stdout
+          run: scalafmt ${target}
           success_codes: [0]
           run_from: ${root_or_parent_with(.scalafmt.conf)}
-          stdin: true
           cache_results: true
           formatter: true
+          in_place: true
+          batch: true
       environment:
         - name: PATH
           list: ["${linter}"]

--- a/linters/sort-package-json/plugin.yaml
+++ b/linters/sort-package-json/plugin.yaml
@@ -21,6 +21,7 @@ lint:
           success_codes: [0]
           in_place: true
           formatter: true
+          batch: true
       tools: [sort-package-json]
       suggest_if: never # decide whether this is something we want on by default
       path_format: generic

--- a/linters/sql-formatter/plugin.yaml
+++ b/linters/sql-formatter/plugin.yaml
@@ -17,6 +17,7 @@ lint:
           success_codes: [0]
           formatter: true
           stdin: true
+          # Linter does not support batching.
       tools: [sql-formatter]
       known_good_version: 7.0.1
       suggest_if: never

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -30,5 +30,5 @@ lint:
           formatter: true
           in_place: true
           success_codes: [0]
-          enabled: true
+          enabled: false
           batch: true

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -30,4 +30,5 @@ lint:
           formatter: true
           in_place: true
           success_codes: [0]
-          enabled: false
+          enabled: true
+          batch: true

--- a/linters/sqlfmt/plugin.yaml
+++ b/linters/sqlfmt/plugin.yaml
@@ -23,3 +23,4 @@ lint:
           read_output_from: stderr
           formatter: true
           in_place: true
+          batch: true


### PR DESCRIPTION
We used to be conservative about when to enable batching due to the worse error messages when a linter failed, but with the new batch bisection feature, we can enable batching in many more places. Even for very fast linters like clang-format, batching is a large speedup. The only place we would not want to batch is for very expensive linters like clang-tidy or if unsupported by the linter's CLI.

This enables batching on all formatters and also checkov.