### PR TITLE
Adds action testing

### DIFF
--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -50,7 +50,7 @@ runs:
 
     - name: Run action tests
       if: runner.os == 'Windows'
-      run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci --passWithNoTests
+      run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --passWithNoTests --ci
       shell: bash
       working-directory: ${{ inputs.path }}
       env:
@@ -67,7 +67,7 @@ runs:
         trunk-token: ${{ inputs.trunk-token  }}
         org: trunk-staging-org
         run:
-          npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci --passWithNoTests
+          npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --passWithNoTests --ci
       env:
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}

--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -59,7 +59,6 @@ runs:
 
     - name: Run action tests
       if: runner.os != 'Windows'
-      # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
       uses: trunk-io/breakpoint@v1.3.0
       with:
         breakpoint-id: trunk-plugins-action-tests

--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -1,0 +1,74 @@
+name: Action Tests
+description: Run tests against plugin actions
+
+inputs:
+  cli-version:
+    description: Trunk cli version to run test against. Mutually exclusive with `cli-path`
+    required: false
+  cli-path:
+    description: Trunk cli path to run test against. Overrides `cli-version` if set.
+    required: false
+  path:
+    description: The cwd from which to run plugin commands
+    required: false
+    default: .
+  append-args:
+    description: Additional args to append to the test invocation
+    required: false
+    default: actions --
+  trunk-token:
+    description: CI debugger api token
+    required: true
+
+runs:
+  # TODO(Tyler): See if this can be converted to a js action
+  using: composite
+  steps:
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Specify defaults
+      run: |
+        echo "CLI_PATH=${{ inputs.cli-path }}" >> "$GITHUB_ENV"
+
+        case "$RUNNER_OS" in
+          Windows)
+            echo "PLATFORM_APPEND_ARGS=--maxWorkers=5" >> "$GITHUB_ENV"
+            if [[ "${{ inputs.cli-path }}" == "" ]]; then
+              echo "CLI_PATH=${{ github.workspace }}\trunk.ps1" >> "$GITHUB_ENV"
+            fi
+            ;;
+        esac
+      shell: bash
+
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+      working-directory: ${{ inputs.path }}
+
+    - name: Run action tests
+      if: runner.os == 'Windows'
+      run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci --passWithNoTests
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      env:
+        PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
+        PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
+
+    - name: Run action tests
+      if: runner.os != 'Windows'
+      # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
+      uses: trunk-io/breakpoint@v1.3.0
+      with:
+        breakpoint-id: trunk-plugins-action-tests
+        shell: bash
+        working-directory: ${{ inputs.path }}
+        trunk-token: ${{ inputs.trunk-token  }}
+        org: trunk-staging-org
+        run:
+          npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci --passWithNoTests
+      env:
+        PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
+        PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -21,6 +21,11 @@ all-tools:
   - runtimes/**
   - tests/driver/!(lint_driver.ts)
 
+all-actions:
+  - *framework
+  - runtimes/**
+  - tests/driver/!(action_driver.ts)
+
 # Run tests against specific linters if existing linters have been modified or updated.
 # These test will be run with KnownGoodVersion and Latest to verify linter integrity at the latest and fallback version.
 # Someone should not be able to add a new linter without verifying that it also works on the latest version.
@@ -30,6 +35,9 @@ linters:
 
 tools:
   - added|modified: tools/**
+
+actions:
+  - added|modified: actions/**
 
 # Run tests against the health and configuration of the repo if any plugin definition
 # or testing framework change is made.

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -270,3 +270,16 @@ jobs:
   repo_tests:
     name: Repo Tests
     uses: ./.github/workflows/repo_tests.reusable.yaml
+
+  action_tests_main:
+    name: Action Tests Main
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Action Tests
+        uses: ./.github/actions/action_tests
+        with:
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,6 +36,9 @@ jobs:
       tools: ${{ steps.filter.outputs.tools }}
       all-tools: ${{ steps.post-filter-tools.outputs.out }}
       tools-files: ${{ steps.post-filter-tools-paths.outputs.out }}
+      actions: ${{ steps.filter.outputs.actions }}
+      all-actions: ${{ steps.post-filter-actions.outputs.out }}
+      actions-files: ${{ steps.post-filter-actions-paths.outputs.out }}
 
     steps:
       - name: Checkout
@@ -74,6 +77,13 @@ jobs:
           echo "Run all tool tests"
           echo "out=tools" >> "$GITHUB_OUTPUT"
 
+      - name: Suggest all action tests
+        id: post-filter-actions
+        if: steps.filter.outputs.all-actions == 'true'
+        run: |
+          echo "Run all action tests"
+          echo "out=actions" >> "$GITHUB_OUTPUT"
+
       - name: Suggest normalized individual linter paths
         id: post-filter-paths
         if: steps.filter.outputs.linters
@@ -93,6 +103,16 @@ jobs:
           uniq | tr '\n' ' ')
           echo "Running tests on individual tools: ${tool_files}"
           echo "out=${tool_files}" >> "$GITHUB_OUTPUT"
+
+      - name: Suggest normalized individual action paths
+        id: post-filter-actions-paths
+        if: steps.filter.outputs.actions
+        run: |
+          action_files=$(echo ${{steps.filter.outputs.actions_files}} |
+          grep -oP "\Kactions/.*?(?=/)" |
+          uniq | tr '\n' ' ')
+          echo "Running tests on individual actions: ${action_files}"
+          echo "out=${action_files}" >> "$GITHUB_OUTPUT"
 
   # Run tests against all linters for known_good_version and latest version
   linter_tests:
@@ -164,6 +184,29 @@ jobs:
           append-args:
             ${{ needs.detect_changes.outputs.all-tools }} ${{
             needs.detect_changes.outputs.tools-files }}
+          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+
+  action_tests:
+    name: Action Tests
+    runs-on: [self-hosted, Linux]
+    needs: detect_changes
+    if:
+      needs.detect_changes.outputs.actions == 'true' || needs.detect_changes.outputs.all-actions ==
+      'actions'
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Action Tests
+        uses: ./.github/actions/action_tests
+        if:
+          (failure() || success()) && needs.detect_changes.outputs.actions == 'true' ||
+          needs.detect_changes.outputs.all-actions == 'actions'
+        with:
+          append-args:
+            ${{ needs.detect_changes.outputs.all-actions }} ${{
+            needs.detect_changes.outputs.actions-files }}
           trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
   trunk_check_runner:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,21 +68,21 @@ jobs:
         if: steps.filter.outputs.all-linters == 'true'
         run: |
           echo "Run all linter tests"
-          echo "out=linters" >> "$GITHUB_OUTPUT"
+          echo "out=linters/" >> "$GITHUB_OUTPUT"
 
       - name: Suggest all tool tests
         id: post-filter-tools
         if: steps.filter.outputs.all-tools == 'true'
         run: |
           echo "Run all tool tests"
-          echo "out=tools" >> "$GITHUB_OUTPUT"
+          echo "out=tools/" >> "$GITHUB_OUTPUT"
 
       - name: Suggest all action tests
         id: post-filter-actions
         if: steps.filter.outputs.all-actions == 'true'
         run: |
           echo "Run all action tests"
-          echo "out=actions" >> "$GITHUB_OUTPUT"
+          echo "out=actions/" >> "$GITHUB_OUTPUT"
 
       - name: Suggest normalized individual linter paths
         id: post-filter-paths
@@ -121,7 +121,7 @@ jobs:
     needs: detect_changes
     if:
       needs.detect_changes.outputs.linters == 'true' || needs.detect_changes.outputs.all-linters ==
-      'linters'
+      'linters/'
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -134,9 +134,6 @@ jobs:
       - name: Linter Tests
         # Run tests using KnownGoodVersion with any modified linters and conditionally all linters
         uses: ./.github/actions/linter_tests
-        if:
-          needs.detect_changes.outputs.linters == 'true' || needs.detect_changes.outputs.all-linters
-          == 'linters'
         with:
           linter-version: KnownGoodVersion
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
@@ -163,7 +160,7 @@ jobs:
     needs: detect_changes
     if:
       needs.detect_changes.outputs.tools == 'true' || needs.detect_changes.outputs.all-tools ==
-      'tools'
+      'tools/'
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -177,9 +174,6 @@ jobs:
         # Run tests using KnownGoodVersion with any modified tools and conditionally all tools. Don't run when cancelled.
         # TODO(Tyler): Wire up Latest tests and ReleaseVersionService
         uses: ./.github/actions/tool_tests
-        if:
-          (failure() || success()) && needs.detect_changes.outputs.tools == 'true' ||
-          needs.detect_changes.outputs.all-tools == 'tools'
         with:
           append-args:
             ${{ needs.detect_changes.outputs.all-tools }} ${{
@@ -192,7 +186,7 @@ jobs:
     needs: detect_changes
     if:
       needs.detect_changes.outputs.actions == 'true' || needs.detect_changes.outputs.all-actions ==
-      'actions'
+      'actions/'
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -200,9 +194,6 @@ jobs:
 
       - name: Action Tests
         uses: ./.github/actions/action_tests
-        if:
-          (failure() || success()) && needs.detect_changes.outputs.actions == 'true' ||
-          needs.detect_changes.outputs.all-actions == 'actions'
         with:
           append-args:
             ${{ needs.detect_changes.outputs.all-actions }} ${{

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -206,7 +206,7 @@ jobs:
         with:
           append-args:
             ${{ needs.detect_changes.outputs.all-actions }} ${{
-            needs.detect_changes.outputs.actions-files }}
+            needs.detect_changes.outputs.actions-files }} --
           trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
 
   trunk_check_runner:

--- a/actions/commitlint/commitlint.test.ts
+++ b/actions/commitlint/commitlint.test.ts
@@ -1,0 +1,37 @@
+/* trunk-ignore-all(eslint/import/no-extraneous-dependencies) */
+import { actionRunTest } from "tests";
+import { TrunkActionDriver } from "tests/driver";
+
+const preCheck = (driver: TrunkActionDriver) => {
+  driver.writeFile(
+    "commitlint.config.js",
+    "module.exports = {extends: ['@commitlint/config-conventional']}",
+  );
+};
+
+const testCallback = async (driver: TrunkActionDriver) => {
+  try {
+    await driver.gitDriver?.commit(
+      "Test commit",
+      [],
+      { "--allow-empty": null },
+      (error, result) => {
+        expect(error?.message).toContain("subject may not be empty [subject-empty]");
+        expect(error?.message).toContain("type may not be empty [type-empty]");
+        expect(result).toBeUndefined();
+      },
+    );
+
+    // Commit step should throw
+    expect(1).toBe(2);
+  } catch (_err) {
+    // Intentionally empty
+  }
+};
+
+actionRunTest({
+  actionName: "commitlint",
+  syncGitHooks: true,
+  testCallback,
+  preCheck,
+});

