### PR TITLE
feat: adds terraform-docs action ⚡

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ trunk actions enable {action}
 | [`go-mod-tidy-vendor`](actions/go-mod-tidy-vendor/README.md)                                                                                                                     | automatically tidy and vendor go.mod file                  |
 | [`git-blame-ignore-revs`](actions/git-blame-ignore-revs/README.md)                                                                                                               | automatically configure git to use .git-blame-ignore-revs  |
 | [`npm-check`](actions/npm-check/README.md)                                                                                                                                       | check whether NPM installation is up to date               |
+| [`terraform-docs`](actions/terraform-docs/README.md)                                                                                                                             | generate documentation from Terraform modules              |
 | [`poetry-check`](actions/poetry/README.md), [`poetry-lock`](actions/poetry/README.md), [`poetry-export`](actions/poetry/README.md), [`poetry-install`](actions/poetry/README.md) | hooks to enforce poetry configuration                      |
 | [`yarn-check`](actions/yarn-check/README.md)                                                                                                                                     | check whether Yarn installation is up to date              |
 

--- a/actions/terraform-docs/README.md
+++ b/actions/terraform-docs/README.md
@@ -1,0 +1,13 @@
+# terraform-docs
+
+Generate documentation from Terraform modules in various output formats. Read more about
+terraform-docs [here](https://terraform-docs.io).
+
+This action is intended to be used only with output mode as `inject` with `README.md` files as the
+target. You can configure terraform-docs via a `.terraform-docs.yml` file at the root of your
+repository. Read more about the configuration
+[here](https://terraform-docs.io/user-guide/configuration/).
+
+Is markdownlint causing consistent diffs in your README files? Try using the < !--
+markdownlint-disable --> and < !-- markdownlint-enable --> comments to disable and re-enable
+markdownlint for your terraform-docs section of your README.

--- a/actions/terraform-docs/plugin.yaml
+++ b/actions/terraform-docs/plugin.yaml
@@ -1,0 +1,10 @@
+version: 0.1
+actions:
+  definitions:
+    - id: terraform-docs
+      display_name: Terraform Docs
+      description: Generate documentation from Terraform modules in various output formats
+      runtime: python
+      triggers:
+        - git_hooks: [pre-commit]
+      run: python ${cwd}/terraform-docs.py

--- a/actions/terraform-docs/terraform-docs.py
+++ b/actions/terraform-docs/terraform-docs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Trunk.io plugin for terraform-docs integration.
+
+This script acts as a pre-commit hook to ensure terraform documentation is up to date.
+It performs the following:
+1. Runs terraform-docs to update documentation
+2. Checks if any README.md files show up in the unstaged changes
+3. Exits with failure if there are unstaged README changes, success otherwise
+"""
+
+# trunk-ignore(bandit/B404)
+import subprocess
+import sys
+
+
+def run_command(cmd):
+    """
+    Execute a shell command and return its exit code, stdout, and stderr.
+
+    Args:
+        cmd: List of command arguments to execute
+
+    Returns:
+        Tuple containing (return_code, stdout, stderr)
+    """
+    try:
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            # trunk-ignore(bandit/B603)
+            shell=False,  # Explicitly disable shell to prevent command injection
+        )
+        stdout, stderr = process.communicate()
+        return process.returncode, stdout, stderr
+    except FileNotFoundError:
+        print(
+            f"terraform-docs error: {cmd[0]} not found. Please ensure it's installed and in your PATH"
+        )
+        sys.exit(1)
+    except Exception as e:
+        print(f"terraform-docs error: Executing command {' '.join(cmd)}: {e}")
+        sys.exit(1)
+
+
+# First, run terraform-docs to update documentation
+update_cmd = ["terraform-docs", "."]
+return_code, stdout, stderr = run_command(update_cmd)
+
+if stderr:
+    print(f"terraform-docs error: Warning during execution:\n{stderr}", file=sys.stderr)
+
+# Check git status for unstaged README changes
+status_cmd = ["git", "status", "--porcelain"]
+return_code, stdout, stderr = run_command(status_cmd)
+
+# Look for any README.md files in the unstaged changes
+unstaged_readmes = [
+    line.split()[-1]
+    for line in stdout.splitlines()
+    if line.startswith(" M") and line.endswith("README.md")
+]
+
+# Check if we found any unstaged README files
+if len(unstaged_readmes) > 0:
+    print("terraform-docs error: Please stage any README changes before committing.")
+    sys.exit(1)
+
+print("terraform-docs: Documentation is up to date")
+sys.exit(0)


### PR DESCRIPTION
## Info

* Adds terraform-docs as an action to support automatically generating + updating terraform module documentation for terraform projects.
  * Closes https://github.com/trunk-io/plugins/issues/681
  * This is working well locally.
* Adding terraform-docs support via this PR in favor of #946
* Question: Is there a way to ensure that trunk installs `terraform-docs`? I only see a [`tools` declaration for `commitizen`](https://github.com/trunk-io/plugins/blob/main/actions/commitizen/plugin.yaml#L13-L24) and I'm unsure if I can enforce that the user is using [tools/terraform-docs](https://github.com/trunk-io/plugins/tree/main/tools/terraform-docs). What am I missing there?