### PR TITLE
Fix ruff-nbqa

### DIFF
--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -68,13 +68,13 @@ lint:
       files: [jupyter]
       commands:
         - name: lint
-          run: nbqa ruff --cache-dir=${cachedir} ${target}
+          run: nbqa 'ruff check --cache-dir=${cachedir} --quiet' ${target}
           output: pass_fail
           batch: true
           success_codes: [0, 1]
       runtime: python
       package: ruff
-      extra_packages: [nbqa==1.6.3]
+      extra_packages: [nbqa==1.8.5]
       direct_configs: [ruff.toml]
       affects_cache:
         - pyproject.toml

--- a/linters/ruff/test_data/ruff_nbqa_v0.0.250_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.0.250_basic_nb.check.shot
@@ -9,9 +9,7 @@ exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
       "issueClass": "ISSUE_CLASS_EXISTING",
       "level": "LEVEL_HIGH",
       "linter": "ruff-nbqa",
-      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused
-Found 1 error.
-[*] 1 potentially fixable with the --fix option.",
+      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused",
       "targetType": "jupyter",
     },
   ],

--- a/linters/ruff/test_data/ruff_nbqa_v0.1.0_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.1.0_basic_nb.check.shot
@@ -9,9 +9,7 @@ exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
       "issueClass": "ISSUE_CLASS_EXISTING",
       "level": "LEVEL_HIGH",
       "linter": "ruff-nbqa",
-      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused
-Found 1 error.
-[*] 1 fixable with the \`--fix\` option.",
+      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused",
       "targetType": "jupyter",
     },
   ],

--- a/linters/ruff/test_data/ruff_nbqa_v0.5.0_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.5.0_basic_nb.check.shot
@@ -11,7 +11,7 @@ exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
       "linter": "ruff-nbqa",
       "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused
   |
-1 | # %%NBQA-CELL-SEP22268f
+1 | # %%NBQA-CELL-SEP
 2 | import os
   |        ^^ F401
 3 | 

--- a/linters/ruff/test_data/ruff_nbqa_v0.5.0_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_nbqa_v0.5.0_basic_nb.check.shot
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff-nbqa test basic_nb 1`] = `
+{
+  "issues": [
+    {
+      "code": "error",
+      "file": "test_data/basic_nb.in.ipynb",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "linter": "ruff-nbqa",
+      "message": "/tmp/plugins_/test_data/basic_nb.in.ipynb:cell_1:1:8: F401 [*] \`os\` imported but unused
+  |
+1 | # %%NBQA-CELL-SEP22268f
+2 | import os
+  |        ^^ F401
+3 | 
+4 | print("Hello World!")
+  |
+  = help: Remove unused import: \`os\`",
+      "targetType": "jupyter",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff-nbqa",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff-nbqa",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/tests/utils/landing_state.ts
+++ b/tests/utils/landing_state.ts
@@ -76,6 +76,7 @@ const normalizeMessage = (message?: string) =>
     .replaceAll("\\", "/")
     .replace(/\/plugins_.{6}/gm, "/plugins_")
     .replace(".dup.", ".")
+    .replace(/NBQA-CELL-SEP.{6}/gm, "NBQA-CELL-SEP")
     .trim();
 
 // trunk-ignore(eslint/@typescript-eslint/no-non-null-assertion)


### PR DESCRIPTION
Ruff `0.5.0` deprecated running on files without the `check` subcommand. Fix our `ruff-nbqa` definition to support this and forward args correctly. Fixes failures in [run](https://github.com/trunk-io/plugins/actions/runs/9709549433/job/26798463120)