--- a/actions/hello-world/python/hello_world.test.ts
+++ b/actions/hello-world/python/hello_world.test.ts
@@ -1,24 +1,13 @@
-import * as fs from "fs";
-import path from "path";
 import { actionRunTest } from "tests";
 import { TrunkActionDriver } from "tests/driver";
 
 const testCallback = async (driver: TrunkActionDriver) => {
-  // trunk-ignore(semgrep): Safe path
-  const stderrPath = path.resolve(driver.getSandbox(), "stderr");
-  const stderrStream = fs.createWriteStream(stderrPath);
+  await driver.gitDriver?.commit("Test commit", [], { "--allow-empty": null }, (error, result) => {
+    expect(error).toBeNull();
+    expect(result).toBeTruthy();
+  });
 
-  await driver.gitDriver
-    ?.outputHandler((_command, _stdout, stderr) => {
-      // See https://github.com/steveukx/git-js/blob/main/examples/git-output-handler.md for more info
-      stderr.pipe(stderrStream);
-    })
-    .commit("Test commit", [], { "--allow-empty": null }, (error, result) => {
-      expect(error).toBeNull();
-      expect(result).toBeTruthy();
-    });
-
-  expect(fs.readFileSync(stderrPath, "utf8")).toContain("[34mHello[31m World");
+  expect(driver.readGitStderr()).toContain("[34mHello[31m World");
 };
 
 actionRunTest({ actionName: "hello-world-python", syncGitHooks: true, testCallback });

