### PR TITLE
fix: use python3 as executable for tf-docs script

### DIFF
--- a/actions/terraform-docs/plugin.yaml
+++ b/actions/terraform-docs/plugin.yaml
@@ -7,4 +7,4 @@ actions:
       runtime: python
       triggers:
         - git_hooks: [pre-commit]
-      run: python ${cwd}/terraform-docs.py
+      run: python3 ${cwd}/terraform-docs.py


### PR DESCRIPTION
## Info

* Follow up from #966 - Executing `python` doesn't do the trick, the executable needs to be `python3`