### PR TITLE
Handle eslint pre-9.0.0

### DIFF
--- a/linters/eslint/README.md
+++ b/linters/eslint/README.md
@@ -1,0 +1,22 @@
+# eslint
+
+## Migration Guide
+
+Trunk does not yet support `eslint@9.x`, which includes substantial config format changes (see their
+[migration guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-config)). If you'd like
+to opt-in to `eslint@9.x` with Trunk before we release official support, you can add the following
+override to your `.trunk/trunk.yaml`:
+
+```yaml
+version: 0.1
+---
+lint:
+  enabled:
+    - eslint@9.0.0
+  definitions:
+    - name: eslint
+      direct_configs:
+        - eslint.config.js
+        - eslint.config.mjs
+        - eslint.config.cjs
+```

--- a/linters/eslint/eslint.test.ts
+++ b/linters/eslint/eslint.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
+import semver from "semver";
 import { customLinterCheckTest } from "tests";
 import { TrunkLintDriver } from "tests/driver";
 import { osTimeoutMultiplier, TEST_DATA } from "tests/utils";
@@ -68,12 +69,22 @@ const preCheck = (driver: TrunkLintDriver) => {
   }
 };
 
+const manualVersionReplacer = (version: string) => {
+  // NOTE(Tyler): Continue to test eslint pre-9.0.0 and gate until we have a long-term fix.
+  const parsedVersion = semver.parse(version);
+  if (parsedVersion && parsedVersion.major >= 9) {
+    return "8.57.0";
+  }
+  return version;
+};
+
 // This set of testing is incomplete with regard to failure modes and unicode autofixes with eslint, but it serves as a sampling
 // Use upstream=false in order to supply autofixes for committed files.
 customLinterCheckTest({
   linterName: "eslint",
   args: `${TEST_DATA} -y --upstream=false`,
   preCheck,
+  manualVersionReplacer,
   pathsToSnapshot: [
     path.join(TEST_DATA, "non_ascii.ts"),
     path.join(TEST_DATA, "eof_autofix.ts"),
@@ -86,4 +97,5 @@ customLinterCheckTest({
   testName: "bad_install",
   args: `${TEST_DATA} -y`,
   preCheck: moveConfig,
+  manualVersionReplacer,
 });

--- a/linters/eslint/eslint.test.ts
+++ b/linters/eslint/eslint.test.ts
@@ -55,6 +55,7 @@ const preCheck = (driver: TrunkLintDriver) => {
         cwd: driver.getSandbox(),
         timeout: INSTALL_TIMEOUT,
         windowsHide: true,
+        shell: true,
       },
     );
     driver.debug(install);


### PR DESCRIPTION
Offers some temporary fixes to make `main` green and provide a migration guide until we have a long-term story for #735. Also includes a node fix with [executing `.bat` files](https://github.com/trunk-io/plugins/actions/runs/8702103641/job/23865448625) related to https://github.com/prebuild/prebuildify/issues/83