### PR TITLE
Add tool: yq

### DIFF
--- a/tools/yq/plugin.yaml
+++ b/tools/yq/plugin.yaml
@@ -5,7 +5,6 @@ downloads:
       - os:
           linux: linux
           macos: darwin
-          windows: windows
         cpu:
           x86_64: 386
           arm_64: arm64

--- a/tools/yq/plugin.yaml
+++ b/tools/yq/plugin.yaml
@@ -1,0 +1,18 @@
+version: 0.1
+downloads:
+  - name: yq
+    downloads:
+      - os:
+          linux: linux
+          macos: darwin
+          windows: windows
+        cpu:
+          x86_64: 386
+          arm_64: arm64
+        url: https://github.com/mikefarah/yq/releases/download/v${version}/yq_${os}_${cpu}.tar.gz
+tools:
+  definitions:
+    - name: yq
+      download: yq
+      known_good_version: 4.40.5
+      shims: [yq]

--- a/tools/yq/plugin.yaml
+++ b/tools/yq/plugin.yaml
@@ -10,6 +10,12 @@ downloads:
           x86_64: 386
           arm_64: arm64
         url: https://github.com/mikefarah/yq/releases/download/v${version}/yq_${os}_${cpu}.tar.gz
+      - os:
+          windows: windows
+        cpu:
+          x86_64: 386
+          arm_64: arm64
+        url: https://github.com/mikefarah/yq/releases/download/v${version}/yq_${os}_${cpu}.zip
 tools:
   definitions:
     - name: yq

--- a/tools/yq/yq.test.ts
+++ b/tools/yq/yq.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "yq",
+  toolVersion: "4.40.5",
+});


### PR DESCRIPTION
Replaces #653. `yq` is the yaml equivalent of `jq`. Works really nicely to print a lint definition using:
`trunk config print | .trunk/tools/yq '.lint.definitions[] | select(.name == "eslint")'`, which could be streamlined via a Trunk Action if desired once tools are supported in Actions.