### PR TITLE
Ensure trunk knows when checkov fails

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,7 +17,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.10
+      ref: v1.0.1
 
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -15,14 +15,14 @@ lint:
         - name: lint
           # on Windows, we need to make sure 'checkov' resolves to 'checkov.cmd'
           platforms: [windows]
-          # Comma is required on output-file-path
           run: checkov.cmd -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
           success_codes: [0]
           read_output_from: tmp_file
           is_security: true
         - name: lint
-          # Comma is required on output-file-path
+          # Comma is required on output-file-path.
+          # Use soft-fail so we can rely on exit code meaning the linter crashed.
           run: checkov -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
           success_codes: [0]

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -15,14 +15,14 @@ lint:
         - name: lint
           # on Windows, we need to make sure 'checkov' resolves to 'checkov.cmd'
           platforms: [windows]
-          # Comma is required here
+          # Comma is required on output-file-path
           run: checkov.cmd -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
           success_codes: [0]
           read_output_from: tmp_file
           is_security: true
         - name: lint
-          # Comma is required here
+          # Comma is required on output-file-path
           run: checkov -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
           success_codes: [0]

--- a/linters/checkov/plugin.yaml
+++ b/linters/checkov/plugin.yaml
@@ -15,15 +15,17 @@ lint:
         - name: lint
           # on Windows, we need to make sure 'checkov' resolves to 'checkov.cmd'
           platforms: [windows]
-          run: checkov.cmd -f ${target} -o sarif --output-file-path ${tmpfile},
+          # Comma is required here
+          run: checkov.cmd -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
-          success_codes: [0, 1]
+          success_codes: [0]
           read_output_from: tmp_file
           is_security: true
         - name: lint
-          run: checkov -f ${target} -o sarif --output-file-path ${tmpfile},
+          # Comma is required here
+          run: checkov -f ${target} -o sarif --output-file-path ${tmpfile}, --soft-fail
           output: sarif_uri
-          success_codes: [0, 1]
+          success_codes: [0]
           read_output_from: tmp_file
           is_security: true
       known_good_version: 2.3.75


### PR DESCRIPTION
Python will exit 1 when printing a backtrace from a crash so we want trunk to know that is a failure.
Tell checkov to always exit 0, even when there are issues, so we can rely on that.