### PR TITLE
Fix vale on Windows

### DIFF
--- a/linters/vale/plugin.yaml
+++ b/linters/vale/plugin.yaml
@@ -25,7 +25,8 @@ tools:
       known_good_version: 3.4.1
       environment:
         - name: PATH
-          list: ["${tool}"]
+          # Needs access to shared libraries on Windows.
+          list: ["${tool}", "${env.PATH}"]
 
 lint:
   definitions:


### PR DESCRIPTION
Should have caught this pre-last release. We need to forward the PATH so that we can access necessary shared libraries.