### PR TITLE
Cleanup terrascan definition

### DIFF
--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -52,4 +52,3 @@ lint:
       environment:
         - name: PATH
           list: ["${linter}"]
-      direct_configs: [terrascan_config.toml]


### PR DESCRIPTION
Remove terrascan configuration file since it is not read by default. In order to specify a configuration file, users must override as follows:
Either
```yaml
lint:
  definitions:
    - name: terrascan
      direct_configs: [terrascan_config.toml]
      environment:
        - name: TERRASCAN_CONFIG
          value: ${workspace}/.trunk/configs/terrascan_config.toml
```

Or
```yaml
lint:
  definitions:
    - name: terrascan
      direct_configs: [terrascan_config.toml]
      commands:
        - name: lint
          run: terrascan scan -i terraform -c terrascan_config.toml --iac-file ${target} --output sarif
        - name: lint-docker
          run: terrascan scan -i docker -c terrascan_config.toml --iac-file ${target} --output sarif
```