### PR TITLE
(Docs): Add lint ignore conversion guide

### DIFF
--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -115,7 +115,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some ${{ inputs.results-prefix }}test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }} >"
+                  text: "Failure: <https://github.com/trunk-io/plugins/actions/runs/${{ github.run_id }}| Unable to download some ${{ inputs.results-prefix }}test result artifacts (ubuntu: ${{ steps.download-ubuntu.outcome }}, macos: ${{ steps.download-macos.outcome }})>"
 
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -53,6 +53,9 @@ lint:
       paths:
         - "**/test_data" # required for golangci-lint, which runs on directories
         - "**/test_data/**"
+  threshold:
+    - linters: [trunk]
+      level: high
 
 actions:
   # Uncomment to enable more verbose action logs

--- a/linters/eslint/README.md
+++ b/linters/eslint/README.md
@@ -76,4 +76,6 @@ alert("foo");
 ### Notes
 
 Only `eslint-disable-line` and `eslint-disable-next-line` support `//` comments. All other
-ESLint-style ignores must use `/* */` comments.
+ESLint-style ignores must use `/* */` comments. The full set of rules and their applicable files can
+be configured in an
+[eslint config file](https://eslint.org/docs/latest/use/configure/rules#using-configuration-files).

--- a/linters/eslint/README.md
+++ b/linters/eslint/README.md
@@ -6,3 +6,74 @@
 [migration guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-config)) in order to run.
 Trunk will automatically detect which config file you have and by default will only enable a
 compatible version.
