### PR TITLE
feat: add bazel build action

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ trunk actions enable {action}
 | [`git-blame-ignore-revs`](actions/git-blame-ignore-revs/README.md)   | automatically configure git to use .git-blame-ignore-revs  |
 | [`npm-check`](actions/npm-check/README.md)                           | check whether NPM installation is up to date               |
 | [`yarn-check`](actions/yarn-check/README.md)                         | check whether Yarn installation is up to date              |
+| [`bazel-build`](actions/bazel/README.md)                         | run `bazel build //...` before `git push`              |
 
 ### Supported Tools
 

--- a/actions/bazel/README.md
+++ b/actions/bazel/README.md
@@ -1,0 +1,3 @@
+# bazel-build
+
+Run `bazel build //...` before every `git push`. **Must** be a bazel project and have [bazel](https://bazel.build) installed.

--- a/actions/bazel/plugin.yaml
+++ b/actions/bazel/plugin.yaml
@@ -3,8 +3,7 @@ actions:
   definitions:
     - id: bazel-build
       display_name: Bazel Build
-      description:
-        Run 'bazel build //...' before git push
+      description: Run 'bazel build //...' before git push
       run: bazel build //...
       triggers:
         - git_hooks: [pre-push]

--- a/actions/bazel/plugin.yaml
+++ b/actions/bazel/plugin.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+actions:
+  definitions:
+    - id: bazel-build
+      display_name: Bazel Build
+      description:
+        Run 'bazel build //...' before git push
+      run: bazel build //...
+      triggers:
+        - git_hooks: [pre-push]


### PR DESCRIPTION
I was just tired of having to wait for ci to see if bazel build succeeds since most of the time I forget to run bazel build manually after commit.