### PR TITLE
Remove CI Debugger

### DIFF
--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -58,8 +58,8 @@ runs:
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
 
     - name: Upload results
-      # TODO(Tyler): Add upload on MacOS/Windows once the action supports it.
-      if: "!cancelled() && runner.os == 'Linux'"
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows'"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: actions/ --
   trunk-token:
-    description: CI debugger api token
+    description: Test analytics api token
     required: true
 
 runs:
@@ -49,26 +49,9 @@ runs:
       working-directory: ${{ inputs.path }}
 
     - name: Run action tests
-      if: runner.os == 'Windows'
       run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --passWithNoTests --ci
       shell: bash
       working-directory: ${{ inputs.path }}
-      env:
-        JEST_SUITE_NAME: Action Tests
-        PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
-        PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
-
-    - name: Run action tests
-      if: runner.os != 'Windows'
-      uses: trunk-io/breakpoint@v1.3.0
-      with:
-        breakpoint-id: trunk-plugins-action-tests
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        trunk-token: ${{ inputs.trunk-token }}
-        org: trunk-staging-org
-        run:
-          npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --passWithNoTests --ci
       env:
         JEST_SUITE_NAME: Action Tests
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}

--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -16,9 +16,12 @@ inputs:
     description: Additional args to append to the test invocation
     required: false
     default: actions/ --
-  trunk-token:
-    description: Test analytics api token
-    required: true
+  trunk-staging-token:
+    description: Test analytics staging api token (org token)
+    required: false
+  trunk-prod-token:
+    description: Test analytics prod api token (org token)
+    required: false
 
 runs:
   # TODO(Tyler): See if this can be converted to a js action
@@ -57,9 +60,21 @@ runs:
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
 
-    - name: Upload results
+    - name: Upload prod results
       # TODO(Tyler): Add upload on Windows once the action supports it.
-      if: "!cancelled() && runner.os != 'Windows'"
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-prod-token != ''"
+      uses: trunk-io/analytics-uploader@main
+      with:
+        junit-paths: junit.xml
+        org-slug: trunk
+        token: ${{ inputs.trunk-prod-token }}
+      continue-on-error: true
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
+
+    - name: Upload staging results
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-staging-token != ''"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -24,7 +24,7 @@ inputs:
     description: Token to login for sourcery test
     required: true
   trunk-token:
-    description: CI debugger api token (org token)
+    description: Test analytics api token (org token)
     required: true
   ref-type:
     description: release or main
@@ -92,7 +92,6 @@ runs:
       working-directory: ${{ inputs.path }}
 
     - name: Run plugin tests
-      if: runner.os == 'Windows'
       run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       shell: bash
       working-directory: ${{ inputs.path }}
@@ -106,27 +105,6 @@ runs:
         JEST_SUITE_NAME: Linter Tests
         JEST_JUNIT_SUITE_NAME:
           "{title} ${{ runner.os }} ${{ inputs.ref-type }} ${{ inputs.linter-version }}"
-
-    - name: Run plugin tests
-      if: runner.os != 'Windows'
-      # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
-      uses: trunk-io/breakpoint@v1.3.0
-      with:
-        breakpoint-id: trunk-plugins-linter-tests
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        trunk-token: ${{ inputs.trunk-token }}
-        org: trunk-staging-org
-        run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci --runInBand
-      env:
-        PLUGINS_TEST_LINTER_VERSION: ${{ inputs.linter-version }}
-        PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
-        PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
-        SOURCERY_TOKEN: ${{ inputs.sourcery-token }}
-        DEBUG: Driver:nixpkgs-fmt:*, Driver:eslint:*
-        JEST_SUITE_NAME: Linter Tests
-        JEST_JUNIT_SUITE_NAME:
-          "{title} ${{ runner.os }} ${{ inputs.ref-type }} ${{ env.JEST_LINTER_VERSION }}"
 
     - name: Upload results
       # TODO(Tyler): Add upload on MacOS/Windows once the action supports it.

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -107,8 +107,8 @@ runs:
           "{title} ${{ runner.os }} ${{ inputs.ref-type }} ${{ inputs.linter-version }}"
 
     - name: Upload results
-      # TODO(Tyler): Add upload on MacOS/Windows once the action supports it.
-      if: "!cancelled() && runner.os == 'Linux'"
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows'"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -23,9 +23,12 @@ inputs:
   sourcery-token:
     description: Token to login for sourcery test
     required: true
-  trunk-token:
-    description: Test analytics api token (org token)
-    required: true
+  trunk-staging-token:
+    description: Test analytics staging api token (org token)
+    required: false
+  trunk-prod-token:
+    description: Test analytics prod api token (org token)
+    required: false
   ref-type:
     description: release or main
     required: false
