### PR TITLE
update hadolint download urls for >=2.13.1

### DIFF
--- a/linters/hadolint/plugin.yaml
+++ b/linters/hadolint/plugin.yaml
@@ -7,25 +7,45 @@ downloads:
       - os: linux
         cpu: x86_64
         url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64
+        version: <2.13.1
       - os: linux
         cpu: arm_64
         url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-arm64
+        version: <2.13.1
       - os: macos
         cpu: x86_64
         url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
+        version: <2.13.1
       # Use rosetta
       - os: macos
         cpu: arm_64
         url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Darwin-x86_64
+        version: <2.13.1
       - os: windows
         cpu: x86_64
         url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Windows-x86_64.exe
+        version: <2.13.1
+      # >2.13.1 changed the download url
+      - os:
+          linux: linux
+          macos: macos
+        cpu:
+          x86_64: x86_64
+          arm_64: arm64
+        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${cpu}
+        version: ">=2.13.1"
+      - os:
+          windows: windows
+        cpu:
+          x86_64: x86_64
+        url: https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-${os}-${cpu}.exe
+        version: ">=2.13.1"
 tools:
   definitions:
     - name: hadolint
       download: hadolint
       shims: [hadolint]
-      known_good_version: 2.10.0
+      known_good_version: 2.13.1
 lint:
   definitions:
     - name: hadolint
@@ -47,7 +67,7 @@ lint:
         - name: PATH
           list: ["${linter}"]
       issue_url_format: https://github.com/hadolint/hadolint/wiki/{}
-      known_good_version: 2.10.0
+      known_good_version: 2.13.1
       suggest_if: files_present
       version_command:
         parse_regex: ${semver}


### PR DESCRIPTION
# Problem

Hadolint 2.13.1 is currently failing to install on arm64 Mac (likely others). It appears as though the naming conventions of the downloadable assets were changed in 2.13.1 - https://github.com/hadolint/hadolint/releases. There also appears to be no 2.13.0 tag 🤷 

```
trunk_cli_version: 1.25.0
title: "Error while executing: Installing hermetic tool hadolint v2.13.1"
report:
  - HTTP 404 'https://github.com/hadolint/hadolint/releases/download/v2.13.1/hadolint-Darwin-x86_64'
```

# Solution
I've added support for versions `>= 2.13.1` using the new paths.