### PR TITLE
Allow smoke testing pre-release analytics CLI via Actions variable

### DIFF
--- a/.github/actions/action_tests/action.yaml
+++ b/.github/actions/action_tests/action.yaml
@@ -19,6 +19,10 @@ inputs:
   trunk-prod-token:
     description: Test analytics prod api token (org token)
     required: false
+  analytics-cli-version:
+    description: Analytics uploader CLI version; 'latest' uses the uploader's own resolution
+    required: false
+    default: latest
 
 runs:
   # TODO(Tyler): See if this can be converted to a js action
@@ -89,5 +93,6 @@ runs:
         org-slug: trunk
         token: ${{ inputs.trunk-prod-token }}
         variant: ${{ runner.os }}
+        cli-version: ${{ inputs.analytics-cli-version }}
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io

--- a/.github/actions/linter_tests/action.yaml
+++ b/.github/actions/linter_tests/action.yaml
@@ -29,6 +29,10 @@ inputs:
   trunk-prod-token:
     description: Test analytics prod api token (org token)
     required: false
+  analytics-cli-version:
+    description: Analytics uploader CLI version; 'latest' uses the uploader's own resolution
+    required: false
+    default: latest
   ref-type:
     description: release or main
     required: false
@@ -123,5 +127,6 @@ runs:
         org-slug: trunk
         token: ${{ inputs.trunk-prod-token }}
         variant: ${{ runner.os }}
+        cli-version: ${{ inputs.analytics-cli-version }}
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io

--- a/.github/actions/tool_tests/action.yaml
+++ b/.github/actions/tool_tests/action.yaml
@@ -19,6 +19,10 @@ inputs:
   trunk-prod-token:
     description: Test analytics prod api token (org token)
     required: false
+  analytics-cli-version:
+    description: Analytics uploader CLI version; 'latest' uses the uploader's own resolution
+    required: false
+    default: latest
   ref-type:
     description: release or main
     required: false
@@ -85,5 +89,6 @@ runs:
         org-slug: trunk
         token: ${{ inputs.trunk-prod-token }}
         variant: ${{ runner.os }}
+        cli-version: ${{ inputs.analytics-cli-version }}
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk.io

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -70,6 +70,7 @@ jobs:
           snyk-token: ${{ secrets.TRUNK_SNYK_TOKEN }}
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   # Run tests against all linters for snapshots and latest version as they exist in latest release
   # This job is used to update the list of validated versions
@@ -176,6 +177,7 @@ jobs:
           snyk-token: ${{ secrets.TRUNK_SNYK_TOKEN }}
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
       - name: Upload Test Outputs for Upload Job
         # Only upload results from latest. Always run, except when cancelled.
@@ -236,6 +238,7 @@ jobs:
         with:
           append-args: tools -- --json --outputFile=${{ matrix.results-file }}-res.json
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
       - name: Upload Test Outputs for Notification Job
         # Always run, except when cancelled.
