### PR TITLE
Fix nightly invocation of actions tests

### DIFF
--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -15,7 +15,7 @@ inputs:
   append-args:
     description: Additional args to append to the test invocation
     required: false
-    default: actions --
+    default: actions/ --
   trunk-token:
     description: CI debugger api token
     required: true


### PR DESCRIPTION
For unknown reasons, `jest` parses command line args differently in certain CI settings. I changed all `linters`/`actions`, etc. to `linters/`/`actions/`, but I missed this case, as apparent in https://github.com/trunk-io/plugins/actions/runs/7453451001/job/20278848879