### PR TITLE
Change yamllint default config to better support idiomatic github actions syntax

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,6 +23,7 @@ lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin
   disabled:
     - pylint # pylint diagnostics are too strict
+    - semgrep
 
   ignore:
     - linters: [ALL]

--- a/linters/yamllint/.yamllint.yaml
+++ b/linters/yamllint/.yamllint.yaml
@@ -2,9 +2,6 @@ rules:
   quoted-strings:
     required: only-when-needed
     extra-allowed: ["{|}"]
-  empty-values:
-    forbid-in-block-mappings: true
-    forbid-in-flow-mappings: true
   key-duplicates: {}
   octal-values:
     forbid-implicit-octal: true


### PR DESCRIPTION
This turns off warnings for empty blocks like these:
```yaml
on:
  pull_request:
  workflow_dispatch:
```
Which are typical in github actions yaml.