### PR TITLE
feat: add HOL Guard tool

### DIFF
--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "2.2.126",
+  toolVersion: "3.0.0",
 });

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "hol-guard",
+  toolVersion: "2.2.88",
+});

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "3.0.12",
+  toolVersion: "3.0.18",
 });

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "3.0.9",
+  toolVersion: "3.0.12",
 });

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "2.2.88",
+  toolVersion: "2.2.125",
 });

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "2.2.125",
+  toolVersion: "2.2.126",
 });

--- a/tools/hol-guard/hol_guard.test.ts
+++ b/tools/hol-guard/hol_guard.test.ts
@@ -2,5 +2,5 @@ import { toolInstallTest } from "tests";
 
 toolInstallTest({
   toolName: "hol-guard",
-  toolVersion: "3.0.0",
+  toolVersion: "3.0.9",
 });

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 3.0.0
+      known_good_version: 3.0.9
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 2.2.88
+      known_good_version: 2.2.125
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 2.2.125
+      known_good_version: 2.2.126
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -1,0 +1,11 @@
+version: 0.1
+tools:
+  definitions:
+    - name: hol-guard
+      runtime: python
+      package: hol-guard
+      known_good_version: 2.2.88
+      shims: [hol-guard]
+      health_checks:
+        - command: hol-guard --version
+          parse_regex: ${semver}

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 3.0.12
+      known_good_version: 3.0.18
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 3.0.9
+      known_good_version: 3.0.12
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version

--- a/tools/hol-guard/plugin.yaml
+++ b/tools/hol-guard/plugin.yaml
@@ -4,7 +4,7 @@ tools:
     - name: hol-guard
       runtime: python
       package: hol-guard
-      known_good_version: 2.2.126
+      known_good_version: 3.0.0
       shims: [hol-guard]
       health_checks:
         - command: hol-guard --version


### PR DESCRIPTION
## Summary

Adds HOL Guard as a standalone Trunk tool backed by the stable `hol-guard` PyPI package.

- exposes the `hol-guard` shim through Trunk's default plugin source
- pins the validated `known_good_version` to `3.0.166`
- adds a `hol-guard --version` semver health check
- adds the repository-native `toolInstallTest`

This follows the current `tools/` contribution pattern for Python runtime packages. HOL Guard `v3.0.166` is the validated release used by this contribution.

## Validation

- manifest/test structure mirrors existing Trunk Python tools and hyphenated tool naming
- `plugin.yaml` and `toolInstallTest` both pin `3.0.166`
- the earlier merge-queue macOS failure was on `3.0.18`, where a base LiteLLM dependency fell back to a Rust build under Python 3.14; `3.0.166` no longer includes LiteLLM/Cisco scanner in its base dependencies

I could not run the full local `trunk check` in the connected execution environment, so I am not claiming that as passed; the repository-native install test is included for CI.

Affiliation: I maintain HOL Guard / Hashgraph Online. AI assistance was used to prepare this focused contribution and the release refresh.