### PR TITLE
(Fix): Change dockerfile regex to match re2

### DIFF
--- a/linters/hadolint/test_data/hadolint_v2.10.0_CUSTOM.check.shot
+++ b/linters/hadolint/test_data/hadolint_v2.10.0_CUSTOM.check.shot
@@ -31,6 +31,15 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "fileGroupName": "docker",
       "linter": "hadolint",
       "paths": [
+        "test_data/Dockerfile.empty",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
@@ -41,6 +50,15 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "linter": "hadolint",
       "paths": [
         "test_data/empty.Dockerfile",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
+        "test_data/nested/Dockerfile.debug",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
@@ -77,6 +95,16 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "fileGroupName": "docker",
       "linter": "hadolint",
       "paths": [
+        "test_data/Dockerfile.empty",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "upstream": true,
@@ -88,6 +116,16 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "linter": "hadolint",
       "paths": [
         "test_data/empty.Dockerfile",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
+        "test_data/nested/Dockerfile.debug",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",

--- a/linters/hadolint/test_data/hadolint_v2.12.1-beta_CUSTOM.check.shot
+++ b/linters/hadolint/test_data/hadolint_v2.12.1-beta_CUSTOM.check.shot
@@ -31,6 +31,15 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "fileGroupName": "docker",
       "linter": "hadolint",
       "paths": [
+        "test_data/Dockerfile.empty",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "verb": "TRUNK_VERB_CHECK",
@@ -41,6 +50,15 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "linter": "hadolint",
       "paths": [
         "test_data/empty.Dockerfile",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
+        "test_data/nested/Dockerfile.debug",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
@@ -77,6 +95,16 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "fileGroupName": "docker",
       "linter": "hadolint",
       "paths": [
+        "test_data/Dockerfile.empty",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
         "test_data/basic.Dockerfile",
       ],
       "upstream": true,
@@ -88,6 +116,16 @@ exports[`Testing linter hadolint test CUSTOM 1`] = `
       "linter": "hadolint",
       "paths": [
         "test_data/empty.Dockerfile",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "docker",
+      "linter": "hadolint",
+      "paths": [
+        "test_data/nested/Dockerfile.debug",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",

--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -221,8 +221,7 @@ lint:
         # ?: is a non-capturing group, so that the RE2 DFA is more memory efficient
         # NOTE(Tyler): This is more strict than it realistically needs to be, but this partial match
         # and the file extensions provide a general enough capture.
-        # Note that re2 does not support ?!, so this does not capture all correct cases.
-        - (?i)(?:^|/)Dockerfile\.(?!.*\.dockerignore$).+$
+        - (?i)(?:^|/)Dockerfile\..+$
       filenames:
         - dockerfile
         - Dockerfile
@@ -707,3 +706,6 @@ lint:
 
     - linters: [osv-scanner]
       paths: ["**/go.sum"]
+
+    - linters: [checkov, hadolint, snyk, terrascan, trivy]
+      paths: ["**/*.dockerignore"]


### PR DESCRIPTION
Reverts #943 and also adds an ignore to handle the original request

Fixes the error log `Error parsing '(?i)(?:^|/)Dockerfile\.(?!.*\.dockerignore$).+$': invalid perl operator: (?!`, since re2 doesn't support negative matches. Tested that the log is no longer there and `trunk check query` produces the correct LQRs