### PR TITLE
(Fix): Disable caching for pyright

### DIFF
--- a/linters/pyright/plugin.yaml
+++ b/linters/pyright/plugin.yaml
@@ -19,7 +19,7 @@ lint:
           success_codes: [0, 1]
           read_output_from: stdout
           batch: true
-          cache_results: true
+          cache_results: false
           parser:
             runtime: python
             run: python3 ${plugin}/linters/pyright/pyright_to_sarif.py


### PR DESCRIPTION
Similar to eslint, pyright needs to be aware of the rest of the repo for imports, which means we can't make an isolated caching sandbox. We should default this off