### PR TITLE
Fix sqlfluff fix command

### DIFF
--- a/linters/sqlfluff/plugin.yaml
+++ b/linters/sqlfluff/plugin.yaml
@@ -28,10 +28,19 @@ lint:
             runtime: python
             run: python3 ${plugin}/linters/sqlfluff/sqlfluff_to_sarif.py
         - name: fix
+          version: ">=3.0.0"
+          run: sqlfluff fix ${target} --disable-progress-bar
+          output: rewrite
+          formatter: true
+          in_place: true
+          success_codes: [0, 1]
+          enabled: false
+          batch: true
+        - name: fix
           run: sqlfluff fix ${target} --disable-progress-bar --force
           output: rewrite
           formatter: true
           in_place: true
-          success_codes: [0]
+          success_codes: [0, 1]
           enabled: false
           batch: true

--- a/linters/sqlfluff/sqlfluff.test.ts
+++ b/linters/sqlfluff/sqlfluff.test.ts
@@ -18,4 +18,8 @@ const fmtCallbacks: TestCallback = (driver) => {
 };
 
 // An additional test to run 'sqlfluff fmt' with some additional test setup.
-linterFmtTest({ linterName: "sqlfluff", namedTestPrefixes: ["basic_fmt"], preCheck: fmtCallbacks });
+linterFmtTest({
+  linterName: "sqlfluff",
+  namedTestPrefixes: ["basic_fmt", "basic_check"],
+  preCheck: fmtCallbacks,
+});

--- a/linters/sqlfluff/test_data/sqlfluff_v1.4.2_basic_check.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v1.4.2_basic_check.fmt.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter sqlfluff test basic_check 1`] = `
+"SELECT
+    *,
+    1,
+    blah AS foo
+FROM myschema.mytable
+"
+`;

--- a/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v2.0.0_basic_check.fmt.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter sqlfluff test basic_check 1`] = `
+"SELECT
+    *,
+    1,
+    blah AS foo
+FROM myschema.mytable
+"
+`;

--- a/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_check.fmt.shot
+++ b/linters/sqlfluff/test_data/sqlfluff_v3.0.0_basic_check.fmt.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter sqlfluff test basic_check 1`] = `
+"SELECT
+    *,
+    1,
+    blah AS foo
+FROM myschema.mytable
+"
+`;


### PR DESCRIPTION
Fixes 2 issues:
- In some scenarios (such as when there are still issues after autofixes), `sqlfluff fix` will nonzero exit code, causing a linter failure presently. It will still format, so there's no other need for triage
- sqlfluff soft-deprecated the `--force` flag (it's now default on), so we can get ahead of that