### PR TITLE
Update biome snapshots and clean up manual replacer

### DIFF
--- a/linters/biome/test_data/biome_v1.6.0_basic_check.check.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_check.check.shot
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter biome test basic_check 1`] = `
+{
+  "issues": [
+    {
+      "code": "lint/complexity/noUselessLoneBlockStatements",
+      "column": "3",
+      "file": "test_data/basic_check.in.ts",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "13",
+      "linter": "biome",
+      "message": "This block statement doesn't serve any purpose and can be safely removed.",
+      "targetType": "typescript",
+    },
+    {
+      "code": "lint/style/useEnumInitializers",
+      "column": "6",
+      "file": "test_data/basic_check.in.ts",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "biome",
+      "message": "This enum declaration contains members that are implicitly initialized.",
+      "targetType": "typescript",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "fmt",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
+      "column": "1",
+      "file": "test_data/basic_check.in.ts",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "biome",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
+}
+`;

--- a/linters/biome/test_data/biome_v1.6.0_basic_fmt.fmt.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_fmt.fmt.shot
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter biome test basic_fmt 1`] = `
+"const foobar = () => {};
+const barfoo = () => {};
+
+enum Bar {
+	Baz,
+}
+
+const foo = (bar: Bar) => {
+	switch (bar) {
+		case Bar.Baz:
+			foobar();
+			barfoo();
+			break;
+	}
+	{
+		!foo ? null : 1;
+	}
+};
+"
+`;

--- a/linters/biome/test_data/biome_v1.6.0_basic_json.fmt.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_json.fmt.shot
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter biome test basic_json 1`] = `
+"{ "a": "foo", "b": 1, "a": true }
+"
+`;

--- a/linters/psscriptanalyzer/psscriptanalyzer.test.ts
+++ b/linters/psscriptanalyzer/psscriptanalyzer.test.ts
@@ -6,25 +6,15 @@ import { TEST_DATA } from "tests/utils";
 // Run with `-y` since on Windows Invoke-Formatter will add carriage returns, and for testing's sake it's easier to just apply.
 const checkArgs = `${path.join(TEST_DATA, "check.in.ps1")} -y`;
 
-const manualVersionReplacer = (version: string) => {
-  if (version === "1.22.0") {
-    // As of 3/11, 1.22.0 doesn't have a release asset.
-    return "1.21.0";
-  }
-  return version;
-};
-
 // Run tests with default rules
 linterFmtTest({
   linterName: "psscriptanalyzer",
   namedTestPrefixes: ["format"],
-  manualVersionReplacer,
 });
 customLinterCheckTest({
   linterName: "psscriptanalyzer",
   testName: "check",
   args: checkArgs,
-  manualVersionReplacer,
 });
 
 // Create a PSScriptAnalyzerSettings.psd1 for further testing
@@ -43,12 +33,10 @@ linterFmtTest({
   linterName: "psscriptanalyzer",
   namedTestPrefixes: ["format"],
   preCheck,
-  manualVersionReplacer,
 });
 customLinterCheckTest({
   linterName: "psscriptanalyzer",
   testName: "check_custom_settings",
   args: checkArgs,
   preCheck,
-  manualVersionReplacer,
 });

--- a/linters/psscriptanalyzer/psscriptanalyzer.test.ts
+++ b/linters/psscriptanalyzer/psscriptanalyzer.test.ts
@@ -6,9 +6,26 @@ import { TEST_DATA } from "tests/utils";
 // Run with `-y` since on Windows Invoke-Formatter will add carriage returns, and for testing's sake it's easier to just apply.
 const checkArgs = `${path.join(TEST_DATA, "check.in.ps1")} -y`;
 
+const manualVersionReplacer = (version: string) => {
+  if (version === "1.22.0") {
+    // As of 3/11, 1.22.0 doesn't have a release asset.
+    return "1.21.0";
+  }
+  return version;
+};
+
 // Run tests with default rules
-linterFmtTest({ linterName: "psscriptanalyzer", namedTestPrefixes: ["format"] });
-customLinterCheckTest({ linterName: "psscriptanalyzer", testName: "check", args: checkArgs });
+linterFmtTest({
+  linterName: "psscriptanalyzer",
+  namedTestPrefixes: ["format"],
+  manualVersionReplacer,
+});
+customLinterCheckTest({
+  linterName: "psscriptanalyzer",
+  testName: "check",
+  args: checkArgs,
+  manualVersionReplacer,
+});
 
 // Create a PSScriptAnalyzerSettings.psd1 for further testing
 const preCheck = (driver: TrunkLintDriver) => {
@@ -26,10 +43,12 @@ linterFmtTest({
   linterName: "psscriptanalyzer",
   namedTestPrefixes: ["format"],
   preCheck,
+  manualVersionReplacer,
 });
 customLinterCheckTest({
   linterName: "psscriptanalyzer",
   testName: "check_custom_settings",
   args: checkArgs,
   preCheck,
+  manualVersionReplacer,
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -663,6 +663,7 @@ export const fuzzyLinterCheckTest = ({
  *                   Takes in the test's linter version (from snapshots).
  * @param preCheck callback to run during setup
  * @param postCheck callback to run for additional assertions from the base snapshot
+ * @param manualVersionReplacer a mutator to replace the enabled version with another version
  */
 export const linterCheckTest = ({
   linterName,
@@ -671,6 +672,7 @@ export const linterCheckTest = ({
   skipTestIf = (_version?: string) => false,
   preCheck,
   postCheck,
+  manualVersionReplacer,
 }: {
   linterName: string;
   dirname?: string;
@@ -678,6 +680,7 @@ export const linterCheckTest = ({
   skipTestIf?: (version?: string) => boolean;
   preCheck?: TestCallback;
   postCheck?: TestCallback;
+  manualVersionReplacer?: (version: string) => string;
 }) => {
   // Step 1a: Detect test files to run
   const linterTestTargets = detectTestTargets(dirname, namedTestPrefixes);
@@ -690,7 +693,14 @@ export const linterCheckTest = ({
         // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
-          const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
+          const driver = setupLintDriver(
+            dirname,
+            {},
+            linterName,
+            linterVersion,
+            preCheck,
+            manualVersionReplacer,
+          );
 
           // Step 3: Run each test
           conditionalTest(skipTestIf(linterVersion), prefix, async () => {
@@ -754,6 +764,7 @@ export const linterCheckTest = ({
  *                   Takes in the test's linter version (from snapshots).
  * @param preCheck callback to run during setup
  * @param postCheck callback to run for additional assertions from the base snapshot
+ * @param manualVersionReplacer a mutator to replace the enabled version with another version
  */
 export const linterFmtTest = ({
   linterName,
@@ -762,6 +773,7 @@ export const linterFmtTest = ({
   skipTestIf = (_version?: string) => false,
   preCheck,
   postCheck,
+  manualVersionReplacer,
 }: {
   linterName: string;
   dirname?: string;
@@ -769,6 +781,7 @@ export const linterFmtTest = ({
   skipTestIf?: (version?: string) => boolean;
   preCheck?: TestCallback;
   postCheck?: TestCallback;
+  manualVersionReplacer?: (version: string) => string;
 }) => {
   // Step 1a: Detect test files to run and versions for asserts.
   const linterTestTargets = detectTestTargets(dirname, namedTestPrefixes);
@@ -781,7 +794,14 @@ export const linterFmtTest = ({
         // TODO(Tyler): Find a reliable way to replace the name "test" with version that doesn't violate snapshot export names.
         describe("test", () => {
           // Step 2: Define test setup and teardown
-          const driver = setupLintDriver(dirname, {}, linterName, linterVersion, preCheck);
+          const driver = setupLintDriver(
+            dirname,
+            {},
+            linterName,
+            linterVersion,
+            preCheck,
+            manualVersionReplacer,
+          );
 
           // Step 3: Run each test
           conditionalTest(skipTestIf(linterVersion), prefix, async () => {


### PR DESCRIPTION
2 cleanups, motivated by nightly:
- Generate new release-able snapshot for biome, and update the script to autogen snapshots even if not all the tests are failing (e.g. 1 failure, 2 passes, identical on platforms)
- Add some more args for manual version replacer (~for psscriptanalyzer so things can land until their `v1.22.0` asset gets released~)