### PR TITLE
(Fix): Trivy config files and autorecommended

### DIFF
--- a/linters/trivy/plugin.yaml
+++ b/linters/trivy/plugin.yaml
@@ -27,7 +27,7 @@ lint:
   definitions:
     - name: trivy
       tools: [trivy]
-      suggest_if: files_present
+      suggest_if: config_present
       description: A comprehensive and versatile security scanner
       known_good_version: 0.44.1
       # trivy supports --format template --template "@contrib/sarif.tpl", but it reports the wrong filepaths.
@@ -74,7 +74,8 @@ lint:
           parser:
             runtime: python
             run: python3 ${plugin}/linters/trivy/trivy_config_to_sarif.py
-      direct_configs: [trivy-secret.yaml]
+      # trivy-secret.yaml is old config file https://aquasecurity.github.io/trivy/v0.27.1/docs/secret/configuration/
+      direct_configs: [trivy.yaml, .trivyignore, .trivyignore.yaml, trivy-secret.yaml]
       version_command:
         parse_regex: Version ${semver}
         run: trivy --version

--- a/tests/repo_tests/config_check.test.ts
+++ b/tests/repo_tests/config_check.test.ts
@@ -165,7 +165,6 @@ describe("Global config health check", () => {
         "svgo",
         "taplo",
         "tflint",
-        "trivy",
         "trufflehog",
         "yamllint",
       ]


### PR DESCRIPTION
`trivy-secret.yaml` is the old config file. Now the config file for trivy is `trivy.yaml`, and there are also ignore files.

Also changes `suggest_if` to `config_present` while we investigate trivy issues with shared cachedir.