### PR TITLE
Add additional stylelint configs

### DIFF
--- a/linters/stylelint/plugin.yaml
+++ b/linters/stylelint/plugin.yaml
@@ -31,12 +31,16 @@ lint:
           run: stylelint --fix ${target}
           in_place: true
       direct_configs:
-        - .stylelintrc
+        - stylelint.config.js
+        - .stylelintrc.js
+        - stylelint.config.mjs
+        - .stylelintrc.mjs
+        - stylelint.config.cjs
+        - .stylelintrc.cjs
         - .stylelintrc.json
         - .stylelintrc.yml
         - .stylelintrc.yaml
-        - .stylelintrc.js
-        - .stylelintrc.cjs
+        - .stylelintrc
       suggest_if: config_present
       affects_cache:
         - package.json


### PR DESCRIPTION
Stylelint has expanded its set of [configs](https://github.com/trunk-io/plugins/pull/new/tyler/stylelint-improvements) since we added our integration. Updates the configs and their order of precedence to reflect this.