### PR TITLE
(Fix): Use correct token input name

### DIFF
--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -79,7 +79,7 @@ runs:
       with:
         junit-paths: junit.xml
         org-slug: trunk-staging-org
-        token: ${{ inputs.trunk-token }}
+        token: ${{ inputs.trunk-staging-token }}
       continue-on-error: true
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -128,7 +128,7 @@ runs:
       with:
         junit-paths: junit.xml
         org-slug: trunk-staging-org
-        token: ${{ inputs.trunk-token }}
+        token: ${{ inputs.trunk-staging-token }}
       continue-on-error: true
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -96,7 +96,7 @@ runs:
       with:
         junit-paths: junit.xml
         org-slug: trunk-staging-org
-        token: ${{ inputs.trunk-token }}
+        token: ${{ inputs.trunk-staging-token }}
       continue-on-error: true
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io


### PR DESCRIPTION
I broke this a couple months ago when I removed CI Debugger. We were getting non-fatal [errors](https://github.com/trunk-io/plugins/actions/runs/10687539115/job/29625379323) `Missing trunk api token` for staging uploads