### PR TITLE
Add support for `biome.jsonc` configuration file

### DIFF
--- a/linters/biome/plugin.yaml
+++ b/linters/biome/plugin.yaml
@@ -39,6 +39,7 @@ lint:
       suggest_if: config_present
       direct_configs:
         - biome.json
+        - biome.jsonc
         - rome.json # For backwards compatibility with rome
       affects_cache:
         - package.json


### PR DESCRIPTION
Since `v1.6`, Biome [supports .jsonc for its configuration file](https://biomejs.dev/blog/biome-v1-6/#support-for-biomejsonc).