### PR TITLE
Update ruby parse_regex

### DIFF
--- a/linters/buildifier/test_data/buildifier_v7.1.0_basic_check.check.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_basic_check.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter buildifier test basic_check 1`] = `
 {

--- a/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.add_tables.BUILD.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.add_tables.BUILD.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter buildifier test no_config 1`] = `
 "foo_macro(

--- a/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.basic.bzl.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_no_config.test_data.basic.bzl.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter buildifier test no_config 1`] = `
 "# Misformatted file

--- a/linters/buildifier/test_data/buildifier_v7.1.0_with_config.test_data.add_tables.BUILD.fmt.shot
+++ b/linters/buildifier/test_data/buildifier_v7.1.0_with_config.test_data.add_tables.BUILD.fmt.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing formatter buildifier test with_config 1`] = `
 "foo_macro(

--- a/linters/golangci-lint/plugin.yaml
+++ b/linters/golangci-lint/plugin.yaml
@@ -30,6 +30,8 @@ lint:
         - name: lint
           # Custom parser type defined in the trunk cli to handle golangci-lint's JSON output.
           output: golangci_lint
+          # We need to run golangci-lint on directories since running on files only works for --fast
+          # and can also produce false positives.
           target: ${parent}
           # Exclude go linters we already include.
           run:
@@ -46,7 +48,8 @@ lint:
           # 7 - error logged
           success_codes: [0, 2, 7]
           run_from: ${root_or_parent_with(go.mod)}
-          disable_upstream: true # TODO(Sam): re-enable the upstream for golang (needs test coverage)
+          # TODO(Tyler): Audit golangci-lint running on upstream once sandboxing and relative path fix is landed.
+          disable_upstream: true
       suggest_if: files_present
       direct_configs:
         - .golangci.json

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_all.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_all.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter golangci-lint test all 1`] = `
 {

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_empty.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_empty.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter golangci-lint test empty 1`] = `
 {

--- a/linters/golangci-lint/test_data/golangci_lint_v1.57.0_unbuildable.check.shot
+++ b/linters/golangci-lint/test_data/golangci_lint_v1.57.0_unbuildable.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter golangci-lint test unbuildable 1`] = `
 {

--- a/linters/pyright/test_data/pyright_v1.1.359_basic.check.shot
+++ b/linters/pyright/test_data/pyright_v1.1.359_basic.check.shot
@@ -1,5 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// trunk-upgrade-validation:RELEASE
 
 exports[`Testing linter pyright test basic 1`] = `
 {

--- a/runtimes/ruby/plugin.yaml
+++ b/runtimes/ruby/plugin.yaml
@@ -47,7 +47,7 @@ runtimes:
       known_good_version: 3.1.4
       version_commands:
         - run: ruby --version
-          parse_regex: ruby ([0-9\.]+)(p+.*)
+          parse_regex: ruby ${semver}(p+.*)?
       shims:
         - bundle
         - bundler


### PR DESCRIPTION
Mainline releases of ruby don't have a `p` in the version output (anymore). Modernize our `parse_regex` to better support this and other system versions of ruby:

```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
```

Also removes release tags for cleanliness.