### PR TITLE
Fix textproto filetypes

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -601,8 +601,10 @@ lint:
 
     - name: textproto
       extensions:
+        - pbtxt
         - textpb
         - textproto
+        - txtpb
       comments:
         - hash
 


### PR DESCRIPTION
Brought to attention by https://github.com/trunk-io/plugins/issues/832. Brought up to date to support the filetypes defined [here](https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files)