@@ -106,9 +109,21 @@ runs:
         JEST_JUNIT_SUITE_NAME:
           "{title} ${{ runner.os }} ${{ inputs.ref-type }} ${{ inputs.linter-version }}"
 
-    - name: Upload results
+    - name: Upload prod results
       # TODO(Tyler): Add upload on Windows once the action supports it.
-      if: "!cancelled() && runner.os != 'Windows'"
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-prod-token != ''"
+      uses: trunk-io/analytics-uploader@main
+      with:
+        junit-paths: junit.xml
+        org-slug: trunk
+        token: ${{ inputs.trunk-prod-token }}
+      continue-on-error: true
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
+
+    - name: Upload staging results
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-staging-token != ''"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -75,8 +75,8 @@ runs:
         JEST_JUNIT_SUITE_NAME: "{title} ${{ runner.os }} ${{ inputs.ref-type }}"
 
     - name: Upload results
-      # TODO(Tyler): Add upload on MacOS/Windows once the action supports it.
-      if: "!cancelled() && runner.os == 'Linux'"
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows'"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -16,9 +16,12 @@ inputs:
     description: Additional args to append to the test invocation
     required: false
     default: tools --
-  trunk-token:
-    description: Test analytics api token (org token)
-    required: true
+  trunk-staging-token:
+    description: Test analytics staging api token (org token)
+    required: false
+  trunk-prod-token:
+    description: Test analytics prod api token (org token)
+    required: false
   ref-type:
     description: release or main
     required: false
@@ -74,9 +77,21 @@ runs:
         JEST_SUITE_NAME: Tool Tests
         JEST_JUNIT_SUITE_NAME: "{title} ${{ runner.os }} ${{ inputs.ref-type }}"
 
-    - name: Upload results
+    - name: Upload prod results
       # TODO(Tyler): Add upload on Windows once the action supports it.
-      if: "!cancelled() && runner.os != 'Windows'"
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-prod-token != ''"
+      uses: trunk-io/analytics-uploader@main
+      with:
+        junit-paths: junit.xml
+        org-slug: trunk
+        token: ${{ inputs.trunk-prod-token }}
+      continue-on-error: true
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io
+
+    - name: Upload staging results
+      # TODO(Tyler): Add upload on Windows once the action supports it.
+      if: "!cancelled() && runner.os != 'Windows' && inputs.trunk-staging-token != ''"
       uses: trunk-io/analytics-uploader@main
       with:
         junit-paths: junit.xml

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: tools --
   trunk-token:
-    description: CI debugger api token (org token)
+    description: Test analytics api token (org token)
     required: true
   ref-type:
     description: release or main
@@ -65,27 +65,9 @@ runs:
       working-directory: ${{ inputs.path }}
 
     - name: Run plugin tests
-      if: runner.os == 'Windows'
       run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       shell: bash
       working-directory: ${{ inputs.path }}
