### PR TITLE
Add svelte filetype

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -574,6 +574,12 @@ lint:
         - strings
         - stringsdict
 
+    - name: svelte
+      extensions:
+        - svelte
+      comments:
+        - html-tag
+
     - name: svg
       extensions:
         - svg


### PR DESCRIPTION
Adds a svelte filetype, which isn't used by default but is commonly overriden by users for prettier and eslint