### PR TITLE
Support other osv-scanner lockfile types

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -389,9 +389,13 @@ lint:
         - requirements.txt
         - Pipfile.lock
         - poetry.lock
+        - pdm.lock
 
         # Ruby
         - Gemfile.lock
+
+        # R
+        - renv.lock
 
     - name: lua
       extensions:


### PR DESCRIPTION
Supports `pdm.lock` and `renv.lock`, which osv-scanner started checking for this year. Reported by a community user.