--- a/actions/hello-world/python/hello_world.test.ts
+++ b/actions/hello-world/python/hello_world.test.ts
@@ -10,4 +10,10 @@ const testCallback = async (driver: TrunkActionDriver) => {
   expect(driver.readGitStderr()).toContain("[34mHello[31m World");
 };
 
-actionRunTest({ actionName: "hello-world-python", syncGitHooks: true, testCallback });
+// NOTE(Tyler): This test is currently skipped. To demonstrate its functionality, remove the skipTestIf
+actionRunTest({
+  actionName: "hello-world-python",
+  syncGitHooks: true,
+  testCallback,
+  skipTestIf: () => true,
+});

--- a/actions/hello-world/python/hello_world.test.ts
+++ b/actions/hello-world/python/hello_world.test.ts
@@ -1,0 +1,24 @@
+import * as fs from "fs";
+import path from "path";
+import { actionRunTest } from "tests";
+import { TrunkActionDriver } from "tests/driver";
+
+const testCallback = async (driver: TrunkActionDriver) => {
+  // trunk-ignore(semgrep): Safe path
+  const stderrPath = path.resolve(driver.getSandbox(), "stderr");
+  const stderrStream = fs.createWriteStream(stderrPath);
+
+  await driver.gitDriver
+    ?.outputHandler((_command, _stdout, stderr) => {
+      // See https://github.com/steveukx/git-js/blob/main/examples/git-output-handler.md for more info
+      stderr.pipe(stderrStream);
+    })
+    .commit("Test commit", [], { "--allow-empty": null }, (error, result) => {
+      expect(error).toBeNull();
+      expect(result).toBeTruthy();
+    });
+
+  expect(fs.readFileSync(stderrPath, "utf8")).toContain("[34mHello[31m World");
+};
+
+actionRunTest({ actionName: "hello-world-python", syncGitHooks: true, testCallback });