@@ -281,3 +284,4 @@ jobs:
         uses: ./.github/actions/action_tests
         with:
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -157,6 +157,7 @@ jobs:
             ${{ needs.detect_changes.outputs.all-linters }} ${{
             needs.detect_changes.outputs.linters-files }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
       - name: Linter Tests Latest
         # Run tests on Latest with any modified linters (see filters.yaml). Don't run when cancelled.
@@ -171,6 +172,7 @@ jobs:
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           append-args: ${{ needs.detect_changes.outputs.linters-files }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   tool_tests:
     name: Tool Tests
@@ -197,6 +199,7 @@ jobs:
             ${{ needs.detect_changes.outputs.all-tools }} ${{
             needs.detect_changes.outputs.tools-files }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   action_tests:
     name: Action Tests
@@ -217,6 +220,7 @@ jobs:
             ${{ needs.detect_changes.outputs.all-actions }} ${{
             needs.detect_changes.outputs.actions-files }} --
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   trunk_check_runner:
     name: Trunk Check runner [linux]
@@ -265,6 +269,7 @@ jobs:
           cli-path: ${{ github.workspace }}\trunk.ps1
           append-args: ${{needs.detect_changes.outputs.linters-files }} -- --maxWorkers=5
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   # TODO(Tyler): Re-add Windows runners.
   windows_tool_tests:
@@ -290,6 +295,7 @@ jobs:
           append-args: ${{needs.detect_changes.outputs.tools-files }} -- --maxWorkers=5
           cli-path: ${{ github.workspace }}\trunk.ps1
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   # Run repo healthcheck tests
   repo_tests:

--- a/.github/workflows/upload_results.reusable.yaml
+++ b/.github/workflows/upload_results.reusable.yaml
@@ -216,6 +216,7 @@ jobs:
           snyk-token: ${{ secrets.TRUNK_SNYK_TOKEN }}
           sourcery-token: ${{ secrets.TRUNK_SOURCERY_TOKEN }}
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
         env:
           PLUGINS_TEST_UPDATE_SNAPSHOTS: "true"
 

--- a/.github/workflows/windows_nightly.yaml
+++ b/.github/workflows/windows_nightly.yaml
@@ -52,6 +52,7 @@ jobs:
           append-args: linters -- --maxWorkers=5
           # Analytics uploader is not yet supported on Windows
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}
 
   tool_tests_main:
     name: Tool Tests Main
@@ -91,3 +92,4 @@ jobs:
           append-args: tools -- --maxWorkers=5
           # Analytics uploader is not yet supported on Windows
           trunk-prod-token: ${{ secrets.TRUNK_ORG_PROD_TOKEN }}
+          analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}


### PR DESCRIPTION
## What

Adds an org-wide escape hatch for exercising a specific (e.g. pre-release) **analytics CLI** build in the test-result uploads, without a code change. Set the `ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION` Actions variable to a version and every `analytics-uploader` invocation uses it; set it to `latest` (the default) and the uploader resolves latest itself.

Mirrors the change in `trunk-io/trunk2`, `trunk-io/trunk`, and `trunk-io/chimerarepo`.

## ⚠️ Input name: `analytics-cli-version` (not `cli-version`)

These composite actions **already have a `cli-version` input**, but it means *the trunk CLI under test* (`PLUGINS_TEST_CLI_VERSION`) — unrelated to the analytics uploader. To avoid a collision, the new input is named **`analytics-cli-version`**.

## Why it's threaded through inputs, not `vars` directly

The uploader lives inside the `linter_tests`, `tool_tests`, and `action_tests` composite actions, and the `vars` context is **not readable inside composite actions**. So an `analytics-cli-version` input (default `latest`) is added to each, and `${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}` is passed at every call site. The uploader step forwards it: `cli-version: ${{ inputs.analytics-cli-version }}`.

## Behavior

| `ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION` | `cli-version` used |
|---|---|
| `latest` (default) | passed to the uploader, which resolves latest itself |
| e.g. `0.14.0.pre.beta.2` | that exact version |

These steps previously set no `cli-version`, so the `latest` default is behavior-preserving.

## Changes

- **`.github/actions/{linter_tests,tool_tests,action_tests}/action.yaml`** — new `analytics-cli-version` input (default `latest`); `Upload prod results` step now sets `cli-version: ${{ inputs.analytics-cli-version }}`.
- **Call sites (13)** pass `analytics-cli-version: ${{ vars.ANALYTICS_CLI_PRE_RELEASE_TEST_VERSION }}`: `pr.yaml` (6), `nightly.yaml` (4), `windows_nightly.yaml` (2), `upload_results.reusable.yaml` (1).

## Notes / scope

- Wired at **all** call sites uniformly, including the Windows jobs (`windows_nightly.yaml` and the disabled `windows_*` jobs in `pr.yaml`). The uploader step is gated `runner.os != 'Windows'`, so those are harmless no-ops today — but consistent and ready if Windows upload is enabled.
- **Out of scope:** `upload_results.reusable.yaml`'s `trunk upload-linter-versions` step is a plugins-specific upload (not the analytics-uploader) and is untouched. The lone `Gemfile` (`linters/brakeman/test_data/`) is linter *test fixture* data, not a CI rspec flow.
- I could not run `trunk check` / `trunk fmt` locally (the sandbox proxy blocks `get.trunk.io`); edits match existing indentation and were validated with a YAML parser; the repo's Trunk Check on the PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qcw8v8TiTHRGdDSH7J3ia)_