### PR TITLE
Add linter: toml-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ trunk check enable {linter}
 | Terraform       | [terraform] (validate and fmt), [checkov], [tflint], [tfsec], [terrascan], [tofu]                                                        |
 | Terragrunt      | [terragrunt]                                                                                                                             |
 | Textproto       | [txtpbfmt]                                                                                                                               |
-| TOML            | [taplo]                                                                                                                                  |
+| TOML            | [taplo], [toml-tidy]                                                                                                                     |
 | Typescript      | [deno], [eslint], [prettier], [rome], [semgrep]                                                                                          |
 | YAML            | [prettier], [semgrep], [yamlfmt], [yamllint]                                                                                             |
 
@@ -189,6 +189,7 @@ trunk check enable {linter}
 [swiftformat]: https://github.com/nicklockwood/SwiftFormat#readme
 [swiftlint]: https://github.com/realm/SwiftLint#readme
 [taplo]: https://github.com/tamasfe/taplo#readme
+[toml-tidy]: https://github.com/AndrewDongminYoo/toml-tidy#readme
 [terrascan]: https://github.com/tenable/terrascan#readme
 [terraform]: https://developer.hashicorp.com/terraform/cli/code
 [tofu]: https://opentofu.org/

--- a/linters/toml-tidy/README.md
+++ b/linters/toml-tidy/README.md
@@ -1,9 +1,12 @@
 # toml-tidy
 
