### PR TITLE
feat: add Oxlint linter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ trunk check enable {linter}
 | HAML            | [haml-lint]                                                                                                                              |
 | HTML Templates  | [djlint]                                                                                                                                 |
 | Java            | [google-java-format], [pmd], [semgrep]                                                                                                   |
-| Javascript      | [biome], [deno], [eslint], [prettier], [rome], [semgrep]                                                                                 |
+| Javascript      | [biome], [deno], [eslint], [oxlint], [prettier], [rome], [semgrep]                                                                       |
 | JSON            | [biome], [deno], [eslint], [prettier], [semgrep]                                                                                         |
 | Kotlin          | [detekt], [ktlint]                                                                                                                       |
 | Kubernetes      | [kube-linter]                                                                                                                            |
@@ -89,7 +89,7 @@ trunk check enable {linter}
 | Terragrunt      | [terragrunt]                                                                                                                             |
 | Textproto       | [txtpbfmt]                                                                                                                               |
 | TOML            | [taplo]                                                                                                                                  |
-| Typescript      | [deno], [eslint], [prettier], [rome], [semgrep]                                                                                          |
+| Typescript      | [deno], [eslint], [oxlint], [prettier], [rome], [semgrep]                                                                                |
 | YAML            | [prettier], [semgrep], [yamlfmt], [yamllint]                                                                                             |
 
 [actionlint]: https://trunk.io/linters/infra/actionlint
@@ -149,6 +149,7 @@ trunk check enable {linter}
 [opa]: https://www.openpolicyagent.org/docs/latest/cli/
 [osv-scanner]: https://trunk.io/linters/security/osv-scanner
 [oxipng]: https://github.com/shssoichiro/oxipng#readme
+[oxlint]: https://oxc.rs/docs/guide/usage/linter.html
 [perlcritic]: https://metacpan.org/pod/Perl::Critic
 [perltidy]: https://metacpan.org/dist/Perl-Tidy/view/bin/perltidy
 [pinact]: https://github.com/suzuki-shunsuke/pinact#readme

--- a/linters/oxlint/oxlint.test.ts
+++ b/linters/oxlint/oxlint.test.ts
@@ -1,0 +1,4 @@
+import { linterCheckTest, linterFmtTest } from "tests";
+
+linterCheckTest({ linterName: "oxlint", namedTestPrefixes: ["basic"] });
+linterFmtTest({ linterName: "oxlint", namedTestPrefixes: ["format"] });

--- a/linters/oxlint/plugin.yaml
+++ b/linters/oxlint/plugin.yaml
@@ -1,0 +1,56 @@
+version: 0.1
+tools:
+  definitions:
+    - name: oxlint
+      runtime: node
+      package: oxlint
+      shims: [oxlint]
+      known_good_version: 1.71.0
+    - name: oxfmt
+      runtime: node
+      package: oxfmt
+      shims: [oxfmt]
+      known_good_version: 0.56.0
+lint:
+  definitions:
+    - name: oxlint
+      files: [javascript, javascript-xml, typescript, typescript-xml]
+      main_tool: oxlint
+      tools: [oxfmt]
+      description: Fast JavaScript and TypeScript linting and formatting
+      commands:
+        - name: lint
+          output: sarif
+          run: oxlint --format sarif ${target}
+          success_codes: [0, 1]
+          read_output_from: stdout
+          batch: true
+          cache_results: true
+        - name: format
+          output: rewrite
+          run: oxfmt --write ${target}
+          success_codes: [0]
+          batch: true
+          cache_results: true
+          formatter: true
+          in_place: true
+      suggest_if: config_present
+      direct_configs:
+        - .oxlintrc.json
+        - .oxlintrc.jsonc
+        - .oxfmtrc.json
+        - .oxfmtrc.jsonc
+        - .prettierignore
+        - oxlint.config.ts
+        - oxlint.config.mts
+        - oxfmt.config.ts
+        - oxfmt.config.mts
+      affects_cache:
+        - .editorconfig
+        - .eslintignore
+        - package.json
+        - tsconfig.json
+      known_good_version: 1.71.0
+      version_command:
+        parse_regex: ${semver}
+        run: oxlint --version

--- a/linters/oxlint/test_data/basic.in.ts
+++ b/linters/oxlint/test_data/basic.in.ts
@@ -1,0 +1,3 @@
+const unused = 1;
+
+console.log("hello");

--- a/linters/oxlint/test_data/format.in.ts
+++ b/linters/oxlint/test_data/format.in.ts
@@ -1,0 +1,3 @@
+const value={name:"trunk",enabled:true};
+
+console.log(value);

--- a/linters/oxlint/test_data/oxlint_v1.71.0_basic.check.shot
+++ b/linters/oxlint/test_data/oxlint_v1.71.0_basic.check.shot
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter oxlint test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "eslint(no-unused-vars)",
+      "column": "7",
+      "file": "test_data/basic.in.ts",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_MEDIUM",
+      "line": "1",
+      "linter": "oxlint",
+      "message": "Variable 'unused' is declared but never used. Unused variables should start with a '_'.",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.ts",
+          "length": "6",
+          "offset": "6",
+        },
+      ],
+      "targetType": "typescript",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "format",
+      "fileGroupName": "typescript",
+      "linter": "oxlint",
+      "paths": [
+        "test_data/basic.in.ts",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "oxlint",
+      "paths": [
+        "test_data/basic.in.ts",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "typescript",
+      "linter": "oxlint",
+      "paths": [
+        "test_data/basic.in.ts",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/oxlint/test_data/oxlint_v1.71.0_format.fmt.shot
+++ b/linters/oxlint/test_data/oxlint_v1.71.0_format.fmt.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter oxlint test format 1`] = `
+"const value = { name: "trunk", enabled: true };
+
+console.log(value);
+"
+`;


### PR DESCRIPTION
## What?

Add an Oxlint integration for JavaScript, TypeScript, JSX, and TSX:

- Run Oxlint with SARIF output for diagnostics.
- Run Oxfmt as the formatter.
- Recognize the documented Oxlint and Oxfmt configuration files.
- Track configuration inputs that affect lint and format results.
- Add lint and format integration tests with pinned-version snapshots.
- Document Oxlint in the supported-linters list.

## Why?

Oxlint and Oxfmt provide fast, dedicated linting and formatting with strong ESLint and Prettier compatibility. This integration installs both tools hermetically and follows their current configuration and CLI conventions.

## Validation

- `npm test -- linters/oxlint`
- `PLUGINS_TEST_LINTER_VERSION=KnownGoodVersion npm test -- linters/oxlint`
- `npm test -- tests/repo_tests/config_check.test.ts --runInBand`
- `npm test -- tests/repo_tests` (Graphite submit hook)
- `trunk check ...` on all changed source files
- Snyk Code scan: no findings
