### PR TITLE
fix(cspell): add all missing but supported config paths

### DIFF
--- a/linters/cspell/plugin.yaml
+++ b/linters/cspell/plugin.yaml
@@ -77,7 +77,6 @@ lint:
         - cspell.jsonc
         - cspell.yaml
         - cspell.yml
-        - package.json
       affects_cache:
         - package.json
       known_good_version: 7.0.0

--- a/linters/cspell/plugin.yaml
+++ b/linters/cspell/plugin.yaml
@@ -24,17 +24,60 @@ lint:
           # NOTE(Tyler): cspell doesn't read symlinked config files, so we must create a copied sandbox.
           sandbox_type: copy_targets
       direct_configs:
-        - .cspell.json
-        - cspell.json
         - .cSpell.json
+        - .config/.cSpell.json
+        - .config/.cspell.config.cjs
+        - .config/.cspell.config.js
+        - .config/.cspell.config.json
+        - .config/.cspell.config.jsonc
+        - .config/.cspell.config.mjs
+        - .config/.cspell.config.yaml
+        - .config/.cspell.config.yml
+        - .config/.cspell.json
+        - .config/.cspell.jsonc
+        - .config/cSpell.json
+        - .config/cspell.config.cjs
+        - .config/cspell.config.js
+        - .config/cspell.config.json
+        - .config/cspell.config.jsonc
+        - .config/cspell.config.mjs
+        - .config/cspell.config.yaml
+        - .config/cspell.config.yml
+        - .config/cspell.json
+        - .config/cspell.jsonc
+        - .config/cspell.yaml
+        - .config/cspell.yml
+        - .cspell.config.cjs
+        - .cspell.config.js
+        - .cspell.config.json
+        - .cspell.config.jsonc
+        - .cspell.config.mjs
+        - .cspell.config.toml
+        - .cspell.config.yaml
+        - .cspell.config.yml
+        - .cspell.json
+        - .cspell.jsonc
+        - .cspell.yaml
+        - .cspell.yml
+        - .vscode/.cspell.json
+        - .vscode/cSpell.json
+        - .vscode/cspell.json
         - cSpell.json
-        - cspell.config.js
+        - config/.cspell.config.toml
+        - config/cspell.config.toml
         - cspell.config.cjs
+        - cspell.config.js
         - cspell.config.json
+        - cspell.config.jsonc
+        - cspell.config.mjs
+        - cspell.config.toml
         - cspell.config.yaml
         - cspell.config.yml
+        - cspell.json
+        - cspell.jsonc
         - cspell.yaml
         - cspell.yml
+        - package.json
       affects_cache:
         - package.json
       known_good_version: 7.0.0


### PR DESCRIPTION
I realised that cspell.config.mjs was not supported in my project.

Considering [cspell's possible config file paths](https://cspell.org/docs/getting-started#1-create-a-configuration-file), I realised that there are actually a lot and most are missing in the plugin.

When these paths are added, the plugin should work again, in any possible project setup.