### PR TITLE
fix(uv): validate config with ‎`uv lock --check`

### DIFF
--- a/actions/uv/plugin.yaml
+++ b/actions/uv/plugin.yaml
@@ -4,8 +4,8 @@ actions:
   definitions:
     - id: uv-check
       display_name: uv check
-      description: Run 'uv check' to validate the project configuration.
-      run: uv check
+      description: Run 'uv lock --check' to validate the project configuration.
+      run: uv lock --check
       triggers:
         - git_hooks: [pre-commit]
       environment:

--- a/actions/uv/uv.test.ts
+++ b/actions/uv/uv.test.ts
@@ -5,7 +5,7 @@ import { TrunkActionDriver } from "tests/driver";
 
 toolInstallTest({
   toolName: "uv",
-  toolVersion: "0.3",
+  toolVersion: "0.7.8",
 });
 
 const preCheck = (driver: TrunkActionDriver) => {

--- a/actions/uv/uv.test.ts
+++ b/actions/uv/uv.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { actionRunTest, toolInstallTest } from "tests";
@@ -33,6 +34,9 @@ dependencies = [
 ]
   `,
   );
+
+  // uv lock --check requires an existing lockfile; create it before the commit
+  execSync("uv lock", { cwd: driver.getSandbox(), stdio: "pipe" });
 };
 
 const checkTestCallback = async (driver: TrunkActionDriver) => {

--- a/actions/uv/uv.test.ts
+++ b/actions/uv/uv.test.ts
@@ -27,10 +27,10 @@ const preCheck = (driver: TrunkActionDriver) => {
 name = "uv-test"
 version = "0.1.0"
 description = ""
-
-[project.dependencies]
-python = "^3.12"
-pendulum = "^3.0.0"
+requires-python = ">=3.12"
+dependencies = [
+  "pendulum>=3.0.0",
+]
   `,
   );
 };


### PR DESCRIPTION
Change `uv check` to `uv lock --check` to fix the `uv-check` action - as `uv` does not have a `uv check` command  currently (see [here](https://github.com/astral-sh/uv/issues/9653)).