### PR TITLE
Add prettier support for postcss

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -412,6 +412,12 @@ lint:
       extensions:
         - png
 
+    - name: postcss
+      extensions:
+        # TODO(Tyler): Do we want to include css here as well?
+        - pcss
+        - postcss
+
     - name: powershell
       extensions:
         - ps1

--- a/linters/prettier/plugin.yaml
+++ b/linters/prettier/plugin.yaml
@@ -13,6 +13,7 @@ lint:
         - typescript
         - yaml
         - css
+        - postcss
         - sass
         - html
         - markdown


### PR DESCRIPTION
Tested manually on a toy example that prettier formats these correctly. Using [postcss extension](https://marketplace.visualstudio.com/items?itemName=csstools.postcss) as reference. Fixes #738