### PR TITLE
Bump required version

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.18.0"
+required_trunk_version: ">=1.18.2-beta.7"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -25,7 +25,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.18.0",
+    trunkVersion: "1.18.2-beta.7",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
Recent prettier changes require the latest CLI version. Bump the required version to reflect that. 

Technically this is a runtime dependency, not a config-dependency, but because it affects prettier we should gate on this dependency.