### PR TITLE
Add golangci-lint snapshots, cleanup existing snapshots

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.20.2-beta.4
+  version: 1.21.0
   shell_hooks:
     enforce: true
 
@@ -17,7 +17,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v1.0.2
+      ref: v1.0.4
 
 lint:
   # enabled linters inherited from github.com/trunk-io/configs plugin

--- a/linters/biome/test_data/biome_v1.6.0_basic_check.check.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_check.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter biome test basic_check 1`] = `
 {

--- a/linters/biome/test_data/biome_v1.6.0_basic_fmt.fmt.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_fmt.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter biome test basic_fmt 1`] = `
 "const foobar = () => {};

--- a/linters/biome/test_data/biome_v1.6.0_basic_json.fmt.shot
+++ b/linters/biome/test_data/biome_v1.6.0_basic_json.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter biome test basic_json 1`] = `
 "{ "a": "foo", "b": 1, "a": true }

--- a/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
+++ b/linters/eslint/test_data/eslint_v8.10.0_bad_install.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter eslint test bad_install 1`] = `
 {

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_all.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_all.check.shot
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter golangci-lint test all 1`] = `
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "replacements": [
+            {
+              "filePath": "test_data/basic.go",
+              "length": "34",
+              "offset": "45",
+              "replacementText": "// this is the main function 🏃.
+",
+            },
+          ],
+        },
+      ],
+      "code": "godot",
+      "column": "34",
+      "file": "test_data/basic.go",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "6",
+      "linter": "golangci-lint",
+      "message": "Comment should end in a period",
+      "targetType": "go",
+    },
+    {
+      "code": "errcheck",
+      "column": "12",
+      "file": "test_data/basic.go",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "8",
+      "linter": "golangci-lint",
+      "message": "Error return value of \`time.Parse\` is not checked",
+      "targetType": "go",
+    },
+    {
+      "code": "unused",
+      "column": "6",
+      "file": "test_data/unused_func.go",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "5",
+      "linter": "golangci-lint",
+      "message": "func \`helper\` is unused",
+      "targetType": "go",
+    },
+    {
+      "code": "typecheck",
+      "file": "test_data/wrapper/printer.go",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "golangci-lint",
+      "message": ": # golangcilint_linter_test/wrapper
+wrapper/printer.go:12:23: undefined: Wrapper2",
+      "targetType": "go",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "go",
+      "linter": "golangci-lint",
+      "paths": [
+        "test_data",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "go",
+      "linter": "golangci-lint",
+      "paths": [
+        "test_data/wrapper",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_empty.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_empty.check.shot
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter golangci-lint test empty 1`] = `
+{
+  "issues": [
+    {
+      "code": "typecheck",
+      "column": "1",
+      "file": "test_data/empty.go",
+      "issueClass": "ISSUE_CLASS_NEW",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "golangci-lint",
+      "message": "expected 'package', found 'EOF'",
+      "targetType": "go",
+    },
+    {
+      "code": "typecheck",
+      "file": "test_data/wrapper/printer.go",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://golangci-lint.run/usage/linters/",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "golangci-lint",
+      "message": ": # golangcilint_linter_test/wrapper
+wrapper/printer.go:12:23: undefined: Wrapper2",
+      "targetType": "go",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "go",
+      "linter": "golangci-lint",
+      "paths": [
+        "test_data",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "go",
+      "linter": "golangci-lint",
+      "paths": [
+        "test_data/wrapper",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_unbuildable.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_unbuildable.check.shot
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter golangci-lint test unbuildable 1`] = `
+{
+  "issues": [
+    {
+      "code": "error",
+      "file": ".",
+      "issueClass": "ISSUE_CLASS_NEW",
+      "level": "LEVEL_HIGH",
+      "linter": "golangci-lint",
+      "message": "typechecking error: build constraints exclude all Go files in /tmp/plugins_",
+      "targetType": "go",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "go",
+      "linter": "golangci-lint",
+      "paths": [
+        ".",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/pyright/test_data/pyright_v1.1.348_basic.check.shot
+++ b/linters/pyright/test_data/pyright_v1.1.348_basic.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter pyright test basic 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_git_v3.68.0_CUSTOM.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_git_v3.68.0_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog-git test CUSTOM 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_git_v3.69.0_CUSTOM.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_git_v3.69.0_CUSTOM.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog-git test CUSTOM 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.68.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.68.0_buff_size.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test buff_size 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.68.0_secrets.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.68.0_secrets.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test secrets 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.68.0_wrong_line_number.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.68.0_wrong_line_number.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test wrong_line_number 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.69.0_buff_size.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.69.0_buff_size.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test buff_size 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.69.0_secrets.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.69.0_secrets.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test secrets 1`] = `
 {

--- a/linters/trufflehog/test_data/trufflehog_v3.69.0_wrong_line_number.check.shot
+++ b/linters/trufflehog/test_data/trufflehog_v3.69.0_wrong_line_number.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter trufflehog test wrong_line_number 1`] = `
 {


### PR DESCRIPTION
Upgrade and cleanup:
- New `golangci-lint` snapshots for 1.57.0 and tag for release (these were not auto-gen'd because Windows skips some but not all tests)
- Remove tags for old release snapshots, since we just made a release
- Upgrade the CLI to the latest prod version (closes https://github.com/trunk-io/plugins/pull/704)