### PR TITLE
Use prebuilt shfmt binaries 

### DIFF
--- a/linters/shfmt/plugin.yaml
+++ b/linters/shfmt/plugin.yaml
@@ -1,12 +1,26 @@
 version: 0.1
+downloads:
+  - name: shfmt
+    executable: true
+    downloads:
+      - os:
+          linux: linux
+          macos: darwin
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_${os}_${cpu}
+      - os:
+          windows: windows
+        cpu:
+          x86_64: amd64
+        url: https://github.com/mvdan/sh/releases/download/v${version}/shfmt_v${version}_${os}_${cpu}.exe
 tools:
   definitions:
     - name: shfmt
-      runtime: go
-      package: mvdan.cc/sh/v${major_version}/cmd/shfmt
+      download: shfmt
       shims: [shfmt]
-      # shfmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time
-      known_good_version: 3.6.0
+      known_good_version: 3.13.1
 lint:
   definitions:
     - name: shfmt
@@ -24,8 +38,7 @@ lint:
       tools: [shfmt]
       suggest_if: files_present
       affects_cache: [.editorconfig]
-      # shfmt releases are not auto-queriable with our current setup, so we will bump this fixed version from time to time
-      known_good_version: 3.6.0
+      known_good_version: 3.13.1
       version_command:
         parse_regex: ${semver}
         run: shfmt --version

--- a/linters/shfmt/test_data/shfmt_v3.13.1_basic.check.shot
+++ b/linters/shfmt/test_data/shfmt_v3.13.1_basic.check.shot
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter shfmt test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "parse",
+      "column": "24",
+      "file": "test_data/basic.in.sh",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "level": "LEVEL_HIGH",
+      "line": "3",
+      "linter": "shfmt",
+      "message": "\`then\` must be followed by a statement list",
+      "targetType": "shell",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "format",
+      "fileGroupName": "shell",
+      "linter": "shfmt",
+      "paths": [
+        "test_data/basic.in.sh",
+      ],
+      "verb": "TRUNK_VERB_FMT",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
Avoid taking a go runtime dependency - use prebuilt binaries