### PR TITLE
Fix linter tests action to be reusable

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -78,6 +78,7 @@ runs:
     - name: Clean jest cache
       run: npx jest --clearCache
       shell: bash
+      working-directory: ${{ inputs.path }}
 
     - name: Run plugin tests
       if: runner.os == 'Windows'

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,6 @@ updates:
       day: sunday
       # trunk-ignore(yamllint/quoted-strings)
       time: "08:00" # UTC
-    labels: [🤖 dependabot]
     groups:
       dependencies:
         patterns:
@@ -21,9 +20,11 @@ updates:
       day: sunday
       # trunk-ignore(yamllint/quoted-strings)
       time: "08:00" # UTC
-    labels: [🤖 dependabot]
     groups:
       dependencies:
         patterns:
           - "*"
+    # TODO(Tyler): Readd once eslint9 is resolved.
+    ignore:
+      - dependency-name: eslint
     open-pull-requests-limit: 2


### PR DESCRIPTION
Fixes [failures](https://github.com/trunk-io/trunk/actions/runs/8659672695/job/23746050111) and cleans up dependabot ignores for `eslint` until #735 is resolved. [Successful run](https://github.com/trunk-io/trunk/actions/runs/8693488278/job/23840365226)