-      env:
-        PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
-        PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}
-        JEST_SUITE_NAME: Tool Tests
-        JEST_JUNIT_SUITE_NAME: "{title} ${{ runner.os }} ${{ inputs.ref-type }}"
-
-    - name: Run plugin tests
-      if: runner.os != 'Windows'
-      # trunk-ignore(semgrep/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
-      uses: trunk-io/breakpoint@v1.3.0
-      with:
-        breakpoint-id: trunk-plugins-tool-tests
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        trunk-token: ${{ inputs.trunk-token  }}
-        org: trunk-staging-org
-        run: npm test ${{ inputs.append-args }} ${{ env.PLATFORM_APPEND_ARGS }} --ci
       env:
         PLUGINS_TEST_CLI_VERSION: ${{ inputs.cli-version }}
         PLUGINS_TEST_CLI_PATH: ${{ env.CLI_PATH }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -203,6 +203,7 @@ jobs:
       TRUNK_OPEN_PR_APP_PRIVATE_KEY: ${{ secrets.TRUNK_OPEN_PR_APP_PRIVATE_KEY }}
       TRUNK_SOURCERY_TOKEN: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
       TRUNK_DEBUGGER_TOKEN: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+      TRUNK_ORG_PROD_TOKEN: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
     with:
       plugin-version: ${{ needs.linter_tests_release.outputs.plugin-version }}
       upload-validated-versions: true
@@ -258,6 +259,7 @@ jobs:
       TRUNKBOT_SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
       TRUNK_SOURCERY_TOKEN: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
       TRUNK_DEBUGGER_TOKEN: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+      TRUNK_ORG_PROD_TOKEN: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
     with:
       plugin-version: main
       results-prefix: tools-

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,7 +68,8 @@ jobs:
           linter-version: ${{ matrix.linter-version }}
           ref-type: main
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   # Run tests against all linters for snapshots and latest version as they exist in latest release
   # This job is used to update the list of validated versions
@@ -176,7 +177,8 @@ jobs:
           append-args: linters -- --json --outputFile=${{ matrix.results-file }}-res.json
           ref-type: release
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
       - name: Upload Test Outputs for Upload Job
         # Only upload results from latest. Always run, except when cancelled.
@@ -235,7 +237,8 @@ jobs:
         uses: ./.github/actions/tool_tests
         with:
           append-args: tools -- --json --outputFile=${{ matrix.results-file }}-res.json
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
       - name: Upload Test Outputs for Notification Job
         # Always run, except when cancelled.
@@ -278,4 +281,5 @@ jobs:
       - name: Action Tests
         uses: ./.github/actions/action_tests
         with:
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,7 +155,8 @@ jobs:
           append-args:
             ${{ needs.detect_changes.outputs.all-linters }} ${{
             needs.detect_changes.outputs.linters-files }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
       - name: Linter Tests Latest
         # Run tests on Latest with any modified linters (see filters.yaml). Don't run when cancelled.
@@ -168,7 +169,8 @@ jobs:
           ref-type: main
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           append-args: ${{ needs.detect_changes.outputs.linters-files }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   tool_tests:
     name: Tool Tests
@@ -194,7 +196,8 @@ jobs:
           append-args:
             ${{ needs.detect_changes.outputs.all-tools }} ${{
             needs.detect_changes.outputs.tools-files }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   action_tests:
     name: Action Tests
@@ -214,7 +217,8 @@ jobs:
           append-args:
             ${{ needs.detect_changes.outputs.all-actions }} ${{
             needs.detect_changes.outputs.actions-files }} --
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   trunk_check_runner:
     name: Trunk Check runner [linux]
@@ -261,7 +265,8 @@ jobs:
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           cli-path: ${{ github.workspace }}\trunk.ps1
           append-args: ${{needs.detect_changes.outputs.linters-files }} -- --maxWorkers=5
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   windows_tool_tests:
     name: Windows Tool Tests
@@ -285,7 +290,8 @@ jobs:
         with:
           append-args: ${{needs.detect_changes.outputs.tools-files }} -- --maxWorkers=5
           cli-path: ${{ github.workspace }}\trunk.ps1
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   # Run repo healthcheck tests
   repo_tests:

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -38,6 +38,8 @@ on:
         required: false
       TRUNK_DEBUGGER_TOKEN:
         required: false
+      TRUNK_ORG_PROD_TOKEN:
+        required: false
 
 permissions:
   actions: write
@@ -258,7 +260,8 @@ jobs:
           ref-type: main
           append-args: ${{ needs.upload_test_results.outputs.reruns }} -- -u
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
         env:
           PLUGINS_TEST_UPDATE_SNAPSHOTS: "true"
 

--- a/.github/workflows/windows_nightly.yaml
+++ b/.github/workflows/windows_nightly.yaml
@@ -49,8 +49,9 @@ jobs:
           cli-path: ${{ github.workspace }}\trunk.ps1
           # manually specify more parallelism to avoid bottlenecks
           append-args: linters -- --maxWorkers=5
-          # CI Debugger is not yet supported on Windows
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          # Analytics uploader is not yet supported on Windows
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
 
   tool_tests_main:
     name: Tool Tests Main
@@ -88,5 +89,6 @@ jobs:
         with:
           cli-path: ${{ github.workspace }}\trunk.ps1
           append-args: tools -- --maxWorkers=5
-          # CI Debugger is not yet supported on Windows
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          # Analytics uploader is not yet supported on Windows
+          trunk-staging-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
+          trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}

--- a/tests/driver/driver.ts
+++ b/tests/driver/driver.ts
@@ -31,8 +31,8 @@ const UNINITIALIZED_ERROR = `You have attempted to modify the sandbox before it 
 Please call this method after setup has been called.`;
 
 export const executionEnv = (sandbox: string) => {
-  // trunk-ignore(eslint/@typescript-eslint/no-unused-vars): Strip TRUNK_CLI_VERSION from CI-Debugger
-  const { PWD, INIT_CWD, TRUNK_CLI_VERSION, ...strippedEnv } = process.env;
+  // trunk-ignore(eslint/@typescript-eslint/no-unused-vars): Remove vars.
+  const { PWD, INIT_CWD, ...strippedEnv } = process.env;
   return {
     ...strippedEnv,
     // This keeps test downloads separate from manual trunk invocations


### PR DESCRIPTION
CI Debugger has been deprecated, so remove its steps and standardize across platforms.

Also start uploading flaky test info for macOS to prod and staging