### PR TITLE
Add Jpg, gif, pcap, tif, webp as file extensions

### DIFF
--- a/linters/plugin.yaml
+++ b/linters/plugin.yaml
@@ -345,7 +345,7 @@ lint:
       extensions:
         - jpg
         - jpeg
-        
+
     - name: json
       extensions:
         - json
@@ -680,11 +680,11 @@ lint:
         - slashes-inline
         - brace-slashes-block
         - brace-slashes-block-spaced
-        
+
     - name: webp
       extensions:
         - webp
-        
+
     - name: xib
       extensions:
         - xib


### PR DESCRIPTION
Add these following extensions. In our monorepo, we'd like to error on these files being added under git lfs and we'd like to make an upstream PR to remove these file definitions from our local trunk yaml config!