### PR TITLE
Add support for python@3.11.6

### DIFF
--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -50,6 +50,22 @@ downloads:
         version: <=3.11.1
         url: https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
+      - os:
+          linux: unknown-linux-gnu
+          macos: apple-darwin
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        version: <=3.11.6
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
+        strip_components: 1
+      - os:
+          windows: pc-windows-msvc-shared
+        cpu:
+          x86_64: x86_64
+        version: <=3.11.6
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
+        strip_components: 1
 
 runtimes:
   definitions:

--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -57,14 +57,14 @@ downloads:
           x86_64: x86_64
           arm_64: aarch64
         version: <=3.11.6
-        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20231002-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
       - os:
           windows: pc-windows-msvc-shared
         cpu:
           x86_64: x86_64
         version: <=3.11.6
-        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20231002-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
 
 runtimes:
@@ -96,7 +96,7 @@ runtimes:
             - "${linter}/Scripts" # Windows places binaries here instead of bin/
         - name: VIRTUAL_ENV
           value: ${linter}
-      known_good_version: 3.10.8
+      known_good_version: 3.11.6
       version_commands:
         - run: python3 --version
           parse_regex: Python ${semver}

--- a/runtimes/python/plugin.yaml
+++ b/runtimes/python/plugin.yaml
@@ -57,14 +57,14 @@ downloads:
           x86_64: x86_64
           arm_64: aarch64
         version: <=3.11.6
-        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20231002-${cpu}-${os}-install_only.tar.gz
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
       - os:
           windows: pc-windows-msvc-shared
         cpu:
           x86_64: x86_64
         version: <=3.11.6
-        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20231002-${cpu}-${os}-install_only.tar.gz
+        url: https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-${version}+20230116-${cpu}-${os}-install_only.tar.gz
         strip_components: 1
 
 runtimes:
@@ -96,7 +96,7 @@ runtimes:
             - "${linter}/Scripts" # Windows places binaries here instead of bin/
         - name: VIRTUAL_ENV
           value: ${linter}
-      known_good_version: 3.11.6
+      known_good_version: 3.10.8
       version_commands:
         - run: python3 --version
           parse_regex: Python ${semver}

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -88,7 +88,7 @@ runtimes:
     # required in order to query latest
     - go@1.21.0
     - node@18.12.1
-    - python@3.10.8
+    - python@3.11.6
     - ruby@3.1.4
 plugins:
   sources:

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -88,7 +88,7 @@ runtimes:
     # required in order to query latest
     - go@1.21.0
     - node@18.12.1
-    - python@3.11.6
+    - python@3.10.8
     - ruby@3.1.4
 plugins:
   sources:


### PR DESCRIPTION
This download is cross-platform compatible. I also tested setting KGV on the newer version to spot-check: note that our current setup/KGV of `pylint` is incompatible with `python@3.11.x` (per https://github.com/pylint-dev/pylint/issues/5919 is fixed in newer versions of pylint)