### PR TITLE
(Fix): Use new slack schema

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -75,22 +75,19 @@ jobs:
   # This job is used to update the list of validated versions
   linter_tests_release:
     name: Plugin Tests Release
-    # runs-on: [self-hosted, "${{ matrix.os }}"] TODO(Tyler): Set after Windows self-hosted are established.
     runs-on: ${{ matrix.os }}
     timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
         linter-version: [Snapshots, Latest]
-        os: [ubuntu-latest, macOS, windows-latest]
+        os: [ubuntu-latest, macOS]
         include:
           # Normalize the filenames as inputs for ease of parsing
           - os: ubuntu-latest
             results-file: ubuntu-latest
           - os: macOS
             results-file: macos-latest
-          - os: windows-latest
-            results-file: windows-latest
     outputs:
       plugin-version: ${{ steps.get-release.outputs.tag }}
 

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -103,22 +103,16 @@ jobs:
           steps.download-ubuntu.outcome == 'failure' || steps.download-macos.outcome == 'failure' ||
           steps.download-windows.outcome == 'failure'
         with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "text": "Artifact Download Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some ${{ inputs.results-prefix }}test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }}, windows: ${{ steps.download-windows.outcome }}) >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            text: "Artifact Download Failure"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some ${{ inputs.results-prefix }}test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }}, windows: ${{ steps.download-windows.outcome }}) >"
 
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -139,8 +133,9 @@ jobs:
         id: parse
         run: |
           npm run parse
-          echo "failures=$([[ -f failures.json ]] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
-          echo "failures-payload=$(cat failures.json)" >> "$GITHUB_OUTPUT"
+          echo "failures=$([[ -f failures.yaml ]] && echo "true" || echo "false")" >> "$GITHUB_OUTPUT"
+          failures_payload=$(cat failures.yaml)
+          printf "failures-payload<<EOF\n%s\nEOF\n" "$failures_payload" >> "$GITHUB_OUTPUT"
           echo "reruns=$(cat reruns.txt)" >> "$GITHUB_OUTPUT"
         env:
           PLUGIN_VERSION: ${{ inputs.plugin-version }}
@@ -148,6 +143,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           TEST_REF: ${{ inputs.test-ref }}
           TEST_TYPE: ${{ inputs.test-type }}
+          SLACK_CHANNEL_ID: ${{ env.SLACK_CHANNEL_ID }}
 
       - name: Upload Test Results Staging
         if: inputs.upload-validated-versions == true
@@ -184,52 +180,39 @@ jobs:
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         if: always() && steps.parse.outputs.failures == 'true'
         with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
           payload: ${{ steps.parse.outputs.failures-payload }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
 
       - name: Slack Notification For Staging Upload Failure
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         if: inputs.upload-validated-versions == true && steps.upload-staging.outcome == 'failure'
         with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "text": "Upload Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Staging >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            text: "Upload Failure"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Staging >"
 
       - name: Slack Notification For Prod Upload Failure
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         if: inputs.upload-validated-versions == true && steps.upload-prod.outcome == 'failure'
         with:
-          channel-id: ${{ env.SLACK_CHANNEL_ID }}
+          method: chat.postMessage
+          token: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
           payload: |
-            {
-              "text": "Upload Failure",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Prod >"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.TRUNKBOT_SLACK_BOT_TOKEN }}
+            channel: ${{ env.SLACK_CHANNEL_ID }}
+            text: "Upload Failure"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Upload Test Results to Prod >"
   generate_snapshots_pr:
     name: Generate Snapshots PR
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/parser": "^8.14.0",
         "caller": "^1.1.0",
         "debug": "^4.3.7",
-        "eslint": "^9.15.0",
+        "eslint": "9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-plugin-import": "^2.31.0",
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
       "dev": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.4",
@@ -672,9 +672,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
-      "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2674,26 +2674,26 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
-      "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.15.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.7.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.14.0",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",
@@ -2712,7 +2712,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
+        "optionator": "^0.9.3",
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -6033,6 +6034,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^8.14.0",
     "caller": "^1.1.0",
     "debug": "^4.3.7",
-    "eslint": "^9.15.0",
+    "eslint": "9.14.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.31.0",

--- a/tests/parse/index.ts
+++ b/tests/parse/index.ts
@@ -11,9 +11,10 @@ import {
 } from "tests/types";
 import { REPO_ROOT } from "tests/utils";
 import { getTrunkVersion } from "tests/utils/trunk_config";
+import YAML from "yaml";
 
 const RESULTS_FILE = path.resolve(REPO_ROOT, "results.json");
-const FAILURES_FILE = path.resolve(REPO_ROOT, "failures.json");
+const FAILURES_FILE = path.resolve(REPO_ROOT, "failures.yaml");
 const RERUN_FILE = path.resolve(REPO_ROOT, "reruns.txt");
 
 const VALIDATED_LINTER_BLOCKLIST: string[] = [];
@@ -299,10 +300,11 @@ const writeFailuresForNotification = (failures: FailedVersion[]) => {
   const blocks = allBlocks.length > 50 ? allBlocks.slice(0, 49).concat(remainingBlock) : allBlocks;
 
   const failuresObject = {
+    channel: process.env.SLACK_CHANNEL_ID,
     text: `${failures.length} failures encountered running plugins tests for ${TEST_REF}`,
     blocks,
   };
-  const failuresString = JSON.stringify(failuresObject);
+  const failuresString = YAML.stringify(failuresObject);
   fs.writeFileSync(FAILURES_FILE, failuresString);
   console.log(`Wrote ${failures.length} failures out to ${FAILURES_FILE}:`);
   console.log(failuresString);


### PR DESCRIPTION
[`v2.0.0`](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0) changed the payload schema to use YAML, along with a few other schema changes.

I also disabled the nightly Windows linter tests since they're not providing any signal atm.

Also rolls back an eslint upgrade from https://github.com/trunk-io/plugins/pull/918