--- a/tests/driver/action_driver.ts
+++ b/tests/driver/action_driver.ts
@@ -1,0 +1,93 @@
+import Debug from "debug";
+import { GenericTrunkDriver, SetupSettings } from "tests/driver/driver";
+import { REPO_ROOT } from "tests/utils";
+import { getTrunkVersion } from "tests/utils/trunk_config";
+
+const baseDebug = Debug("Driver");
+
+let testNum = 1;
+const actionTests = new Map<string, number>();
+
+const getDebugger = (tool?: string) => {
+  if (!tool) {
+    // If a tool is not provided, provide a counter for easy distinction
+    return baseDebug.extend(`test${testNum++}`);
+  }
+  const numActionTests = actionTests.get(tool);
+  const newNum = (numActionTests ?? 0) + 1;
+  actionTests.set(tool, newNum);
+  return baseDebug.extend(tool).extend(`${newNum}`);
+};
+
+export class TrunkActionDriver extends GenericTrunkDriver {
+  /** The name of action tool. If defined, enable the action during setup. */
+  action: string;
+  syncGitHooks: boolean;
+
+  constructor(
+    testDir: string,
+    setupSettings: SetupSettings,
+    action: string,
+    syncGitHooks: boolean,
+  ) {
+    super(testDir, setupSettings, getDebugger(action));
+    this.action = action;
+    this.syncGitHooks = syncGitHooks;
+  }
+
+  getTrunkYamlContents(trunkVersion: string | undefined): string {
+    return `version: 0.1
+cli:
+  version: ${trunkVersion ?? getTrunkVersion()}
+plugins:
+  sources:
+  - id: trunk
+    local: ${REPO_ROOT}
+actions:
+  enabled:
+    - ${this.action}
+`;
+  }
+
+  /**
+   * Setup a sandbox test directory by copying in test contents and conditionally:
+   * 1. Creating a git repo
+   * 2. Dumping a newly generated trunk.yaml
+   * 3. Calling git hooks sync
+   */
+  async setUp() {
+    await super.setUp();
+
+    if (!this.syncGitHooks || !this.sandboxPath) {
+      return;
+    }
+    try {
+      this.debug("Syncing git hooks");
+      await this.runTrunk(["git-hooks", "sync"]);
+    } catch (error) {
+      console.warn(`Failed to sync git hooks for ${this.action}`, error);
+      if ("stdout" in (error as any)) {
+        // trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)
+        console.log("Error output:", ((error as any).stdout as Buffer).toString());
+      } else {
+        console.log("Error keys:  ", Object.keys(error as object));
+      }
+    }
+  }
+
+  runAction = async (
+    args?: string,
+  ): Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+  }> => {
+    try {
+      const { stdout, stderr } = await this.runTrunk(["run", this.action, args ?? ""]);
+      return { exitCode: 0, stdout, stderr };
+    } catch (e: any) {
+      // trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)
+      return { exitCode: e.code as number, stdout: e.stdout as string, stderr: e.stderr as string };
+    }
+  };
+}

