### PR TITLE
Not suggest terrascan

### DIFF
--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -22,7 +22,7 @@ lint:
     - name: terrascan
       tools: [terrascan]
       known_good_version: 1.18.1
-      suggest_if: files_present
+      suggest_if: never
       commands:
         - name: lint
           output: sarif

--- a/linters/terrascan/plugin.yaml
+++ b/linters/terrascan/plugin.yaml
@@ -22,6 +22,7 @@ lint:
     - name: terrascan
       tools: [terrascan]
       known_good_version: 1.18.1
+      # terrascan does not support some modern terraform syntax. Don't auto-recommend.
       suggest_if: never
       commands:
         - name: lint

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -165,7 +165,6 @@ describe("Global config health check", () => {
         "shfmt",
         "svgo",
         "taplo",
-        "terrascan",
         "tflint",
         "trivy",
         "trufflehog",


### PR DESCRIPTION
terrascan is no longer actively maintained. So, it would be good not to suggest even if related files exist.