+
+## Ignores
+
+Here is a conversion guide for
+[ESLint-style ignores](https://eslint.org/docs/latest/use/configure/rules#disabling-rules) and
+[trunk-ignores](https://docs.trunk.io/code-quality/linters/ignoring-issues-and-files):
+
+### Same Line
+
+```typescript
+alert("foo"); // trunk-ignore(eslint)
+
+alert("foo"); // eslint-disable-line
+```
+
+### Next Line
+
+```typescript
+// trunk-ignore(eslint)
+alert("foo");
+
+/* eslint-disable-next-line */
+alert("foo");
+```
+
+### Specific Issue
+
+```typescript
+// trunk-ignore(eslint/no-alert)
+alert("foo");
+
+/* eslint-disable-next-line no-alert */
+alert("foo");
+```
+
+### Multiple Issues
+
+```typescript
+// trunk-ignore(eslint/no-alert,eslint/quotes)
+alert("foo");
+
+/* eslint-disable-next-line no-alert, quotes */
+alert("foo");
+```
+
+### Blocks
+
+```typescript
+// trunk-ignore-begin(eslint/no-alert)
+alert("foo");
+// trunk-ignore-end(eslint/no-alert)
+
+/* eslint-disable no-alert */
+alert("foo");
+/* eslint-enable no-alert */
+```
+
+### Whole File
+
+```typescript
+// trunk-ignore-all(eslint/no-alert)
+alert("foo");
+
+/* eslint-disable no-alert */
+alert("foo");
+```
+
+### Notes
+
+Only `eslint-disable-line` and `eslint-disable-next-line` support `//` comments. All other
+ESLint-style ignores must use `/* */` comments.

--- a/linters/markdownlint/README.md
+++ b/linters/markdownlint/README.md
@@ -1,0 +1,79 @@
+# markdownlint
+
+## Ignores
+
+Here is a conversion guide for
+[markdownlint-style ignores](https://github.com/DavidAnson/markdownlint/blob/main/README.md#configuration)
+and [trunk-ignores](https://docs.trunk.io/code-quality/linters/ignoring-issues-and-files):
+
+### Same Line
+
+```markdown
+# (name)[link] <!-- trunk-ignore(markdownlint) -->
+
+# (name)[link] <!-- markdownlint-disable-line -->
+```
+
+### Next Line
+
+```markdown
+<!-- trunk-ignore(markdownlint) -->
+
+# (name)[link]
+
+<!-- markdownlint-disable-next-line -->
+
+# (name)[link]
+```
+
+### Specific Issue
+
+```markdown
+<!-- trunk-ignore(markdownlint/MD011) -->
+
+# (name)[link]
+
+<!-- markdownlint-disable-next-line MD011 -->
+
+# (name)[link]
+```
+
+### Multiple Issues
+
+```markdown
+<!-- trunk-ignore(markdownlint/MD001,markdownlint/MD011) -->
+
+# (name)[link]
+
+<!-- markdownlint-disable-next-line MD001 MD011 -->
+
+# (name)[link]
+```
+
+### Blocks
+
+```markdown
+<!-- trunk-ignore-begin(markdownlint/MD011) -->
+
+# (name)[link]
+
+<!-- trunk-ignore-end(markdownlint/MD011) -->
+
+<!-- markdownlint-disable MD011 -->
+
+# (name)[link]
+
+<!-- markdownlint-enable MD011 -->
+```
+
+### Whole File
+
+```markdown
+<!-- trunk-ignore-all(markdownlint/MD011) -->
+
+# (name)[link]
+
+<!-- markdownlint-disable MD011 -->
+
+# (name)[link]
+```

--- a/linters/markdownlint/README.md
+++ b/linters/markdownlint/README.md
@@ -77,3 +77,8 @@ and [trunk-ignores](https://docs.trunk.io/code-quality/linters/ignoring-issues-a
 
 # (name)[link]
 ```
+
+### Notes
+
+Specific rules and multi-file ignores can be specified in a
+[markdownlint config file](https://github.com/DavidAnson/markdownlint#optionsconfig).

--- a/linters/mypy/README.md
+++ b/linters/mypy/README.md
@@ -21,6 +21,7 @@ x: str = 1  # type: ignore
 x: str = 1
 
 # Unsupported in mypy
+x: str = 1
 ```
 
 ### Specific Issue
@@ -47,6 +48,7 @@ x: str = 1
 # trunk-ignore-end(mypy/assigment)
 
 # Unsupported in mypy
+x: str = 1
 ```
 
 ### Whole File
@@ -58,3 +60,8 @@ x: str = 1
 # mypy: disable-error-code="assignment"
 x: str = 1
 ```
+
+### Notes
+
+The applied linter rules can be specified in a
+[mypy config file](https://mypy.readthedocs.io/en/stable/config_file.html#example-mypy-ini).

--- a/linters/mypy/README.md
+++ b/linters/mypy/README.md
@@ -1,0 +1,60 @@
+# mypy
+
+## Ignores
+
+Here is a conversion guide for
+[mypy-style ignores](https://mypy.readthedocs.io/en/stable/common_issues.html#spurious-errors-and-locally-silencing-the-checker)
+and [trunk-ignores](https://docs.trunk.io/code-quality/linters/ignoring-issues-and-files):
+
+### Same Line
+
+```python
+x: str = 1  # trunk-ignore(mypy)
+
+x: str = 1  # type: ignore
+```
+
+### Next Line
+
+```python
+# trunk-ignore(mypy)
+x: str = 1
+
+# Unsupported in mypy
+```
+
+### Specific Issue
+
+```python
+x: str = 1  # trunk-ignore(mypy/assignment)
+
+x: str = 1  # type: ignore[assignment]
+```
+
+### Multiple Issues
+
+```python
+x: str = 1  # trunk-ignore(mypy/assignment,mypy/note)
+
+x: str = 1  # type: ignore[assignment, note]
+```
+
+### Blocks
+
+```python
+# trunk-ignore-begin(mypy/assigment)
+x: str = 1
+# trunk-ignore-end(mypy/assigment)
+
+# Unsupported in mypy
+```
+
+### Whole File
+
+```python
+# trunk-ignore-all(mypy/assigment)
+x: str = 1
+
+# mypy: disable-error-code="assignment"
+x: str = 1
+```

--- a/linters/ruff/README.md
+++ b/linters/ruff/README.md
@@ -1,0 +1,65 @@
+# ruff
+
+## Ignores
+
+Here is a conversion guide for
+[ruff-style ignores](https://docs.astral.sh/ruff/linter/#disabling-fixes) and
+[trunk-ignores](https://docs.trunk.io/code-quality/linters/ignoring-issues-and-files):
+
+### Same Line
+
+```python
+x = 1  # trunk-ignore(ruff)
+
+x = 1  # noqa
+```
+
+### Next Line
+
+```python
+# trunk-ignore(ruff)
+x = 1
+
+# Unsupported in ruff
+```
+
+### Specific Issue
+
+```python
+x = 1  # trunk-ignore(ruff/F841)
+
+x = 1  # noqa: F841
+```
+
+### Multiple Issues
+
+```python
+x = 1  # trunk-ignore(ruff/E741,ruff/F841)
+
+x = 1  # noqa: E741, F841
+```
+
+### Blocks
+
+```python
+# trunk-ignore-begin(ruff/F841)
+x = 1
+# trunk-ignore-end(ruff/F841)
+
+# Unsupported in ruff
+```
+
+### Whole File
+
+```python
+# trunk-ignore-all(ruff/F841)
+x = 1
+
+# ruff: noqa: F841
+x = 1
+```
+
+### Notes
+
+You can also configure which rules to use and which files to apply them to using
+[ruff config files](https://docs.astral.sh/ruff/settings/#lint_per-file-ignores).

--- a/linters/ruff/README.md
+++ b/linters/ruff/README.md
@@ -21,6 +21,7 @@ x = 1  # noqa
 x = 1
 
 # Unsupported in ruff
+x = 1
 ```
 
 ### Specific Issue
@@ -47,6 +48,7 @@ x = 1
 # trunk-ignore-end(ruff/F841)
 
 # Unsupported in ruff
+x = 1
 ```
 
 ### Whole File


### PR DESCRIPTION
A user requested a comparison of ignore capabilities and styles for some of our top python linters. 

For now, I've added repo docs on this for:
- ruff
- mypy
- markdownlint
- eslint