### PR TITLE
Support sqlfluff@3.0.0 and other cleanup

### DIFF
--- a/linters/detekt/detekt.test.ts
+++ b/linters/detekt/detekt.test.ts
@@ -13,18 +13,18 @@ const preCheck = (driver: TrunkLintDriver) => {
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving failure modes.
-linterCheckTest({
-  linterName: "detekt",
-  namedTestPrefixes: ["basic_detekt"],
-  preCheck,
-});
+// linterCheckTest({
+//   linterName: "detekt",
+//   namedTestPrefixes: ["basic_detekt"],
+//   preCheck,
+// });
 
-// detekt-explicit has no default settings, leading to an empty result
-linterCheckTest({
-  linterName: "detekt-explicit",
-  namedTestPrefixes: ["basic_explicit"],
-  preCheck,
-});
+// // detekt-explicit has no default settings, leading to an empty result
+// linterCheckTest({
+//   linterName: "detekt-explicit",
+//   namedTestPrefixes: ["basic_explicit"],
+//   preCheck,
+// });
 
 // detekt-gradle tests rely on a particular gradle-focused system setup, and they require a level of greater configuration here.
 // TODO(Tyler): Because of this setup, this leads to reduced coverage for different versions. We should augment this logic
@@ -51,6 +51,8 @@ const gradlePreCheck: TestCallback = (driver) => {
         - name: JAVA_HOME
           value: ${javaPath}
           optional: false
+        - name: PATH
+          list: ["\${env.PATH}"]
 `);
   driver.writeFile(trunkYamlPath, finalContents);
   // trunk-ignore-end(semgrep)

--- a/linters/detekt/detekt.test.ts
+++ b/linters/detekt/detekt.test.ts
@@ -13,18 +13,18 @@ const preCheck = (driver: TrunkLintDriver) => {
 };
 
 // TODO(Tyler): We will eventually need to add a couple more test cases involving failure modes.
-// linterCheckTest({
-//   linterName: "detekt",
-//   namedTestPrefixes: ["basic_detekt"],
-//   preCheck,
-// });
+linterCheckTest({
+  linterName: "detekt",
+  namedTestPrefixes: ["basic_detekt"],
+  preCheck,
+});
 
-// // detekt-explicit has no default settings, leading to an empty result
-// linterCheckTest({
-//   linterName: "detekt-explicit",
-//   namedTestPrefixes: ["basic_explicit"],
-//   preCheck,
-// });
+// detekt-explicit has no default settings, leading to an empty result
+linterCheckTest({
+  linterName: "detekt-explicit",
+  namedTestPrefixes: ["basic_explicit"],
+  preCheck,
+});
 
 // detekt-gradle tests rely on a particular gradle-focused system setup, and they require a level of greater configuration here.
 // TODO(Tyler): Because of this setup, this leads to reduced coverage for different versions. We should augment this logic

--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -14,6 +14,8 @@ lint:
       known_good_version: 1.4.5
       direct_configs:
         - .sqlfluff
+      affects_cache:
+        - pyproject.toml
       suggest_if: config_present
       commands:
         - name: lint

--- a/linters/sqlfluff/sqlfluff_to_sarif.py
+++ b/linters/sqlfluff/sqlfluff_to_sarif.py
@@ -2,11 +2,19 @@
 
 import json
 import sys
-
+from typing import Optional
 
 def to_result_sarif(
-    path: str, line_number: int, column_number: int, rule_id: str, message: str
+    path: str, start_line_number: int, start_column_number: int, end_line_number: Optional[int], end_column_number: Optional[int], rule_id: str, message: str
 ):
+    region = {
+        "startLine": start_line_number,
+        "startColumn": start_column_number,
+    }
+    if end_line_number is not None and end_column_number is not None:
+        region["endLine"] = end_line_number
+        region["endColumn"] = end_column_number
+
     return {
         "level": "error",
         "locations": [
@@ -15,10 +23,7 @@ def to_result_sarif(
                     "artifactLocation": {
                         "uri": path,
                     },
-                    "region": {
-                        "startColumn": column_number,
-                        "startLine": line_number,
-                    },
+                    "region": region,
                 }
             }
         ],
@@ -36,13 +41,17 @@ def main(argv):
     for result in sqlfluff_json:
         filepath = result["filepath"]
         for violation in result["violations"]:
-            line_number = violation["line_no"]
-            column_number = violation["line_pos"]
+            # In sqlfluff 3.0.0, line_no/line_pos replaced with start_*/end_*
+            start_line_number = violation.get("start_line_no", violation.get("line_no"))
+            start_column_number = violation.get("start_line_pos", violation.get("line_pos"))
+            end_line_number = violation.get("end_line_no")
+            end_column_number = violation.get("end_line_pos")
+
             rule_id = violation["code"]
             message = violation["description"]
 
             results.append(
-                to_result_sarif(filepath, line_number, column_number, rule_id, message)
+                to_result_sarif(filepath, start_line_number, start_column_number, end_line_number, end_column_number, rule_id, message)
             )
 
     sarif = {

--- a/linters/sqlfluff/sqlfluff_to_sarif.py
+++ b/linters/sqlfluff/sqlfluff_to_sarif.py
@@ -4,8 +4,15 @@ import json
 import sys
 from typing import Optional
 
+
 def to_result_sarif(
-    path: str, start_line_number: int, start_column_number: int, end_line_number: Optional[int], end_column_number: Optional[int], rule_id: str, message: str
+    path: str,
+    start_line_number: int,
+    start_column_number: int,
+    end_line_number: Optional[int],
+    end_column_number: Optional[int],
+    rule_id: str,
+    message: str,
 ):
     region = {
         "startLine": start_line_number,
@@ -43,7 +50,9 @@ def main(argv):
         for violation in result["violations"]:
             # In sqlfluff 3.0.0, line_no/line_pos replaced with start_*/end_*
             start_line_number = violation.get("start_line_no", violation.get("line_no"))
-            start_column_number = violation.get("start_line_pos", violation.get("line_pos"))
+            start_column_number = violation.get(
+                "start_line_pos", violation.get("line_pos")
+            )
             end_line_number = violation.get("end_line_no")
             end_column_number = violation.get("end_line_pos")
 
@@ -51,7 +60,15 @@ def main(argv):
             message = violation["description"]
 
             results.append(
-                to_result_sarif(filepath, start_line_number, start_column_number, end_line_number, end_column_number, rule_id, message)
+                to_result_sarif(
+                    filepath,
+                    start_line_number,
+                    start_column_number,
+                    end_line_number,
+                    end_column_number,
+                    rule_id,
+                    message,
+                )
             )
 
     sarif = {

--- a/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_check.check.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_check.check.shot
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter sqlfluff test basic_check 1`] = `
+{
+  "issues": [
+    {
+      "code": "AM04",
+      "column": "1",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Query produces an unknown number of result columns.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "49",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP01",
+      "column": "1",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Keywords must be consistently upper case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "6",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "LT09",
+      "column": "1",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Select targets should be on a new line unless there is only one select target.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "26",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "AL03",
+      "column": "12",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Column expression without alias. Use explicit \`AS\` clause.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "1",
+          "offset": "11",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP01",
+      "column": "20",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Keywords must be consistently upper case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "2",
+          "offset": "19",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "LT01",
+      "column": "22",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Expected only single space before naked identifier. Found '  '.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "2",
+          "offset": "21",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP02",
+      "column": "24",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Unquoted identifiers must be consistently lower case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "3",
+          "offset": "23",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "LT01",
+      "column": "27",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Expected only single space before 'from' keyword. Found '  '.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "2",
+          "offset": "26",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP01",
+      "column": "29",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Keywords must be consistently upper case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "4",
+          "offset": "28",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP02",
+      "column": "34",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Unquoted identifiers must be consistently lower case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "8",
+          "offset": "33",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "CP02",
+      "column": "43",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Unquoted identifiers must be consistently lower case.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "7",
+          "offset": "42",
+        },
+      ],
+      "targetType": "sql",
+    },
+    {
+      "code": "LT01",
+      "column": "7",
+      "file": "test_data/basic_check.in.sql",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "sqlfluff",
+      "message": "Expected only single space before star '*'. Found '  '.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic_check.in.sql",
+          "length": "2",
+          "offset": "6",
+        },
+      ],
+      "targetType": "sql",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "sql",
+      "linter": "sqlfluff",
+      "paths": [
+        "test_data/basic_check.in.sql",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "sql",
+      "linter": "sqlfluff",
+      "paths": [
+        "test_data/basic_check.in.sql",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_fmt.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_fmt.fmt.shot
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter sqlfluff test basic_fmt 1`] = `
+"SELECT
+    col_a,
+    col_b,
+    COUNT(*) AS num,
+    SUM(num) OVER (
+        PARTITION BY col_a
+        ORDER BY col_b
+    ) AS an_aggregate_function
+FROM tbl_a
+GROUP BY 1, 2
+"
+`;

--- a/runtimes/node/plugin.yaml
+++ b/runtimes/node/plugin.yaml
@@ -44,6 +44,9 @@ runtimes:
         - name: NODE_OPTIONS
           value: ${env.NODE_OPTIONS}
           optional: true
+        - name: NPM_CONFIG_USERCONFIG
+          value: ${env.NPM_CONFIG_USERCONFIG}
+          optional: true
       linter_environment:
         - name: PATH
           list: ["${linter}/node_modules/.bin"]


### PR DESCRIPTION
- [Sqlfluff@3.0.0](https://github.com/sqlfluff/sqlfluff/releases/tag/3.0.0) changed their JSON output format slightly, so updates the parser and snapshots
- Fixes detekt test to correctly forward the PATH. This will be necessary for upcoming versionless/packageless changes
- Forward `NPM_CONFIG_USERCONFIG` to node by default