### PR TITLE
Initial support for trunk-toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ trunk check enable {linter}
 [tflint]: https://github.com/terraform-linters/tflint#readme
 [tfsec]: https://github.com/aquasecurity/tfsec
 [trivy]: https://github.com/aquasecurity/trivy#readme
-[trufflehog]: https://github.com/trufflesecurity/trufflehog/
-
-[trunk-toolbox] : https://github.com/trunk-io/toolbox/ [txtpbfmt]:
-https://github.com/protocolbuffers/txtpbfmt/ [yamllint]:
-https://github.com/adrienverge/yamllint#readme [yapf]: https://github.com/google/yapf#readme
+[trufflehog]: https://github.com/trufflesecurity/trufflehog#readme
+[trunk-toolbox]: https://github.com/trunk-io/toolbox#readme
+[txtpbfmt]: https://github.com/protocolbuffers/txtpbfmt#readme
+[yamllint]: https://github.com/adrienverge/yamllint#readme
+[yapf]: https://github.com/google/yapf#readme
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ trunk check enable {linter}
 
 | Technology      | Linters                                                                                                              |
 | --------------- | -------------------------------------------------------------------------------------------------------------------- |
-| All             | [codespell], [cspell], [gitleaks], [git-diff-check], [pre-commit-hooks]                                              |
+| All             | [codespell], [cspell], [gitleaks], [git-diff-check], [pre-commit-hooks], [trunk-toolbox]                             |
 | Ansible         | [ansible-lint]                                                                                                       |
 | Apex            | [pmd]                                                                                                                |
 | Bash            | [shellcheck], [shfmt]                                                                                                |
@@ -175,9 +175,10 @@ trunk check enable {linter}
 [tfsec]: https://github.com/aquasecurity/tfsec
 [trivy]: https://github.com/aquasecurity/trivy#readme
 [trufflehog]: https://github.com/trufflesecurity/trufflehog/
-[txtpbfmt]: https://github.com/protocolbuffers/txtpbfmt/
-[yamllint]: https://github.com/adrienverge/yamllint#readme
-[yapf]: https://github.com/google/yapf#readme
+
+[trunk-toolbox] : https://github.com/trunk-io/toolbox/ [txtpbfmt]:
+https://github.com/protocolbuffers/txtpbfmt/ [yamllint]:
+https://github.com/adrienverge/yamllint#readme [yapf]: https://github.com/google/yapf#readme
 
 <br/>
 

--- a/linters/trunk-toolbox/plugin.yaml
+++ b/linters/trunk-toolbox/plugin.yaml
@@ -1,0 +1,38 @@
+version: 0.1
+
+downloads:
+  - name: trunk-toolbox
+    version: 0.2.0
+    downloads:
+      - version: 0.2.0
+        os:
+          linux: unknown-linux-gnu
+          macos: apple-darwin
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        url: https://github.com/trunk-io/toolbox/releases/download/${version}/trunk-toolbox-${version}-${cpu}-${os}.tar.gz
+tools:
+  definitions:
+    - name: trunk-toolbox
+      download: trunk-toolbox
+      shims: [trunk-toolbox]
+      known_good_version: 0.2.0
+lint:
+  definitions:
+    - name: trunk-toolbox
+      tools: [trunk-toolbox]
+      files: [ALL]
+      known_good_version: 0.2.0
+      commands:
+        - name: lint
+          run: trunk-toolbox --upstream=${upstream-ref} --results=${tmpfile}  ${target}
+          output: sarif
+          batch: true
+          success_codes: [0]
+          read_output_from: tmp_file
+          disable_upstream: true
+      suggest_if: never
+      version_command:
+        parse_regex: ${semver}
+        run: trunk-toolbox --version

--- a/linters/trunk-toolbox/test_data/do_not_land.in.txt
+++ b/linters/trunk-toolbox/test_data/do_not_land.in.txt
@@ -1,0 +1,5 @@
+//DONOTLAND
+//do-not-land
+//do_not_land
+
+Should be three reported issues

--- a/linters/trunk-toolbox/test_data/trunk_toolbox_v0.2.0_do_not_land.check.shot
+++ b/linters/trunk-toolbox/test_data/trunk_toolbox_v0.2.0_do_not_land.check.shot
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter trunk-toolbox test do_not_land 1`] = `
+{
+  "issues": [
+    {
+      "code": "do-not-land",
+      "column": "3",
+      "file": "test_data/do_not_land.in.txt",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "trunk-toolbox",
+      "message": "Found 'DONOTLAND'",
+      "ranges": [
+        {
+          "filePath": "test_data/do_not_land.in.txt",
+          "length": "9",
+          "offset": "2",
+        },
+      ],
+      "targetType": "ALL",
+    },
+    {
+      "code": "do-not-land",
+      "column": "3",
+      "file": "test_data/do_not_land.in.txt",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "trunk-toolbox",
+      "message": "Found 'do-not-land'",
+      "ranges": [
+        {
+          "filePath": "test_data/do_not_land.in.txt",
+          "length": "11",
+          "offset": "14",
+        },
+      ],
+      "targetType": "ALL",
+    },
+    {
+      "code": "do-not-land",
+      "column": "3",
+      "file": "test_data/do_not_land.in.txt",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "3",
+      "linter": "trunk-toolbox",
+      "message": "Found 'do_not_land'",
+      "ranges": [
+        {
+          "filePath": "test_data/do_not_land.in.txt",
+          "length": "11",
+          "offset": "28",
+        },
+      ],
+      "targetType": "ALL",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "ALL",
+      "linter": "trunk-toolbox",
+      "paths": [
+        "test_data/do_not_land.in.txt",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/trunk-toolbox/trunk_toolbox.test.ts
+++ b/linters/trunk-toolbox/trunk_toolbox.test.ts
@@ -1,0 +1,4 @@
+import { linterCheckTest } from "tests";
+import { skipOS } from "tests/utils";
+
+linterCheckTest({ linterName: "trunk-toolbox", skipTestIf: skipOS(["win32"]) });


### PR DESCRIPTION
Trunk toolbox currently supports two primary rules:

1. Do not land - basic linter to protect against landing code that is not intended to land by commenting in a file // do-not-land or similar
2. IfChange code sync linter - which makes sure that file connection can be verified - if one file in a repo depends on another then you can call this dependency out with markup. 


Learn more here:
github.com/trunk-io/toolbox
