### PR TITLE
Add .mjs extension for eslint and prettier

### DIFF
--- a/linters/eslint/plugin.yaml
+++ b/linters/eslint/plugin.yaml
@@ -23,6 +23,7 @@ lint:
         - .eslintrc.cjs
         - .eslintrc.js
         - .eslintrc.json
+        - .eslintrc.mjs
         - .eslintrc.yaml
         - .eslintrc.yml
       suggest_if: config_present

--- a/linters/prettier/plugin.yaml
+++ b/linters/prettier/plugin.yaml
@@ -42,8 +42,10 @@ lint:
         - .prettierrc.json5
         - .prettierrc.js
         - .prettierrc.cjs
+        - .prettierrc.mjs
         - prettier.config.js
         - prettier.config.cjs
+        - prettier.config.mjs
         - .prettierrc.toml
         - .prettierignore
       affects_cache:


### PR DESCRIPTION
## Changes

Adds `.mjs` extension for ESLint and Prettier plugins (note: `.mjs` is always a valid option whenever any `.js` extension is accepted, and Node automatically treats it as the same, just in enforced ESM mode)