### PR TITLE
Add docker ecr login plugin as tools

### DIFF
--- a/tools/docker-credential-ecr-login/docker-credential-ecr-login.test.ts
+++ b/tools/docker-credential-ecr-login/docker-credential-ecr-login.test.ts
@@ -1,0 +1,12 @@
+import { makeToolTestConfig, toolTest } from "tests";
+
+toolTest({
+  toolName: "docker-credential-ecr-login",
+  toolVersion: "0.8.0",
+  testConfigs: [
+    makeToolTestConfig({
+      command: ["docker-credential-ecr-login", "-v"],
+      expectedOut: "Version:    0.8.0",
+    }),
+  ],
+});

--- a/tools/docker-credential-ecr-login/plugin.yaml
+++ b/tools/docker-credential-ecr-login/plugin.yaml
@@ -21,4 +21,4 @@ tools:
     - name: docker-credential-ecr-login
       download: docker-credential-ecr-login
       known_good_version: 0.8.0
-       shims: [docker-credential-ecr-login]
+      shims: [docker-credential-ecr-login]

--- a/tools/docker-credential-ecr-login/plugin.yaml
+++ b/tools/docker-credential-ecr-login/plugin.yaml
@@ -1,0 +1,26 @@
+version: 0.1
+downloads:
+  - name: docker-credential-ecr-login
+    executable: true
+    downloads:
+      - os:
+          linux: linux
+          macos: darwin
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${version}/${os}-${cpu}/docker-credential-ecr-login
+      - os:
+          windows: windows
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${version}/windows-${cpu}/docker-credential-ecr-login.exe
+tools:
+  definitions:
+    - name: docker-credential-ecr-login
+      download: docker-credential-ecr-login
+      known_good_version: 0.8.0
+      shims:
+        - name: docker-credential-ecr-login
+          target: docker-credential-ecr-login

--- a/tools/docker-credential-ecr-login/plugin.yaml
+++ b/tools/docker-credential-ecr-login/plugin.yaml
@@ -21,6 +21,4 @@ tools:
     - name: docker-credential-ecr-login
       download: docker-credential-ecr-login
       known_good_version: 0.8.0
-      shims:
-        - name: docker-credential-ecr-login
-          target: docker-credential-ecr-login
+       shims: [docker-credential-ecr-login]


### PR DESCRIPTION
Docker doesn't install this by default anymore. Adding it for easy install for new hires.