### PR TITLE
Integrate linter regal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ trunk check enable {linter}
 | Prisma          | [prisma]                                                                                                             |
 | Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                                                     |
 | Python          | [autopep8], [bandit], [black], [flake8], [isort], [mypy], [pylint], [pyright], [semgrep], [yapf], [ruff], [sourcery] |
+| Rego            | [regal]                                                                                                              |
 | Renovate        | [renovate]                                                                                                           |
 | Ruby            | [brakeman], [rubocop], [rufo], [semgrep], [standardrb]                                                               |
 | Rust            | [clippy], [rustfmt]                                                                                                  |
@@ -148,6 +149,7 @@ trunk check enable {linter}
 [psscriptanalyzer]: https://github.com/PowerShell/PSScriptAnalyzer
 [pylint]: https://github.com/PyCQA/pylint#readme
 [pyright]: https://github.com/microsoft/pyright
+[regal]: https://github.com/StyraInc/regal#readme
 [remark-lint]: https://github.com/remarkjs/remark-lint#readme
 [renovate]: https://github.com/renovatebot/renovate#readme
 [rome]: https://github.com/rome/tools#readme

--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -453,6 +453,12 @@ lint:
       comments:
         - hash
 
+    - name: rego
+      extensions:
+        - rego
+      comments:
+        - hash
+
     - name: ruby
       extensions:
         - rb

--- a/linters/regal/plugin.yaml
+++ b/linters/regal/plugin.yaml
@@ -1,0 +1,39 @@
+version: 0.1
+downloads:
+  - name: regal
+    downloads:
+      - os:
+          linux: Linux
+          macos: Darwin
+        cpu:
+          x86_64: x86_64
+          arm_64: arm64
+        url: https://github.com/StyraInc/regal/releases/download/v${version}/regal_${os}_${cpu}
+      - os:
+          windows: Windows
+        cpu:
+          x86_64: x86_64
+        url: https://github.com/StyraInc/regal/releases/download/v${version}/regal_Windows_x86_64.exe
+tools:
+  definitions:
+    - name: regal
+      download: regal
+      known_good_version: 0.18.0
+      shims: [regal]
+lint:
+  definitions:
+    - name: regal
+      files: [rego]
+      main_tool: regal
+      known_good_version: 0.18.0
+      suggest_if: config_present
+      direct_configs:
+        - .regal/config.yaml
+      commands:
+        - name: lint
+          output: sarif
+          # TODO(Tyler): Integrate opa fmt and turn off opa-fmt style rule.
+          run: regal lint --format sarif ${target}
+          batch: true
+          cache_results: true
+          success_codes: [0, 3]

--- a/linters/regal/regal.test.ts
+++ b/linters/regal/regal.test.ts
@@ -1,0 +1,3 @@
+import { linterCheckTest } from "tests";
+
+linterCheckTest({ linterName: "regal" });

--- a/linters/regal/test_data/basic.in.rego
+++ b/linters/regal/test_data/basic.in.rego
@@ -1,0 +1,12 @@
+package authz
+
+import rego.v1
+
+default allow = false
+
+allow if {
+    isEmployee
+    "developer" in input.user.roles
+}
+
+isEmployee if regex.match("@acmecorp\\.com$", input.user.email)

--- a/linters/regal/test_data/regal_v0.18.0_basic.check.shot
+++ b/linters/regal/test_data/regal_v0.18.0_basic.check.shot
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter regal test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "opa-fmt",
+      "column": "1",
+      "file": "test_data/basic.in.rego",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "regal",
+      "message": "File should be formatted with \`opa fmt\`",
+      "targetType": "rego",
+    },
+    {
+      "code": "prefer-snake-case",
+      "column": "1",
+      "file": "test_data/basic.in.rego",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "12",
+      "linter": "regal",
+      "message": "Prefer snake_case for names",
+      "targetType": "rego",
+    },
+    {
+      "code": "non-raw-regex-pattern",
+      "column": "27",
+      "file": "test_data/basic.in.rego",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "12",
+      "linter": "regal",
+      "message": "Use raw strings for regex patterns",
+      "targetType": "rego",
+    },
+    {
+      "code": "use-assignment-operator",
+      "column": "1",
+      "file": "test_data/basic.in.rego",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "5",
+      "linter": "regal",
+      "message": "Prefer := over = for assignment",
+      "targetType": "rego",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "rego",
+      "linter": "regal",
+      "paths": [
+        "test_data/basic.in.rego",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "rego",
+      "linter": "regal",
+      "paths": [
+        "test_data/basic.in.rego",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
[Regal](https://github.com/StyraInc/regal#readme) is linter for the [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policy language. Addresses https://github.com/trunk-io/plugins/issues/670

Regal complements the formatter `opa fmt` which I may add as a follow-up.