### PR TITLE
Integrate formatter opa

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ trunk check enable {linter}
 | Prisma          | [prisma]                                                                                                             |
 | Protobuf        | [buf] (breaking, lint, and format), [clang-format], [clang-tidy]                                                     |
 | Python          | [autopep8], [bandit], [black], [flake8], [isort], [mypy], [pylint], [pyright], [semgrep], [yapf], [ruff], [sourcery] |
-| Rego            | [regal]                                                                                                              |
+| Rego            | [regal], [opa]                                                                                                       |
 | Renovate        | [renovate]                                                                                                           |
 | Ruby            | [brakeman], [rubocop], [rufo], [semgrep], [standardrb]                                                               |
 | Rust            | [clippy], [rustfmt]                                                                                                  |
@@ -137,6 +137,7 @@ trunk check enable {linter}
 [mypy]: https://github.com/python/mypy#readme
 [nancy]: https://github.com/sonatype-nexus-community/nancy#readme
 [nixpkgs-fmt]: https://github.com/nix-community/nixpkgs-fmt
+[opa]: https://www.openpolicyagent.org/docs/latest/cli/
 [osv-scanner]: https://github.com/google/osv-scanner
 [oxipng]: https://github.com/shssoichiro/oxipng#readme
 [perlcritic]: https://metacpan.org/pod/Perl::Critic

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ plugins:
   sources:
     - id: trunk
       uri: https://github.com/trunk-io/plugins
-      ref: v1.2.5
+      ref: v1.4.4
 ```
 
 This repo is open to contributions! See our
@@ -203,6 +203,7 @@ trunk actions enable {action}
 | action                                                               | description                                                |
 | -------------------------------------------------------------------- | ---------------------------------------------------------- |
 | [`buf-gen`](actions/buf/README.md)                                   | run `buf` on .proto file change                            |
+| [`commitizen`](actions/commitizen/README.md)                         | enforce conventional commits and manage releases           |
 | [`commitlint`](https://github.com/conventional-changelog/commitlint) | enforce conventional commit message for your local commits |
 | [`go-mod-tidy`](actions/go-mod-tidy/README.md)                       | automatically tidy go.mod file                             |
 | [`go-mod-tidy-vendor`](actions/go-mod-tidy-vendor/README.md)         | automatically tidy and vendor go.mod file                  |
@@ -213,7 +214,8 @@ trunk actions enable {action}
 ### Supported Tools
 
 This repository also defines configuration for Trunk Tools, which provides hermetic management of
-different CLI tools. You can read more about it in our [docs](https://docs.trunk.io/tools).
+different CLI tools. You can run `trunk tools list` to view all supported tools. Check out our
+[docs](https://docs.trunk.io/tools).
 
 ### Mission
 

--- a/linters/opa/opa.test.ts
+++ b/linters/opa/opa.test.ts
@@ -1,0 +1,3 @@
+import { linterFmtTest } from "tests";
+
+linterFmtTest({ linterName: "opa" });

--- a/linters/opa/plugin.yaml
+++ b/linters/opa/plugin.yaml
@@ -5,19 +5,16 @@ downloads:
     downloads:
       - os:
           linux: linux
-        cpu:
-          x86_64: amd64
-        url: https://openpolicyagent.org/downloads/v${version}/opa_linux_amd64_static
-      - os:
           macos: darwin
         cpu:
           x86_64: amd64
-        url: https://openpolicyagent.org/downloads/v${version}/opa_darwin_amd64
+          arm_64: arm64
+        url: https://github.com/open-policy-agent/opa/releases/download/v${version}/opa_${os}_${cpu}_static
       - os:
           windows: windows
         cpu:
           x86_64: amd64
-        url: https://openpolicyagent.org/downloads/v${version}/opa_windows_amd64.exe
+        url: https://github.com/open-policy-agent/opa/releases/download/v${version}/opa_windows_amd64.exe
 tools:
   definitions:
     - name: opa

--- a/linters/opa/plugin.yaml
+++ b/linters/opa/plugin.yaml
@@ -1,0 +1,40 @@
+version: 0.1
+downloads:
+  - name: opa
+    executable: true
+    downloads:
+      - os:
+          linux: linux
+        cpu:
+          x86_64: amd64
+        url: https://openpolicyagent.org/downloads/v${version}/opa_linux_amd64_static
+      - os:
+          macos: darwin
+        cpu:
+          x86_64: amd64
+        url: https://openpolicyagent.org/downloads/v${version}/opa_darwin_amd64
+      - os:
+          windows: windows
+        cpu:
+          x86_64: amd64
+        url: https://openpolicyagent.org/downloads/v${version}/opa_windows_amd64.exe
+tools:
+  definitions:
+    - name: opa
+      download: opa
+      known_good_version: 0.62.1
+      shims: [opa]
+lint:
+  definitions:
+    - name: opa
+      files: [rego]
+      main_tool: opa
+      known_good_version: 0.62.1
+      suggest_if: never
+      commands:
+        # TODO(Tyler): Add support for opa check command.
+        - name: format
+          output: rewrite
+          run: opa fmt ${target}
+          formatter: true
+          success_codes: [0]

--- a/linters/opa/test_data/basic.in.rego
+++ b/linters/opa/test_data/basic.in.rego
@@ -1,0 +1,12 @@
+package authz
+
+import rego.v1
+
+default allow=false
+
+allow if {
+    isEmployee
+    "developer" in input.user.roles
+}
+
+isEmployee if regex.match("@acmecorp\\.com$", input.user.email)

--- a/linters/opa/test_data/opa_v0.62.1_basic.fmt.shot
+++ b/linters/opa/test_data/opa_v0.62.1_basic.fmt.shot
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter opa test basic 1`] = `
+"package authz
+
+import rego.v1
+
+default allow = false
+
+allow if {
+	isEmployee
+	"developer" in input.user.roles
+}
+
+isEmployee if regex.match("@acmecorp\\\\.com$", input.user.email)
+"
+`;

--- a/linters/regal/plugin.yaml
+++ b/linters/regal/plugin.yaml
@@ -32,7 +32,6 @@ lint:
       commands:
         - name: lint
           output: sarif
-          # TODO(Tyler): Integrate opa fmt and turn off opa-fmt style rule.
           run: regal lint --format sarif ${target}
           batch: true
           cache_results: true


### PR DESCRIPTION
Stacked on #690. Adds the [`opa`](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt) tool and formatter, the CLI tool for [Open Policy Agent](https://www.openpolicyagent.org/) and [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) files. See https://github.com/trunk-io/plugins/issues/670

Also cleans up some readme.md content.