### PR TITLE
Don't upload eslint validated versions

### DIFF
--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -16,6 +16,9 @@ const RESULTS_FILE = path.resolve(REPO_ROOT, "results.json");
 const FAILURES_FILE = path.resolve(REPO_ROOT, "failures.json");
 const RERUN_FILE = path.resolve(REPO_ROOT, "reruns.txt");
 
+// TODO(Tyler): Remove this blocklist once eslint-friendly release is out.
+const VALIDATED_LINTER_BLOCKLIST = ["eslint"];
+
 const RUN_ID = process.env.RUN_ID ?? "";
 const TEST_REF = process.env.TEST_REF ?? "latest release";
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? "missing_repo";
@@ -323,7 +326,11 @@ const writeTestResults = (testResults: TestResultSummary) => {
   const pluginVersion = PLUGIN_VERSION;
   const validatedVersions = Array.from(testResults.testResults).reduce(
     (accumulator: ValidatedVersion[], [linter, { version, testResultStatus }]) => {
-      if (testResultStatus === "passed" && version) {
+      if (
+        testResultStatus === "passed" &&
+        version &&
+        !VALIDATED_LINTER_BLOCKLIST.includes(linter)
+      ) {
         const additionalValidatedVersion: ValidatedVersion = { linter, version };
         return accumulator.concat([additionalValidatedVersion]);
       }


### PR DESCRIPTION
This is a temporary mechanism to avoid sending new, 9.x validated versions for eslint to LUV. That way, we can make a plugins release that has the eslint9 support, and users on older CLI versions will have some time to upgrade before we start OOTB recommending newest eslint. See https://github.com/trunk-io/plugins/pull/735#issuecomment-2136174176

Intended to be reverted ~1 week after next plugins release