### PR TITLE
Ignore *.dockerignore files as they do not conform to the Dockerfile spec

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -202,7 +202,7 @@ lint:
         # ?: is a non-capturing group, so that the RE2 DFA is more memory efficient
         # NOTE(Tyler): This is more strict than it realistically needs to be, but this partial match
         # and the file extensions provide a general enough capture.
-        - (?i)(?:^|/)Dockerfile\..+$
+        - (?i)(?:^|/)Dockerfile\.(?!.*\.dockerignore$).+$
       filenames:
         - dockerfile
         - Dockerfile


### PR DESCRIPTION
[Docker supports ignore files](https://docs.docker.com/build/concepts/context/#dockerignore-files) to keep build contexts clean.

The current configuration ignores the generic `.dockerignore` as expected, [but attempts to lint Dockerfile-specific configurations](https://docs.docker.com/build/concepts/context/#filename-and-location) such as `Dockerfile.dockerignore`, `test.Dockerfile.dockerignore` and `Dockerfile.build.dockerignore`.

This PR aims to resolve this bug.