### PR TITLE
Don't cache rustfmt

### DIFF
--- a/linters/rustfmt/plugin.yaml
+++ b/linters/rustfmt/plugin.yaml
@@ -9,7 +9,6 @@ lint:
           output: rewrite
           run: rustfmt ${target}
           success_codes: [0]
-          cache_results: true
           formatter: true
           in_place: true
           batch: true


### PR DESCRIPTION
Rustfmt run on paths (instead of stdin) will try to follow imports. This changed when it was made to be batched. Disabling caching fixes it.