### PR TITLE
Update cuda source file types

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -170,6 +170,18 @@ lint:
         - slashes-block
 
     - name: cuda
+      inherit:
+        - cuda-header
+        - cuda-source
+
+    - name: cuda-header
+      extensions:
+        - cuh
+      comments:
+        - slashes-block
+        - slashes-inline
+
+    - name: cuda-source
       extensions:
         - cu
       comments:


### PR DESCRIPTION
Replicates the file type structure from C files to Cuda files.

* Source file convention remains `*.cu`
* Header file convention is added to include `*.cuh` files

The community-adopted `*.cuh` convention is exemplified in many large-scale public repositories, [including torch](https://github.com/search?q=repo%3Apytorch%2Fpytorch%20path%3A*.cuh&type=code).