### PR TITLE
(Fix): Remove tf.json filetype from terraform

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -592,7 +592,6 @@ lint:
     - name: terraform
       extensions:
         - tf
-        - tf.json
       comments:
         - hash
         - slashes-inline


### PR DESCRIPTION
Fixes https://github.com/trunk-io/plugins/issues/941. Verified repro with terraform and tofu format on `x.tf.json` files. Did a bit of research as well to make sure our other security scanners don't scan `.tf.json` files, and we should be fine.