### PR TITLE
biome: fix silent failures (warnings + .gitignore in sandbox)

### DIFF
--- a/linters/biome/biome.test.ts
+++ b/linters/biome/biome.test.ts
@@ -26,3 +26,24 @@ linterCheckTest({
   namedTestPrefixes: ["warning_check"],
   preCheck: enableWarnRule,
 });
+
+// Verify .gitignore reaches the sandbox so vcs.useIgnoreFile works. Without
+// the symlinks: directive in plugin.yaml, biome aborts with internalError/fs
+// when it can't find the ignore file and silently drops all findings.
+// Regression coverage for trunk-io/plugins#1113 issue 2.
+const setupGitignoreRepo: TestCallback = (driver) => {
+  driver.writeFile(
+    "biome.json",
+    JSON.stringify({
+      $schema: "https://biomejs.dev/schemas/2.3.4/schema.json",
+      vcs: { clientKind: "git", enabled: true, useIgnoreFile: true },
+      linter: { enabled: true, rules: { recommended: true } },
+    }),
+  );
+  driver.writeFile(".gitignore", "");
+};
+linterCheckTest({
+  linterName: "biome",
+  namedTestPrefixes: ["gitignore_check"],
+  preCheck: setupGitignoreRepo,
+});

--- a/linters/biome/biome.test.ts
+++ b/linters/biome/biome.test.ts
@@ -1,5 +1,28 @@
-import { linterCheckTest, linterFmtTest } from "tests";
+import { linterCheckTest, linterFmtTest, TestCallback } from "tests";
 
 linterCheckTest({ linterName: "biome", namedTestPrefixes: ["basic_check"] });
 
 linterFmtTest({ linterName: "biome", namedTestPrefixes: ["basic_fmt", "basic_json"] });
+
+// Verify warning-level findings ('!' marker) are captured by parse_regex,
+// not just errors ('×'). Regression coverage for trunk-io/plugins#1113.
+const enableWarnRule: TestCallback = (driver) => {
+  driver.writeFile(
+    "biome.json",
+    JSON.stringify({
+      $schema: "https://biomejs.dev/schemas/2.3.4/schema.json",
+      linter: {
+        enabled: true,
+        rules: {
+          recommended: false,
+          style: { noNonNullAssertion: "warn" },
+        },
+      },
+    }),
+  );
+};
+linterCheckTest({
+  linterName: "biome",
+  namedTestPrefixes: ["warning_check"],
+  preCheck: enableWarnRule,
+});

--- a/linters/biome/plugin.yaml
+++ b/linters/biome/plugin.yaml
@@ -57,3 +57,10 @@ lint:
       version_command:
         parse_regex: biome CLI version ${semver}
         run: biome --version
+      symlinks:
+        # biome's vcs.useIgnoreFile reads .gitignore from the sandbox root.
+        # Without this, the per-target sandbox lacks .gitignore and biome
+        # aborts with internalError/fs, silently dropping all findings.
+        # See trunk-io/plugins#1113.
+        - from: ${workspace}/.gitignore
+          to: .gitignore

--- a/linters/biome/plugin.yaml
+++ b/linters/biome/plugin.yaml
@@ -22,9 +22,15 @@ lint:
       commands:
         - name: lint
           output: regex
+          # Match both errors (×) and warnings (!). The marker line must be
+          # the immediate next line (after a blank line) following the header,
+          # so each diagnostic is parsed as a self-contained block — the prior
+          # regex lazily matched across diagnostics and silently mis-attributed
+          # path/line/col to a different finding's message. Info-level (i) is
+          # intentionally excluded; biome surfaces those for hints, not gating.
           parse_regex:
-            ' *(?P<path>.*?):(?P<line>\d+):(?P<col>\d+) (?P<code>[^ ]+)(?:[^×]*\n).*×
-            (?P<message>.*)\n'
+            ' *(?P<path>[^\n]*?):(?P<line>\d+):(?P<col>\d+) (?P<code>[^ \n]+)[^\n]*\n[ \t]*\n[
+            \t]+[×!] (?P<message>[^\n]+)'
           run: biome check ${target}
           success_codes: [0, 1]
           batch: true

