### PR TITLE
PHP needs more requirements to be setup on mac machines

### DIFF
--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -73,6 +73,7 @@ runs:
             sudo apt install -y php8.2-fpm php8.2-xml php8.2-mbstring php8.2-curl
             ;;
           macOS)
+            brew install powershell/tap/powershell
             brew install cpanminus
             cpanm YAML::PP Class::Tiny Perl::Critic
             brew unlink perl && brew link perl

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -73,9 +73,8 @@ runs:
             sudo apt install -y php8.2-fpm php8.2-xml php8.2-mbstring php8.2-curl
             ;;
           macOS)
-            brew install cpm
-            cpm install -g --no-test --color YAML::PP
-            cpm install -g --no-test --color Perl::Critic Perl::Tidy
+            brew install cpanminus
+            cpanm YAML::PP Class::Tiny Perl::Critic
             brew unlink perl && brew link perl
             brew install php gnupg
             ;;

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -74,6 +74,7 @@ runs:
             ;;
           macOS)
             brew install cpm
+            cpm install -g --no-test --color YAML::PP
             cpm install -g --no-test --color Perl::Critic Perl::Tidy
             brew unlink perl && brew link perl
             brew install php gnupg

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 
 # version used for local trunk runs and testing
 cli:
-  version: 1.22.11-beta.4
+  version: 1.22.12
   shell_hooks:
     enforce: true
 
@@ -17,7 +17,7 @@ plugins:
 
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v1.0.10
+      ref: v1.0.11
 
 lint:
   files:
@@ -42,7 +42,7 @@ lint:
   enabled:
     # enabled linters inherited from github.com/trunk-io/configs plugin
     - definition-checker
-    - eslint@9.20.1
+    - eslint@9.24.0
     - trunk-toolbox@0.5.4
   disabled:
     - pylint # pylint diagnostics are too strict

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -42,7 +42,7 @@ lint:
       files: [lockfile]
       tools: [osv-scanner]
       known_good_version: 2.0.1
-      description: Checks for known vulnerabilities in your dependencies
+      description: Checks for known vulnerabilities in your dependencies.
       commands:
         - name: scan
           output: sarif

--- a/linters/osv-scanner/plugin.yaml
+++ b/linters/osv-scanner/plugin.yaml
@@ -1,7 +1,7 @@
 version: 0.1
 downloads:
   - name: osv-scanner
-    version: 1.3.6
+    version: 2.0.1
     executable: true
     downloads:
       - os:
@@ -35,13 +35,13 @@ tools:
     - name: osv-scanner
       download: osv-scanner
       shims: [osv-scanner]
-      known_good_version: 1.3.6
+      known_good_version: 2.0.1
 lint:
   definitions:
     - name: osv-scanner
       files: [lockfile]
       tools: [osv-scanner]
-      known_good_version: 1.3.6
+      known_good_version: 2.0.1
       description: Checks for known vulnerabilities in your dependencies
       commands:
         - name: scan

--- a/linters/osv-scanner/test_data/bun.lock
+++ b/linters/osv-scanner/test_data/bun.lock
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "dependencies": {
+    "chalk@5.2.0": {
+      "integrity": "sha512-abc123...",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz"
+    },
+    "react@18.2.0": {
+      "integrity": "sha512-def456...",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+    },
+    "react-dom@18.2.0": {
+      "integrity": "sha512-ghi789...",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
+    }
+  }
+}

--- a/linters/osv-scanner/test_data/osv_scanner_v2.0.1_CUSTOM.check.shot
+++ b/linters/osv-scanner/test_data/osv_scanner_v2.0.1_CUSTOM.check.shot
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter osv-scanner test CUSTOM 1`] = `
+{
+  "issues": [],
+  "lintActions": [
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/Cargo.lock",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/Gemfile.lock",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/bun.lock",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/composer.lock",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/go.mod",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/requirements.txt",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "scan",
+      "fileGroupName": "lockfile",
+      "linter": "osv-scanner",
+      "paths": [
+        "test_data/yarn.lock",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -378,6 +378,10 @@ lint:
         # Conan (C++)
         - conan.lock
 
+        # csharp
+        - deps.json
+        - packages.config
+
         # Golang
         - go.mod
         - go.sum
@@ -385,6 +389,10 @@ lint:
         # Gradle (Android/Java/Kotlin)
         - buildscript-gradle.lockfile
         - gradle.lockfile
+
+        # Haskell
+        - cabal.project.freeze
+        - stack.yaml.lock
 
         # Maven
         - pom.xml
@@ -396,6 +404,7 @@ lint:
         - package-lock.json
         - pnpm-lock.yaml
         - yarn.lock
+        - bun.lock
 
         # NuGet (.NET)
         - packages.lock.json


### PR DESCRIPTION
1. Update testing framework to use cpanimus for better PHP testing support on mac
2. Update definitions of supported lockfiles to include ones now handeld by osv-scanner 2.0
3. Update osv-scanner to 2.0
4. New test snapshot for kube-linter
