### PR TITLE
Add command name to codespell definition

### DIFF
--- a/linters/codespell/plugin.yaml
+++ b/linters/codespell/plugin.yaml
@@ -19,7 +19,8 @@ lint:
       known_good_version: 2.2.2
       known_bad_versions: [2.2.3]
       commands:
-        - output: sarif
+        - name: lint
+          output: sarif
           run: codespell ${target}
           success_codes: [0, 65]
           read_output_from: stdout


### PR DESCRIPTION
Not sure how this got missed the first time. If it comes up again, we'll want to add a repo test for it. This would also be a good use case for the "trunk-doctor" or other tool.