### PR TITLE
Minor testing refactor

### DIFF
--- a/tests/driver/tool_driver.ts
+++ b/tests/driver/tool_driver.ts
@@ -154,6 +154,22 @@ lint:
     }
   }
 
+  runInstall = async (
+    toolName: string,
+  ): Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+  }> => {
+    try {
+      const { stdout, stderr } = await this.runTrunk(["tools", "install", toolName, "--ci"]);
+      return { exitCode: 0, stdout, stderr };
+    } catch (e: any) {
+      // trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)
+      return { exitCode: e.code as number, stdout: e.stdout as string, stderr: e.stderr as string };
+    }
+  };
+
   /**
    * Parse the result of 'getFullTrunkConfig' in the context of 'ARGS' to identify the desired tool version to enable.
    */

--- a/tests/reporter/reporter.ts
+++ b/tests/reporter/reporter.ts
@@ -47,7 +47,8 @@ export default class TestReporter implements CustomReporter {
         // full test name is stored in origin, test type label is stored in message
         testTypeMap.set(origin, message);
       }
-      return !isLinterVersionMessage && !hasTestType;
+      // Return whether or not console should include the message.
+      return !isLinterVersionMessage && !hasTestType && !hasFailureMode;
     });
     testResult.console = filteredConsole?.length ? filteredConsole : undefined;
 

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import * as os from "os";
 import path from "path";
 import semver from "semver";
+import { TestTarget } from "tests/driver";
 import { CheckType, LandingState, LinterVersion, TaskFailure, TestingArguments } from "tests/types";
 
 export const REPO_ROOT = path.resolve(__dirname, "../..");
@@ -277,10 +278,10 @@ export const osTimeoutMultiplier =
   process.platform === "darwin"
     ? 3
     : process.platform === "win32"
-    ? 3
-    : process.platform === "linux" && process.arch === "arm64"
-    ? 3
-    : 1;
+      ? 3
+      : process.platform === "linux" && process.arch === "arm64"
+        ? 3
+        : 1;
 
 /**
  * This wrapper on existing matchers is used to improve debuggability when an unexpected failure occurs.
@@ -337,4 +338,41 @@ export const landingStateWrapper = (actual: LandingState | undefined, snapshotPa
       details: snapshotContainsFailure(failure) ? expect.stringMatching(/.*$/m) : failure.details,
     })),
   };
+};
+
+export const conditionalTest = (
+  skipTest: boolean,
+  name: string,
+  fn?: jest.ProvidesCallback | undefined,
+  timeout?: number | undefined,
+) => (skipTest ? it.skip(name, fn, timeout) : it(name, fn, timeout));
+
+/**
+ * If `namedTestPrefixes` are specified, checks for their existence in `dirname`/test_data. Otherwise,
+ * automatically scan `dirname` for all available test inputs.
+ * @param dirname absolute path to the linter subdir.
+ * @param namedTestPrefixes optional prefixes of test inputs.
+ */
+export const detectTestTargets = (dirname: string, namedTestPrefixes: string[]): TestTarget[] => {
+  const testDataDir = path.resolve(dirname, TEST_DATA);
+  const testTargets = fs
+    .readdirSync(testDataDir)
+    .sort()
+    .reduce((accumulator: Map<string, TestTarget>, file: string) => {
+      // Check if this is an input file. If so, set it in the accumulator.
+      const inFileRegex = /(?<prefix>.+)\.in\.(?<extension>.+)$/;
+      const foundIn = file.match(inFileRegex);
+      const prefix = foundIn?.groups?.prefix;
+      if (foundIn && prefix) {
+        if (prefix && (namedTestPrefixes.includes(prefix) || namedTestPrefixes.length === 0)) {
+          // inputPath is intentionally a relative path
+          const inputPath = path.join(TEST_DATA, file);
+          accumulator.set(prefix, { prefix, inputPath });
+          return accumulator;
+        }
+      }
+      return accumulator;
+    }, new Map<string, TestTarget>());
+
+  return [...testTargets.values()];
 };


### PR DESCRIPTION
Moves nonessential functions outside of the top-level `tests/index.ts` (it's getting quite long, and some functions need to be there in order for the jest context to work appropriately.

Also fix the custom console override to filter out `suspected-failure-mode` from showing up in the console (it should be hidden and forwarded to the test reporter).