--- a/tests/driver/action_driver.ts
+++ b/tests/driver/action_driver.ts
@@ -22,15 +22,11 @@ const getDebugger = (tool?: string) => {
 };
 
 export class TrunkActionDriver extends GenericTrunkDriver {
-  /** The name of action tool. If defined, enable the action during setup. */
-  action: string;
-  syncGitHooks: boolean;
-
   constructor(
     testDir: string,
     setupSettings: SetupSettings,
-    action: string,
-    syncGitHooks: boolean,
+    private action: string,
+    private syncGitHooks: boolean,
   ) {
     super(testDir, setupSettings, getDebugger(action));
     this.action = action;

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -10,7 +10,7 @@ import * as util from "util";
 import YAML from "yaml";
 
 /**
- * Configuration for when a TrunkLintDriver instance runs `setUp`.
+ * Configuration for when a TrunkDriver instance runs `setUp`.
  */
 export interface SetupSettings {
   /** Whether or not to run `git init` and attach a gitDriver. */

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -4,11 +4,22 @@ import * as fs from "fs";
 import * as os from "os";
 import path from "path";
 import * as git from "simple-git";
-import { SetupSettings } from "tests/driver";
 import { ARGS, DOWNLOAD_CACHE, REPO_ROOT, TEMP_PREFIX, TEST_DATA } from "tests/utils";
 import { getTrunkConfig } from "tests/utils/trunk_config";
 import * as util from "util";
 import YAML from "yaml";
+
+/**
+ * Configuration for when a TrunkLintDriver instance runs `setUp`.
+ */
+export interface SetupSettings {
+  /** Whether or not to run `git init` and attach a gitDriver. */
+  setupGit?: boolean;
+  /** Whether or not to create a new .trunk/trunk.yaml */
+  setupTrunk?: boolean;
+  /** Version of trunk to initialize (overrides environment vars) */
+  trunkVersion?: string;
+}
 
 const execFilePromise = util.promisify(execFile);
 

--- a/tests/driver/index.ts
+++ b/tests/driver/index.ts
@@ -1,14 +1,3 @@
-/**
- * Configuration for when a TrunkLintDriver instance runs `setUp`.
- */
-export interface SetupSettings {
-  /** Whether or not to run `git init` and attach a gitDriver. */
-  setupGit?: boolean;
-  /** Whether or not to create a new .trunk/trunk.yaml */
-  setupTrunk?: boolean;
-  /** Version of trunk to initialize (overrides environment vars) */
-  trunkVersion?: string;
-}
-
+export * from "./action_driver";
 export * from "./lint_driver";
 export * from "./tool_driver";

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -1,13 +1,11 @@
 import Debug from "debug";
 import * as fs from "fs";
 import path from "path";
-import { SetupSettings } from "tests/driver";
+import { GenericTrunkDriver, SetupSettings } from "tests/driver/driver";
 import { LandingState, TrunkVerb } from "tests/types";
 import { ARGS, REPO_ROOT } from "tests/utils";
 import { tryParseLandingState } from "tests/utils/landing_state";
 import { getTrunkVersion } from "tests/utils/trunk_config";
-
-import { GenericTrunkDriver } from "./driver";
 
 const baseDebug = Debug("Driver");
 let testNum = 1;

--- a/tests/driver/tool_driver.ts
+++ b/tests/driver/tool_driver.ts
@@ -1,11 +1,9 @@
 import Debug from "debug";
 import * as fs from "fs";
 import path from "path";
-import { SetupSettings } from "tests/driver";
+import { GenericTrunkDriver, SetupSettings } from "tests/driver/driver";
 import { ARGS, REPO_ROOT } from "tests/utils";
 import { getTrunkVersion } from "tests/utils/trunk_config";
-
-import { GenericTrunkDriver } from "./driver";
 
 const baseDebug = Debug("Driver");
 
@@ -24,7 +22,7 @@ const getDebugger = (tool?: string) => {
 };
 
 /**
- * The result of running a 'trunk check' or 'trunk fmt' command.
+ * The result of invoking a tool.
  */
 export interface TrunkToolRunResult {
   exitCode: number;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -212,12 +212,12 @@ export const setupTrunkActionDriver = (
   );
 
   beforeAll(async () => {
+    await driver.setUp();
     if (preCheck) {
       // preCheck is not always async, but we must await in case it is.
       await preCheck(driver);
       driver.debug("Finished running custom preCheck hook");
     }
-    await driver.setUp();
   });
 
   afterAll(() => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,7 +1,8 @@
 import caller from "caller";
 import * as fs from "fs";
 import * as path from "path";
-import { SetupSettings, TrunkLintDriver, TrunkToolDriver } from "tests/driver";
+import { TrunkActionDriver, TrunkLintDriver, TrunkToolDriver } from "tests/driver";
+import { SetupSettings } from "tests/driver/driver";
 import { FailureMode, FileIssue, LandingState } from "tests/types";
 
 import specific_snapshot = require("jest-specific-snapshot");
@@ -86,6 +87,7 @@ const CUSTOM_SNAPSHOT_PREFIX = "CUSTOM";
 
 export type TestCallback = (driver: TrunkLintDriver) => unknown;
 export type ToolTestCallback = (driver: TrunkToolDriver) => unknown;
+export type ActionTestCallback = (driver: TrunkActionDriver) => unknown;
 
 /**** Test Setup ****/
 
@@ -96,7 +98,7 @@ export type ToolTestCallback = (driver: TrunkToolDriver) => unknown;
  * @param linterName if specified, enables this linter during setup.
  * @param version the version of a linter to enable, if specified. May be a version string or one of `LinterVersion`
  */
-export const setupDriver = (
+export const setupLintDriver = (
   dirname: string,
   { setupGit = true, setupTrunk = true, trunkVersion = undefined }: SetupSettings,
   linterName?: string,
@@ -191,6 +193,35 @@ export const setUpTrunkToolDriverForHealthCheck = (
 
   afterEach(() => {
     registerVersion("tool", driver.enabledVersion);
+  });
+  return driver;
+};
+
+export const setupTrunkActionDriver = (
+  dirname: string,
+  { setupGit = true, setupTrunk = true, trunkVersion = undefined }: SetupSettings,
+  actionName: string,
+  syncGitHooks: boolean,
+  preCheck?: ActionTestCallback,
+): TrunkActionDriver => {
+  const driver = new TrunkActionDriver(
+    dirname,
+    { setupGit, setupTrunk, trunkVersion },
+    actionName,
+    syncGitHooks,
+  );
+
+  beforeAll(async () => {
+    if (preCheck) {
+      // preCheck is not always async, but we must await in case it is.
+      await preCheck(driver);
+      driver.debug("Finished running custom preCheck hook");
+    }
+    await driver.setUp();
+  });
+
+  afterAll(() => {
+    driver.tearDown();
   });
   return driver;
 };
@@ -325,7 +356,7 @@ export const customLinterCheckTest = ({
       // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
       describe("test", () => {
         // Step 2: Define test setup and teardown
-        const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+        const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
 
         // Step 3: Run the test
         conditionalTest(skipTestIf(linterVersion), testName, async () => {
@@ -445,7 +476,7 @@ export const customLinterFmtTest = ({
       // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
       describe("test", () => {
         // Step 2: Define test setup and teardown
-        const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+        const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
 
         // Step 3: Run the test
         conditionalTest(skipTestIf(linterVersion), testName, async () => {
@@ -547,7 +578,7 @@ export const fuzzyLinterCheckTest = ({
       // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
       describe("test", () => {
         // Step 2: Define test setup and teardown
-        const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+        const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
 
         // Step 3: Run the test
         conditionalTest(skipTestIf(linterVersion), testName, async () => {
@@ -646,7 +677,7 @@ export const linterCheckTest = ({
         // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
-          const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+          const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
 
           // Step 3: Run each test
           conditionalTest(skipTestIf(linterVersion), prefix, async () => {
@@ -737,7 +768,7 @@ export const linterFmtTest = ({
         // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
-          const driver = setupDriver(dirname, {}, linterName, linterVersion, preCheck);
+          const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
 
           // Step 3: Run each test
           conditionalTest(skipTestIf(linterVersion), prefix, async () => {
@@ -783,6 +814,41 @@ export const linterFmtTest = ({
           });
         });
       });
+    });
+  });
+};
+
+/**** Action Tests ****/
+
+/**
+ * Test an action by enabling it and provided a hook to test any assertions. Bare-bones setup
+ * Without any frills.
+ *
+ * @param dirname absolute path to the linter subdir.
+ * @param actionName action to enable
+ * @param testCallback callback to run for any assertions. Use built-in methods to run actions.
+ * @param skipTestIf callback to check if test should be skipped or run.
+ * @param preCheck callback to run during setup
+ */
+export const actionRunTest = ({
+  actionName,
+  syncGitHooks,
+  testCallback,
+  dirName = path.dirname(caller()),
+  skipTestIf = (_version?: string) => false,
+  preCheck,
+}: {
+  actionName: string;
+  syncGitHooks: boolean;
+  testCallback: ActionTestCallback;
+  dirName?: string;
+  skipTestIf?: () => boolean;
+  preCheck?: ActionTestCallback;
+}) => {
+  describe(`Testing action ${actionName}`, () => {
+    const driver = setupTrunkActionDriver(dirName, {}, actionName, syncGitHooks, preCheck);
+    conditionalTest(skipTestIf(), "action ", async () => {
+      await testCallback(driver);
     });
   });
 };

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import path from "path";
-import { setupDriver } from "tests";
+import { setupLintDriver } from "tests";
 import { osTimeoutMultiplier, REPO_ROOT } from "tests/utils";
 
 // Avoid strictly typing composite config
@@ -20,7 +20,7 @@ jest.setTimeout(300000 * osTimeoutMultiplier); // 300s or 900s
  */
 describe("Global config health check", () => {
   // Step 1: Define test setup and teardown
-  const driver = setupDriver(REPO_ROOT, {
+  const driver = setupLintDriver(REPO_ROOT, {
     setupGit: false,
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
@@ -180,7 +180,7 @@ describe("Global config health check", () => {
  */
 describe("Explicitly enabled healthcheck", () => {
   // Step 1: Define test setup and teardown
-  const driver = setupDriver(REPO_ROOT, {
+  const driver = setupLintDriver(REPO_ROOT, {
     setupGit: false,
     setupTrunk: true,
   });


### PR DESCRIPTION
Adds a super straightforward framework for testing Trunk Actions in this repo. Instantiate a `TrunkActionDriver` the same as the other tests, and then call a `preCheck` if necessary, and then pass assertions to `testCallback` (parametrized since action functionality is diverse).

In this callback either invoke `driver.runAction()` or use the simpleGit `driver.gitDriver()` and assert based on its error handler or based on `driver.readGitStderr()`.

I've added 2 tests to demonstrate this:
- `hello_world` (currently disabled for speed, especially since it's just a sample)
- `commitlint` (only added a test for a standard failure case. We may want to expand the test coverage for it in the future, including via `trunk run`)

We can backfill the remaining actions with tests whenever we feel the need to, but this will help us prevent any action regressions, particularly with commitlint.

Example successful [run](https://github.com/trunk-io/plugins/actions/runs/7403264485/job/20142746117?pr=609)