### PR TITLE
Upgrade trunk, fix trufflehog and buildifier

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.21.0
+  version: 1.21.1-beta.14
   shell_hooks:
     enforce: true
 

--- a/linters/buildifier/test_data/buildifier_v7.1.0_basic_check.check.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_basic_check.check.shot
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing linter buildifier test basic_check 1`] = `
+{
+  "issues": [
+    {
+      "code": "module-docstring",
+      "column": "1",
+      "file": "test_data/basic.bzl",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#module-docstring",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "buildifier",
+      "message": "The file has no module docstring.
+A module docstring is a string literal (not a comment) which should be the first statement of a file (it may follow comment lines).",
+      "targetType": "starlark",
+    },
+    {
+      "code": "load",
+      "column": "26",
+      "file": "test_data/basic.bzl",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "buildifier",
+      "message": "Loaded symbol "a" is unused. Please remove it.
+To disable the warning, add '@unused' in a comment.
+If you want to re-export a symbol, use the following pattern:
+
+    load(..., _a = "a", ...)
+    a = _a",
+      "targetType": "starlark",
+    },
+    {
+      "code": "load",
+      "column": "26",
+      "file": "test_data/basic.bzl",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "buildifier",
+      "message": "Loaded symbol "b" is unused. Please remove it.
+To disable the warning, add '@unused' in a comment.
+If you want to re-export a symbol, use the following pattern:
+
+    load(..., _b = "b", ...)
+    b = _b",
+      "targetType": "starlark",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "fix",
+      "fileGroupName": "bazel-build",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/add_tables.BUILD",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "fix",
+      "fileGroupName": "starlark",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/basic.bzl",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "warn",
+      "fileGroupName": "bazel-build",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/add_tables.BUILD",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "warn",
+      "fileGroupName": "starlark",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/basic.bzl",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "warn",
+      "fileGroupName": "bazel-build",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/add_tables.BUILD",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "warn",
+      "fileGroupName": "starlark",
+      "linter": "buildifier",
+      "paths": [
+        "test_data/basic.bzl",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [
+    {
+      "column": "1",
+      "file": "test_data/add_tables.BUILD",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "buildifier",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+    {
+      "column": "1",
+      "file": "test_data/basic.bzl",
+      "issueClass": "ISSUE_CLASS_UNFORMATTED",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "buildifier",
+      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
+    },
+  ],
+}
+`;

--- a/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.add_tables.BUILD.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.add_tables.BUILD.fmt.shot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter buildifier test no_config 1`] = `
+"foo_macro(
+    fizz = [
+        ":lib2",
+        ":lib1",
+    ],
+)
+
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+)
+
+sh_library(
+    name = "lib1",
+    srcs = ["src1.sh"],
+)
+
+sh_library(
+    name = "lib2",
+    srcs = ["src1.sh"],
+)
+
+sh_binary(
+    name = "foo",
+    srcs = ["foo.sh"],
+    deps = [
+        ":lib1",
+        ":lib2",
+    ],
+)
+"
+`;

--- a/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.basic.bzl.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.basic.bzl.fmt.shot
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter buildifier test no_config 1`] = `
+"# Misformatted file
+def eponymous_name():
+    name = native.package_name()
+
+    return name[name.rfind("/") + 1:]
+"
+`;

--- a/linters/buildifier/test_data/buildifier_v7.1.0_with_config.test_data.add_tables.BUILD.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_with_config.test_data.add_tables.BUILD.fmt.shot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+// trunk-upgrade-validation:RELEASE
+
+exports[`Testing formatter buildifier test with_config 1`] = `
+"foo_macro(
+    fizz = [
+        ":lib1",
+        ":lib2",
+    ],
+)
+
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+)
+
+sh_library(
+    name = "lib1",
+    srcs = ["src1.sh"],
+)
+
+sh_library(
+    name = "lib2",
+    srcs = ["src1.sh"],
+)
+
+sh_binary(
+    name = "foo",
+    srcs = ["foo.sh"],
+    deps = [
+        ":lib1",
+        ":lib2",
+    ],
+)
+"
+`;

--- a/linters/trufflehog/plugin.yaml
+++ b/linters/trufflehog/plugin.yaml
@@ -31,7 +31,10 @@ lint:
           success_codes: [0, 183]
           is_security: true
           batch: true
+          cache_results: true
           cache_ttl: 1h
+          # trufflehog 3.71.1 stopped linting symlinks
+          sandbox_type: copy_targets
           parser:
             runtime: python
             run: python3 ${plugin}/linters/trufflehog/trufflehog_to_sarif.py

--- a/linters/trufflehog/trufflehog.test.ts
+++ b/linters/trufflehog/trufflehog.test.ts
@@ -13,6 +13,8 @@ const preCheck = async (driver: TrunkLintDriver) => {
     await driver.gitDriver.add("secrets.in.py").add("secrets2.in.py").commit("Add secrets");
     driver.deleteFile("secrets.in.py");
     await driver.gitDriver.add("secrets.in.py").commit("Remove secrets");
+  } else {
+    driver.debug("Error: failed to initialize git driver");
   }
 };
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 # IfChange
-required_trunk_version: ">=1.18.2-beta.7"
+required_trunk_version: ">=1.21.1-beta.14"
 # ThenChange tests/repo_tests/config_check.test.ts
 
 environments:

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -25,7 +25,7 @@ describe("Global config health check", () => {
     setupTrunk: true,
     // NOTE: This version should be kept compatible in lockstep with the `required_trunk_version` in plugin.yaml
     // IfChange
-    trunkVersion: "1.18.2-beta.7",
+    trunkVersion: "1.21.1-beta.14",
     // ThenChange plugin.yaml
   });
 


### PR DESCRIPTION
- Upgrade trunk and bump the minimum required version
  - This will unblock #229
  - This will fix some of the Windows [nightly issues](https://github.com/trunk-io/plugins/actions/runs/8448489088/job/23140665928) (I'll queue a job after this lands)
  - This will fix the [check nightly](https://github.com/trunk-io/.trunk/actions/runs/8355518290/job/22870763034) runs (I'll queue a job after this lands)
  - This will add PHP runtime support (soon)
  - Note there is one rare daemon lifetime bug that will need a fast follow-up upgrade fix
- buildifier released [7.1.0](https://github.com/bazelbuild/buildtools/releases/tag/v7.1.0), which mandates `load` sorting as a formatting fix
- trufflehog released [3.71.1](https://github.com/trufflesecurity/trufflehog/releases/tag/v3.71.1), which no longer lints symlinks, so we have to use `copy_targets` and cache results to generate a sandbox (`cache_ttl` does not imply `cache_results` currently)

Note that we will need to have a prod CLI release before we can next release plugins (minor version bump)
 