### PR TITLE
clang-format: bump default and known_good_version to 20.1.0

### DIFF
--- a/linters/clang-format/plugin.yaml
+++ b/linters/clang-format/plugin.yaml
@@ -1,7 +1,16 @@
 version: 0.1
+# Binaries are hosted on the trunk.io CDN (small, clang-format-only tarballs).
+# Available versions per platform:
+#   14.0.1                            — linux-x86_64, macos-x86_64, macos-arm64
+#                                       (no linux-aarch64 build was published)
+#   16.0.3, 16.0.6                    — all four platforms
+#   17.0.1, 17.0.6                    — all four platforms
+#   18.1.8                            — all four platforms
+#   20.1.0                            — all four platforms
+# Any other version (e.g. 15.x, 19.x, 20.1.x>0, 21+) will 404.
 downloads:
   - name: clang-format
-    version: 14.0.1
+    version: 20.1.0
     downloads:
       # macos arm64 was introduced after this version.
       - os: macos
@@ -47,7 +56,7 @@ lint:
       tools: [clang-format]
       suggest_if: config_present
       direct_configs: [.clang-format]
-      known_good_version: 16.0.3
+      known_good_version: 20.1.0
       version_command:
         parse_regex: ${semver}
         run: clang-format --version


### PR DESCRIPTION
## Summary

- Move clang-format's default `version` from `14.0.1` and the lint `known_good_version` from `16.0.3` to `20.1.0`, the newest patch the trunk.io CDN actually hosts.
- Add a header comment in `plugin.yaml` enumerating the patches available per platform on the trunk.io CDN so future contributors can pick a working version without trial-and-error.

The `downloads:` block is structurally unchanged — only the default and the documented `known_good_version` move.

## Test plan

- [x] Pre-push hook runs `tests/repo_tests/{valid_package_download,config_check}.test.ts` — passed (228 tests, 1 snapshot).
- [ ] Snapshot update: the lint test currently uses `clang_format_v16.0.3_*.shot`; running with `known_good_version: 20.1.0` will regenerate snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)