### PR TITLE
Various nightly cleanups

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -127,11 +127,6 @@ jobs:
         with:
           ref: ${{ steps.get-release.outputs.tag }}
           clean: false
-          sparse_checkout: |
-            plugin.yaml
-            linters
-            actions
-            tools
 
       - name: Overwrite test runners with latest behavior
         shell: bash

--- a/linters/markdown-link-check/markdown-link-check.test.ts
+++ b/linters/markdown-link-check/markdown-link-check.test.ts
@@ -1,3 +1,11 @@
 import { linterCheckTest } from "tests";
 
-linterCheckTest({ linterName: "markdown-link-check" });
+const manualVersionReplacer = (version: string) => {
+  if (version === "3.12.1") {
+    // As of 3/19, 3.12.1 cannot check for anchors, so we view it as a bad version.
+    return "3.11.2";
+  }
+  return version;
+};
+
+linterCheckTest({ linterName: "markdown-link-check", manualVersionReplacer });

--- a/tools/gt/gt.test.ts
+++ b/tools/gt/gt.test.ts
@@ -1,20 +1,5 @@
 import { makeToolTestConfig, toolTest } from "tests";
-import { skipCPUOS, skipOS } from "tests/utils";
-
-toolTest({
-  toolName: "gt",
-  toolVersion: "0.20.19",
-  testConfigs: [makeToolTestConfig({ command: ["gt", "--version"], expectedOut: "0.20.19" })],
-  skipTestIf: (version) => {
-    if (process.env.CI) {
-      console.log("Skipping gt test for CI until we have better parsing logic.");
-      return true;
-    }
-
-    // Unsupported download
-    return skipCPUOS([{ os: "linux", cpu: "arm64" }])(version);
-  },
-});
+import { skipOS } from "tests/utils";
 
 toolTest({
   toolName: "gt",

--- a/tools/gt/plugin.yaml
+++ b/tools/gt/plugin.yaml
@@ -1,32 +1,11 @@
 version: 0.1
-downloads:
-  - name: gt
-    executable: true
-    downloads:
-      - os:
-          linux: linux
-        cpu:
-          x86_64: x86_64
-        url: https://github.com/withgraphite/graphite-cli/releases/download/v${version}/gt-${os}
-      - os:
-          macos: macos
-        url: https://github.com/withgraphite/graphite-cli/releases/download/v${version}/gt-${os}
-      - os:
-          windows: win
-        url: https://github.com/withgraphite/graphite-cli/releases/download/v${version}/gt-${os}.exe
 tools:
   definitions:
     - name: gt
-      version_constraint: ">=1.0.0"
+      # There used to be a download for older versions, but the assets are no longer available.
       known_good_version: 1.0.0
       runtime: node
       package: "@withgraphite/graphite-cli"
-      shims:
-        - name: gt
-          target: gt
-    - name: gt
-      known_good_version: 0.20.19
-      download: gt
       shims:
         - name: gt
           target: gt


### PR DESCRIPTION
- Cleanup `sparse_checkout`, which is not a valid input, so this was never working
- Add `manualVersionReplacer` for `markdown-link-check`, since `3.12.1` has been broken for a while and a fix hasn't released
- Remove the old download for `gt` since it is no longer a publicly accessible asset. We still have the npm package for newer versions

Successful [nightly run](https://github.com/trunk-io/plugins/actions/runs/8347542833/job/22847380037) off this branch.