### PR TITLE
(Fix): Forward env var for git-lfs

### DIFF
--- a/actions/git/plugin.yaml
+++ b/actions/git/plugin.yaml
@@ -14,5 +14,7 @@ actions:
         - name: SSH_AGENT_PID
           value: ${env.SSH_AGENT_PID}
           optional: true
-
+        - name: GITHUB_SERVER_URL
+          value: ${env.GITHUB_SERVER_URL}
+          optional: true
       notify_on_error: false


### PR DESCRIPTION
This is required for codespaces to work when using the git-lfs pre-commit Trunk Action