### PR TITLE
(Fix): Ruff now runs on jupyter notebooks by default

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -46,6 +46,7 @@ lint:
   disabled:
     - pylint # pylint diagnostics are too strict
     - semgrep
+    - trivy # investigating issues with shared cachedir
 
   ignore:
     - linters: [ALL]

--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -9,12 +9,23 @@ tools:
 lint:
   definitions:
     - name: ruff
-      files: [python, python-interface]
       description: A Python linter and formatter
       commands:
         - name: lint
+          # As of ruff v0.6.0, ruff runs by default on jupyter notebooks
+          version: ">=0.6.0"
+          files: [python, python-interface, jupyter]
+          run: ruff check --cache-dir ${cachedir} --output-format json ${target}
+          output: sarif
+          parser:
+            runtime: python
+            run: python3 ${cwd}/ruff_to_sarif.py 0
+          batch: true
+          success_codes: [0, 1]
+        - name: lint
           # As of ruff v0.1.0, --format is replaced with --output-format
           version: ">=0.1.0"
+          files: [python, python-interface]
           run: ruff check --cache-dir ${cachedir} --output-format json ${target}
           output: sarif
           parser:
@@ -25,6 +36,7 @@ lint:
         - name: lint
           # As of ruff v0.0.266, column edits are 1-indexed
           version: ">=0.0.266"
+          files: [python, python-interface]
           run: ruff check --cache-dir ${cachedir} --format json ${target}
           output: sarif
           parser:
@@ -33,6 +45,7 @@ lint:
           batch: true
           success_codes: [0, 1]
         - name: lint
+          files: [python, python-interface]
           run: ruff check --cache-dir ${cachedir} --format json ${target}
           output: sarif
           parser:
@@ -41,6 +54,7 @@ lint:
           batch: true
           success_codes: [0, 1]
         - name: format
+          files: [python, python-interface]
           output: rewrite
           run: ruff format ${target}
           success_codes: [0]
@@ -63,6 +77,7 @@ lint:
         parse_regex: ruff ${semver}
         run: ruff --version
 
+    # Not necessary if ruff>=0.6.0
     - name: ruff-nbqa
       description: A Python linter for Jupyter notebooks
       files: [jupyter]

--- a/linters/ruff/ruff.test.ts
+++ b/linters/ruff/ruff.test.ts
@@ -1,8 +1,24 @@
+import semver from "semver";
 import { linterCheckTest, linterFmtTest } from "tests";
 import { TrunkLintDriver } from "tests/driver";
 import { skipOS } from "tests/utils";
 
 linterCheckTest({ linterName: "ruff", namedTestPrefixes: ["basic", "interface"] });
+
+const skipJupyterTestIf = (version?: string) => {
+  console.log(`Jupyter version: ${version}`);
+  if (!version || !semver.valid(version)) {
+    // Run if version is KGV or a string, or error loudly if malformed.
+    return false;
+  }
+  return semver.lt(version, "0.6.0");
+};
+
+linterCheckTest({
+  linterName: "ruff",
+  namedTestPrefixes: ["basic_nb"],
+  skipTestIf: skipJupyterTestIf,
+});
 
 // ruff-nbqa still runs correctly on Windows, but the diagnostics are slightly different from the assertions.
 linterCheckTest({

--- a/linters/ruff/ruff.test.ts
+++ b/linters/ruff/ruff.test.ts
@@ -6,7 +6,6 @@ import { skipOS } from "tests/utils";
 linterCheckTest({ linterName: "ruff", namedTestPrefixes: ["basic", "interface"] });
 
 const skipJupyterTestIf = (version?: string) => {
-  console.log(`Jupyter version: ${version}`);
   if (!version || !semver.valid(version)) {
     // Run if version is KGV or a string, or error loudly if malformed.
     return false;

--- a/linters/ruff/test_data/ruff_v0.2.1_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_v0.2.1_basic_nb.check.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test basic_nb 1`] = `
+{
+  "issues": [],
+  "lintActions": [],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/test_data/ruff_v0.6.0_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_v0.6.0_basic_nb.check.shot
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test basic_nb 1`] = `
+{
+  "issues": [
+    {
+      "autofixOptions": [
+        {
+          "message": "Remove unused import: \`os\`",
+          "replacements": [
+            {
+              "filePath": "test_data/basic_nb.in.ipynb",
+              "length": "2",
+            },
+          ],
+        },
+      ],
+      "code": "F401",
+      "column": "1",
+      "file": "test_data/basic_nb.in.ipynb",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "ruff",
+      "message": "\`os\` imported but unused",
+      "targetType": "jupyter",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
New in [v0.6.0](https://github.com/astral-sh/ruff/releases/tag/0.6.0). Added test and new versioned subcommand. `ruff-nbqa` basically becomes obsolete at this point.

Also disabled trivy in this repo