### PR TITLE
Fix biome fmt error case

### DIFF
--- a/linters/biome/biome.test.ts
+++ b/linters/biome/biome.test.ts
@@ -1,5 +1,22 @@
-import { linterCheckTest, linterFmtTest } from "tests";
+import path from "path";
+import { customLinterCheckTest, linterCheckTest, linterFmtTest } from "tests";
+import { TrunkLintDriver } from "tests/driver";
+import { TEST_DATA } from "tests/utils";
 
 linterCheckTest({ linterName: "biome", namedTestPrefixes: ["basic_check"] });
 
 linterFmtTest({ linterName: "biome", namedTestPrefixes: ["basic_fmt", "basic_json"] });
+
+const preCheck = (driver: TrunkLintDriver) => {
+  // Write an invalid biome config and verify we surface an error for format.
+  // NOTE(Tyler): We should handle config errors better for 'lint' too, but the JSON
+  // output for biome is not stable and they don't support SARIF.
+  driver.writeFile("biome.json", JSON.stringify({ rules: { "no-foo": "error" } }));
+};
+
+customLinterCheckTest({
+  linterName: "biome",
+  testName: "error",
+  args: path.join(TEST_DATA, "basic_check.in.ts"),
+  preCheck,
+});

--- a/linters/biome/plugin.yaml
+++ b/linters/biome/plugin.yaml
@@ -30,7 +30,7 @@ lint:
         - name: fmt
           output: rewrite
           run: biome format --write "${target}"
-          success_codes: [0, 1]
+          success_codes: [0]
           batch: true
           cache_results: true
           formatter: true

--- a/linters/biome/test_data/biome_v1.4.1_error.check.shot
+++ b/linters/biome/test_data/biome_v1.4.1_error.check.shot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter biome test error 1`] = `
+{
+  "issues": [],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/basic_check.in.ts",
+      "name": "biome",
+    },
+  ],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/biome/test_data/biome_v1.6.0_error.check.shot
+++ b/linters/biome/test_data/biome_v1.6.0_error.check.shot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter biome test error 1`] = `
+{
+  "issues": [],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/basic_check.in.ts",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [
+    {
+      "details": StringMatching /\\.\\*\\$/m,
+      "message": "test_data/basic_check.in.ts",
+      "name": "biome",
+    },
+  ],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Fixes https://github.com/trunk-io/plugins/issues/771 for cases of malformed config. `biome fmt` outputs an exit code of 1. For lint, we have to have `success_codes: [0, 1]`, but for format we can just have `success_codes: [0]` so that we better surface this error to users.

Also adds a relevant test case.