-[toml-tidy](https://github.com/AndrewDongminYoo/toml-tidy) sorts TOML keys within each table while preserving table hierarchy, comments, and source formatting.
-It complements [taplo](https://github.com/tamasfe/taplo) (formatting) rather than replacing it — the relationship mirrors `prettier` and `sort-package-json` for `package.json`.
+[toml-tidy](https://github.com/AndrewDongminYoo/toml-tidy) sorts TOML keys within each table while
+preserving table hierarchy, comments, and source formatting. It complements
+[taplo](https://github.com/tamasfe/taplo) (formatting) rather than replacing it — the relationship
+mirrors `prettier` and `sort-package-json` for `package.json`.
 
-toml-tidy requires Python >= 3.12, which is newer than the default hermetic Python runtime, so enable a compatible runtime alongside the linter:
+toml-tidy requires Python >= 3.12, which is newer than the default hermetic Python runtime, so
+enable a compatible runtime alongside the linter:
 
 ```yaml
 runtimes:
@@ -14,4 +17,5 @@ lint:
     - toml-tidy@0.2.0
 ```
 
-Per-file defaults (sort order, scope, pinned-first tables) can be configured in the nearest `pyproject.toml` under `[tool.toml-tidy]`.
+Per-file defaults (sort order, scope, pinned-first tables) can be configured in the nearest
+`pyproject.toml` under `[tool.toml-tidy]`.

--- a/linters/toml-tidy/README.md
+++ b/linters/toml-tidy/README.md
@@ -1,0 +1,17 @@
+# toml-tidy
+
+[toml-tidy](https://github.com/AndrewDongminYoo/toml-tidy) sorts TOML keys within each table while preserving table hierarchy, comments, and source formatting.
+It complements [taplo](https://github.com/tamasfe/taplo) (formatting) rather than replacing it — the relationship mirrors `prettier` and `sort-package-json` for `package.json`.
+
+toml-tidy requires Python >= 3.12, which is newer than the default hermetic Python runtime, so enable a compatible runtime alongside the linter:
+
+```yaml
+runtimes:
+  enabled:
+    - python@3.12.2
+lint:
+  enabled:
+    - toml-tidy@0.2.0
+```
+
+Per-file defaults (sort order, scope, pinned-first tables) can be configured in the nearest `pyproject.toml` under `[tool.toml-tidy]`.

--- a/linters/toml-tidy/plugin.yaml
+++ b/linters/toml-tidy/plugin.yaml
@@ -1,0 +1,26 @@
+version: 0.1
+tools:
+  definitions:
+    - name: toml-tidy
+      runtime: python
+      package: toml-tidy
+      shims: [toml-tidy]
+      known_good_version: 0.2.0
+lint:
+  definitions:
+    - name: toml-tidy
+      description: Sorts TOML keys while preserving table hierarchy, comments, and formatting
+      files: [toml]
+      commands:
+        - name: format
+          output: rewrite
+          run: toml-tidy --in-place ${target}
+          success_codes: [0]
+          batch: true
+          in_place: true
+          formatter: true
+      tools: [toml-tidy]
+      suggest_if: never # sorting keys is an opinionated choice; complements taplo (formatting) rather than replacing it
+      affects_cache:
+        - pyproject.toml
+      known_good_version: 0.2.0

--- a/linters/toml-tidy/test_data/basic.in.toml
+++ b/linters/toml-tidy/test_data/basic.in.toml
@@ -1,0 +1,17 @@
+title = "example"
+# alpha gets sorted first and keeps this comment
+alpha = 1
+
+[zulu]
+b = 2
+a = 1
+
+[mike]
+item10 = "ten"
+item2 = "two"
+
+[[servers]]
+name = "second declared"
+
+[[servers]]
+name = "first stays first"

--- a/linters/toml-tidy/test_data/toml_tidy_v0.2.0_basic.fmt.shot
+++ b/linters/toml-tidy/test_data/toml_tidy_v0.2.0_basic.fmt.shot
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing formatter toml-tidy test basic 1`] = `
+"# alpha gets sorted first and keeps this comment
+alpha = 1
+title = "example"
+
+[mike]
+item2 = "two"
+item10 = "ten"
+
+[[servers]]
+name = "second declared"
+
+[[servers]]
+name = "first stays first"
+[zulu]
+a = 1
+b = 2
+
+"
+`;

--- a/linters/toml-tidy/toml_tidy.test.ts
+++ b/linters/toml-tidy/toml_tidy.test.ts
@@ -1,0 +1,15 @@
+import { linterFmtTest } from "tests";
+import { TrunkLintDriver } from "tests/driver";
+
+// toml-tidy requires python >=3.12, newer than the default hermetic runtime
+const preCheck = (driver: TrunkLintDriver) => {
+  const trunkYamlPath = ".trunk/trunk.yaml";
+  const currentContents = driver.readFile(trunkYamlPath);
+  const newContents = currentContents.concat(`runtimes:
+  enabled:
+    - python@3.12.2
+`);
+  driver.writeFile(trunkYamlPath, newContents);
+};
+
+linterFmtTest({ linterName: "toml-tidy", preCheck });


### PR DESCRIPTION
## What

Adds [toml-tidy](https://github.com/AndrewDongminYoo/toml-tidy) as a TOML formatter: it sorts keys within each table (and sibling table declarations) while preserving table hierarchy, comments, and source formatting via tomlkit.

## Why

It complements the existing `taplo` integration (whitespace/style formatting) rather than replacing it — the relationship mirrors `prettier` + `sort-package-json` for `package.json`, which this repo already ships. Sorted TOML keeps files like `pyproject.toml` diff-friendly and merge-conflict-resistant.

## Definition notes

- `runtime: python` / PyPI package, following the `black`/`isort` pattern — no binary downloads to maintain.
- `suggest_if: never` — key sorting is an opinionated choice, so it stays opt-in.
- `affects_cache: [pyproject.toml]` — per-file defaults live in `[tool.toml-tidy]`.
- toml-tidy requires Python >= 3.12 (newer than the default hermetic runtime), so the linter README documents enabling `python@3.12.2`, and the test pins it via `preCheck` — same pattern as ktlint's jdk pin.

## Testing

- `npm test linters/toml-tidy` — passes; fmt snapshot generated for `known_good_version` 0.2.0. The fixture exercises key sorting with comment attachment, natural numeric ordering (`item2` < `item10`), sibling-table sorting, and array-of-tables element-order preservation.
- `npm test tests/repo_tests/readme_inclusion.test.ts` — passes (README table updated).