### PR TITLE
(Fix): Upgrade node to 18.20.5

### DIFF
--- a/runtimes/node/plugin.yaml
+++ b/runtimes/node/plugin.yaml
@@ -59,7 +59,7 @@ runtimes:
         - name: NODE_OPTIONS
           value: ${env.NODE_OPTIONS}
           optional: true
-      known_good_version: 18.12.1
+      known_good_version: 18.20.5
       version_commands:
         - run: node --version
           parse_regex: ${semver}

--- a/tests/driver/lint_driver.ts
+++ b/tests/driver/lint_driver.ts
@@ -94,7 +94,7 @@ runtimes:
   enabled:
     # required in order to query latest
     - go@1.21.0
-    - node@18.12.1
+    - node@18.20.5
     - python@3.10.8
     - ruby@3.1.4
 plugins:


### PR DESCRIPTION
Upgrades to LTS for v18 to fix [error](https://github.com/trunk-io/plugins/actions/runs/12253712255/job/34183042496) with prisma install. 