### PR TITLE
(Debug): Break tests for testing purposes

### DIFF
--- a/linters/prettier/plugin.yaml
+++ b/linters/prettier/plugin.yaml
@@ -11,7 +11,6 @@ lint:
     - name: prettier
       files:
         - typescript
-        - yaml
         - css
         - postcss
         - sass

--- a/linters/pylint/plugin.yaml
+++ b/linters/pylint/plugin.yaml
@@ -12,6 +12,7 @@ lint:
       files: [python]
       description: Static code analysis for Python
       commands:
+        # lint should not be flaky
         - name: lint
           # Custom parser type defined in the trunk cli to handle pylint's JSON output.
           output: pylint

--- a/linters/ruff/test_data/ruff_v0.2.1_format.fmt.shot
+++ b/linters/ruff/test_data/ruff_v0.2.1_format.fmt.shot
@@ -6,6 +6,7 @@ exports[`Testing formatter ruff test format 1`] = `
 # A malindented comment
 if __name__ == "__main__":
     a = 4 + 1
+
     b = 2 * 7
     c = [1, 2, 3]
     print(a / b)

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -692,6 +692,12 @@ export const linterCheckTest = ({
   postCheck?: TestCallback;
   manualVersionReplacer?: (version: string) => string;
 }) => {
+  if (linterName.startsWith("pretty")) {
+    throw new Error("`linterCheckTest` is not supported for pretty linters");
+  }
+  if (linterName.startsWith("bio")) {
+    throw new Error("`linterCheckTest` is not supported for bio linters");
+  }
   // Step 1a: Detect test files to run
   const linterTestTargets = detectTestTargets(dirname, namedTestPrefixes);
 


### PR DESCRIPTION
1. prettier: don't run on yaml files, also false positive of the test erroring on "pretty" linters
2. biome: hard-coded to fail and throw error
3. pylint: no change
4. ruff: snapshot changed