### PR TITLE
On MacOS use shellcheck without rosetta

### DIFF
--- a/linters/shellcheck/plugin.yaml
+++ b/linters/shellcheck/plugin.yaml
@@ -14,10 +14,9 @@ downloads:
         cpu: x86_64
         url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
         strip_components: 1
-      # Use rosetta
       - os: macos
         cpu: arm_64
-        url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.x86_64.tar.xz
+        url: https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.darwin.aarch64.tar.xz
         strip_components: 1
       # No windows release
 tools:


### PR DESCRIPTION
On MacOs use shellcheck on aarch64 without rosetta. There is simply no reason to use rosetta and not everyone has or wants to install it.