--- a/linters/biome/test_data/biome_v2.3.4_gitignore_check.check.shot
+++ b/linters/biome/test_data/biome_v2.3.4_gitignore_check.check.shot
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter biome test gitignore_check 1`] = `
+{
+  "issues": [
+    {
+      "code": "lint/correctness/noUnusedVariables",
+      "column": "7",
+      "file": "test_data/gitignore_check.in.ts",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "biome",
+      "message": "This variable unusedHelper is unused.",
+      "targetType": "typescript",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "fmt",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/gitignore_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/gitignore_check.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "biome",
+      "paths": [
+        "test_data/gitignore_check.in.ts",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/biome/test_data/biome_v2.3.4_warning_check.check.shot
+++ b/linters/biome/test_data/biome_v2.3.4_warning_check.check.shot
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing linter biome test basic_check 1`] = `
+exports[`Testing linter biome test warning_check 1`] = `
 {
   "issues": [
     {
-      "code": "lint/correctness/noUnusedVariables",
-      "column": "7",
-      "file": "test_data/basic_check.in.ts",
+      "code": "lint/style/noNonNullAssertion",
+      "column": "16",
+      "file": "test_data/warning_check.in.ts",
       "issueClass": "ISSUE_CLASS_EXISTING",
       "level": "LEVEL_HIGH",
-      "line": "6",
+      "line": "5",
       "linter": "biome",
-      "message": "This variable foo is unused.",
+      "message": "Forbidden non-null assertion.",
       "targetType": "typescript",
     },
   ],
@@ -21,7 +21,7 @@ exports[`Testing linter biome test basic_check 1`] = `
       "fileGroupName": "typescript",
       "linter": "biome",
       "paths": [
-        "test_data/basic_check.in.ts",
+        "test_data/warning_check.in.ts",
       ],
       "verb": "TRUNK_VERB_FMT",
     },
@@ -30,7 +30,7 @@ exports[`Testing linter biome test basic_check 1`] = `
       "fileGroupName": "typescript",
       "linter": "biome",
       "paths": [
-        "test_data/basic_check.in.ts",
+        "test_data/warning_check.in.ts",
       ],
       "verb": "TRUNK_VERB_CHECK",
     },
@@ -39,23 +39,13 @@ exports[`Testing linter biome test basic_check 1`] = `
       "fileGroupName": "typescript",
       "linter": "biome",
       "paths": [
-        "test_data/basic_check.in.ts",
+        "test_data/warning_check.in.ts",
       ],
       "upstream": true,
       "verb": "TRUNK_VERB_CHECK",
     },
   ],
   "taskFailures": [],
-  "unformattedFiles": [
-    {
-      "column": "1",
-      "file": "test_data/basic_check.in.ts",
-      "issueClass": "ISSUE_CLASS_UNFORMATTED",
-      "level": "LEVEL_HIGH",
-      "line": "1",
-      "linter": "biome",
-      "message": "Incorrect formatting, autoformat by running 'trunk fmt'",
-    },
-  ],
+  "unformattedFiles": [],
 }
 `;

--- a/linters/biome/test_data/gitignore_check.in.ts
+++ b/linters/biome/test_data/gitignore_check.in.ts
@@ -1,0 +1,2 @@
+const unusedHelper = (input: number) => input + 1;
+export const sample = 42;

--- a/linters/biome/test_data/warning_check.in.ts
+++ b/linters/biome/test_data/warning_check.in.ts
@@ -1,0 +1,6 @@
+// Triggers biome's lint/style/noNonNullAssertion at warning level when the
+// rule is enabled with `level: "warn"`. Verifies that the lint parse_regex
+// captures '!' (warning marker) findings, not just '×' (error marker).
+const value: number | null = null;
+const result = value!.toFixed();
+console.log(result);


### PR DESCRIPTION
## Summary

Two independent fixes for biome's lint integration that today cause findings to be silently dropped. Each commit stands alone.

### 1. Capture warning-level findings, anchor diagnostic block

`parse_regex` matched only `×` markers — every `!` warning dropped silently. It also lazily spanned newlines, occasionally correlating one diagnostic's path/line/col with a different diagnostic's message.

The new regex anchors each diagnostic to its own `header → blank line → marker` so captures stay self-contained, and accepts `×` and `!` as terminators. Info-level `i` is intentionally excluded — biome surfaces those as hints, not gating.

`basic_check` snapshot updated to the actual warning biome emits on the fixture (previously captured a cross-correlated result).

New `warning_check` test enables `noNonNullAssertion: warn` in `biome.json` to verify warnings reach the snapshot.

### 2. Symlink .gitignore into the lint sandbox

`vcs.useIgnoreFile: true` in `biome.json` makes biome require the workspace's `.gitignore` at its CWD. trunk's per-target sandbox doesn't include it, so biome aborts with `internalError/fs`, exits 1, and `success_codes: [0, 1]` swallows the error — every finding silently dropped.

Add a `symlinks:` directive that lands `\${workspace}/.gitignore` at the sandbox root next to `biome.json` (the only documented escape hatch — same pattern as remark-lint's `node_modules`). Covers a single root-level `.gitignore`; nested ignore files would each need their own entry (no glob form supported). Harmless when `useIgnoreFile` is unset.

New `gitignore_check` test sets `vcs.useIgnoreFile: true` + writes a `.gitignore`, then expects biome's stock `noUnusedVariables` finding. Adversarially verified: stash `plugin.yaml`, the test fails with `issues: []`.

## Test plan

- [x] All 5 biome tests pass at `KnownGoodVersion` (2.3.4): `basic_check`, `warning_check`, `gitignore_check`, `basic_fmt`, `basic_json`
- [x] Adversarial: stash regex change → `warning_check` fails with empty issues
- [x] Adversarial: stash symlinks change → `gitignore_check` fails with empty issues
- [x] Validated end-to-end against a downstream repo (joinhandshake/joinera) two ways:
  - As a `trunk.yaml` override of the published plugin (catches the violation that previously slipped CI)
  - With `plugins.sources` pointing at this branch (same result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)