### PR TITLE
Add tfvars filetype

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -600,6 +600,11 @@ lint:
       comments:
         - hash
 
+    - name: tfvars
+      extensions:
+        # terraform/tofu can't format .tfvars.json files
+        - tfvars
+
     - name: toml
       extensions:
         - toml

--- a/linters/terraform/plugin.yaml
+++ b/linters/terraform/plugin.yaml
@@ -2,7 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: terraform
-      files: [terraform]
+      files: [terraform, tfvars]
       tools: [terraform]
       description: Validate and format terraform files
       commands:

--- a/linters/tofu/plugin.yaml
+++ b/linters/tofu/plugin.yaml
@@ -2,7 +2,7 @@ version: 0.1
 lint:
   definitions:
     - name: tofu
-      files: [terraform]
+      files: [terraform, tfvars]
       tools: [tofu]
       description: A Terraform validator and formatter
       commands:

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -35,9 +35,10 @@ lint:
         - name: fs-vuln
           files: [lockfile]
           output: sarif
+          prepare_run: trivy fs --download-db-only --no-progress --cache-dir ${shared_cachedir}
           run:
-            trivy fs ${target} --scanners vuln --format json --no-progress --cache-dir
-            ${shared_cachedir}
+            trivy fs ${target} --scanners vuln --format json --no-progress --skip-db-update
+            --cache-dir ${shared_cachedir}
           success_codes: [0]
           read_output_from: stdout
           # Trivy does not support batching

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -37,8 +37,8 @@ lint:
           output: sarif
           prepare_run: trivy fs --download-db-only --no-progress --cache-dir ${shared_cachedir}
           run:
-            trivy fs ${target} --scanners vuln --format json --no-progress --skip-db-update
-            --cache-dir ${shared_cachedir}
+            trivy fs ${target} --scanners vuln --format json --no-progress --cache-dir
+            ${shared_cachedir}
           success_codes: [0]
           read_output_from: stdout
           # Trivy does not support batching

--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -35,7 +35,6 @@ lint:
         - name: fs-vuln
           files: [lockfile]
           output: sarif
-          prepare_run: trivy fs --download-db-only --no-progress --cache-dir ${shared_cachedir}
           run:
             trivy fs ${target} --scanners vuln --format json --no-progress --cache-dir
             ${shared_cachedir}

--- a/linters/trivy/trivy.test.ts
+++ b/linters/trivy/trivy.test.ts
@@ -13,12 +13,14 @@ const callbackGenerator =
     const currentContents = driver.readFile(trunkYamlPath);
     const trivyRegex = /- trivy@(.+)\n/;
 
-    // fs-vuln sometimes fails in CI to query DB concurrently.
+    // fs-vuln, config sometimes fail in CI to query DB concurrently.
     const extraContents = `
   definitions:
     - name: trivy
       commands:
         - name: fs-vuln
+          max_concurrency: 1
+        - name: config
           max_concurrency: 1
 `;
     const newContents = currentContents.replace(

--- a/linters/trivy/trivy.test.ts
+++ b/linters/trivy/trivy.test.ts
@@ -42,7 +42,7 @@ fuzzyLinterCheckTest({
   linterName: "trivy",
   testName: "fs-vuln",
   args: "-a",
-  fileIssueAssertionCallback: createFuzzyMatcher(() => vulnExpectedFileIssues, 30),
+  fileIssueAssertionCallback: createFuzzyMatcher(() => vulnExpectedFileIssues, 20),
   preCheck: callbackGenerator("fs-vuln"),
 });
 

--- a/linters/trivy/trivy.test.ts
+++ b/linters/trivy/trivy.test.ts
@@ -12,9 +12,18 @@ const callbackGenerator =
     const trunkYamlPath = ".trunk/trunk.yaml";
     const currentContents = driver.readFile(trunkYamlPath);
     const trivyRegex = /- trivy@(.+)\n/;
+
+    // fs-vuln sometimes fails in CI to query DB concurrently.
+    const extraContents = `
+  definitions:
+    - name: trivy
+      commands:
+        - name: fs-vuln
+          max_concurrency: 1
+`;
     const newContents = currentContents.replace(
       trivyRegex,
-      `- trivy@$1:\n        commands: [${command}]\n`,
+      `- trivy@$1:\n        commands: [${command}]\n${extraContents}`,
     );
     driver.writeFile(trunkYamlPath, newContents);
     if (otherPreCheck) {


### PR DESCRIPTION
Terraform and tofu can run on `.tfvars` files (although notably not `.tfvars.json`). Adds this filetype

Also attempts to fix trivy test failures.