### PR TITLE
Support React comments in JSX/TSX

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -5,6 +5,10 @@ lint:
       leading_delimiter: "{-"
       trailing_delimiter: "-}"
 
+    - name: brace-slashes-block
+      leading_delimiter: "{/*"
+      trailing_delimiter: "*/}"
+
     - name: dashes-block
       leading_delimiter: --[[
       trailing_delimiter: --]]
@@ -282,11 +286,20 @@ lint:
       extensions:
         - cjs
         - js
-        - jsx
         - mjs
+      inherit:
+        - javascript-xml
       comments:
         - slashes-block
         - slashes-inline
+
+    - name: javascript-xml
+      extensions:
+        - jsx
+      comments:
+        - slashes-block
+        - slashes-inline
+        - brace-slashes-block
 
     - name: json
       extensions:
@@ -572,10 +585,19 @@ lint:
       extensions:
         - mts
         - ts
+      inherit:
+        - typescript-xml
+      comments:
+        - slashes-block
+        - slashes-inline
+
+    - name: typescript-xml
+      extensions:
         - tsx
       comments:
         - slashes-block
         - slashes-inline
+        - brace-slashes-block
 
     - name: xib
       extensions:

--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -9,6 +9,10 @@ lint:
       leading_delimiter: "{/*"
       trailing_delimiter: "*/}"
 
+    - name: brace-slashes-block-spaced
+      leading_delimiter: "{ /*"
+      trailing_delimiter: "*/ }"
+
     - name: dashes-block
       leading_delimiter: --[[
       trailing_delimiter: --]]
@@ -300,6 +304,7 @@ lint:
         - slashes-block
         - slashes-inline
         - brace-slashes-block
+        - brace-slashes-block-spaced
 
     - name: json
       extensions:
@@ -598,6 +603,7 @@ lint:
         - slashes-block
         - slashes-inline
         - brace-slashes-block
+        - brace-slashes-block-spaced
 
     - name: xib
       extensions:


### PR DESCRIPTION
Makes [JSX](https://en.wikipedia.org/wiki/JSX_(JavaScript))/TSX their own file formats to correctly handle `trunk-ignores` like:
```typescript
const x = (
  <div>
    {/* trunk-ignore(eslint/@typescript-eslint/no-explicit-any) */}
    <button onClick={(_a: any) => {}} />
  </div>
);
```

Notes:
- We won't be able to correctly autogen comment formats in all cases since we don't detect if we're in an XML block or not. But we will parse them correctly
- We don't support `{  /* */  }` (i.e. additional or mismatched whitespace), but I think this is fine for now. I did include a singular space since it is [somewhat common](https://github.com/search?type=code&q=%22%7B+%2F*%22+path%3A*.tsx) (even though prettier handles this)
- This wasn't working originally since we expect previous line comments to be preceded by only whitespace