### PR TITLE
Fix snapshot auto-generation bug

### DIFF
--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -101,6 +101,11 @@ const mergeTestFailureMetadata = (original: TestResult, incoming: TestResult) =>
           return;
         }
 
+        // If the incoming test result is a skipped, use the current failure mode
+        if (incoming.testResultStatus === "skipped") {
+          return;
+        }
+
         // If the incoming test result is a failure and not assertion_failure, **invalidate the failure mode
         if (incomingSuspectedFailureMode !== "assertion_failure") {
           original.testFailureMetadata.set(testFullName, incomingSuspectedFailureMode);
@@ -343,7 +348,7 @@ const writeTestResults = (testResults: TestResultSummary) => {
       if (status !== "passed" && status !== "skipped") {
         const shouldRerunTest = Array.from(testFailureMetadata.values()).every(
           // If any non-assertion-type failures occur, we can't proactively generate snapshot.
-          (failureMode) => failureMode === "assertion_failure" || failureMode === "passed",
+          (failureMode) => failureMode === "assertion_failure" || failureMode === "skipped",
         );
         if (shouldRerunTest) {
           rerunPaths.push(testFilePath);

--- a/tests/reporter/reporter.ts
+++ b/tests/reporter/reporter.ts
@@ -60,6 +60,8 @@ export default class TestReporter implements CustomReporter {
       if (individualResult.status === "failed") {
         individualResult.suspectedFailureMode =
           suspectedFailureModeMap.get(individualResult.fullName) ?? "unknown";
+      } else if (individualResult.status === "pending") {
+        individualResult.suspectedFailureMode = "skipped";
       } else {
         individualResult.suspectedFailureMode = "passed";
       }

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -132,9 +132,10 @@ export interface LandingState {
  * - unknown: unknown, usually a test timeout, discrepancy, or other setup error -> requires investigation
  * - task_failure: a task failure occurred, whether during execution or linter install -> requires investigation
  * - passed: only during post-processing, if at least some of the tests passed -> can still generate a snapshot
- * - assertion_failure: the exepcted diagnostics vary -> we can usually generate a snapshot proactively
+ * - assertion_failure: the expected diagnostics vary -> we can usually generate a snapshot proactively
+ * - skipped: the test was skipped -> defer to other tests
  */
-export type FailureMode = "unknown" | "passed" | "task_failure" | "assertion_failure";
+export type FailureMode = "unknown" | "passed" | "task_failure" | "assertion_failure" | "skipped";
 
 /**
  * Which OS the test was run on. Must be kept in sync with the matrix in nightly.yaml.


### PR DESCRIPTION
Fixes another bug in snapshot generation that led to the creation of https://github.com/trunk-io/plugins/pull/618. Depending on the order of the test parsing, mismatched versions were being treated as a "pass", which was an overloaded state and led to snapshot auto-generation. I added the `Skipped` failure enum type, which makes these states more explicit and fixes the underlying issue.

I also tested manually that this still has the fix from #612.