### PR TITLE
Add enabled version replacer callback 

### DIFF
--- a/linters/taplo/taplo.test.ts
+++ b/linters/taplo/taplo.test.ts
@@ -11,10 +11,21 @@ const versionGreaterThanOrEqual = (a: string, b: string) => {
   return semver.gte(normalizedA, normalizedB);
 };
 
+const manualVersionReplacer = (version: string) => {
+  if (version === "release-taplo-0.13.0") {
+    // As of 2/26, taplo-cli-0.9.0 does not provide a release binary.
+    // If the binary is released, this version should be updated to 0.9.0.
+    // For now, this callback avoids spammy test notifs.
+    return "0.8.1";
+  }
+  return version;
+};
+
 // NOTE(Tyler): Currently, taplo doesn't have a fully compatible download for Windows. We hope to enable it in the future.
 customLinterCheckTest({
   linterName: "taplo",
   args: `${TEST_DATA} -y`,
   pathsToSnapshot: [path.join(TEST_DATA, "basic.toml")],
   versionGreaterThanOrEqual,
+  manualVersionReplacer,
 });


### PR DESCRIPTION
Adds a replacer to patch the linter's enabled version.

This is mainly for taplo, which changes its version schema frequently and has adopted a new release schema. In theory we could adapt this for some of our go linters for which we can't query release versions well.

This works better as a replacer than just adapting the `preCheck` callback because this needs to happen in setup to best propagate to the snapshot matchers and to LUV wiring. I verified manually that the correct version gets relayed to the LUV output.