### PR TITLE
feat(node): update known good version

### DIFF
--- a/runtimes/node/plugin.yaml
+++ b/runtimes/node/plugin.yaml
@@ -59,7 +59,7 @@ runtimes:
         - name: NODE_OPTIONS
           value: ${env.NODE_OPTIONS}
           optional: true
-      known_good_version: 22.16.0
+      known_good_version: 22.18.0
       version_commands:
         - run: node --version
           parse_regex: ${semver}


### PR DESCRIPTION
cspell requires node 22.18.0 to run. cspell does not reveal any issues on the current node known good version. I updated my `trunk.yaml` node version to 22.18.0 to confirm. On 22.18.0 cspell produced the correct output.

Before: 22.16.0

```
❯ trunk check enable cspell
1 linter was enabled:
  cspell 10.2.1
❯ trunk check -a
Checking 100% [===============================================================================================================>]  256/256  6.8s 
                                                                                                                                                
Checked 43 files
✔ No issues
```

```
❯ cspell
Unsupported NodeJS version (22.16.0); >=22.18.0 is required
```


After: 22.18.0

```
❯ trunk check -a
Checking 100% [==============================================================================================================>]  256/256  33.1s 
                                                                                                                                                
  ISSUES  

.coderabbit.yaml:44:31
  44:31  high  Unknown word (terrateam) Suggestions: [teratoma, teratism, ternate, terrace, terrane]                cspell/error
  48:10  high  Unknown word (terrateam) Suggestions: [teratoma, teratism, ternate, terrace, terrane]                cspell/error
  72:5   high  Unknown word (shellcheck) Suggestions: [spellcheck, spellchecks, shellcheckrc, shellack, shellback]  cspell/error
  80:5   high  Unknown word (languagetool) Suggestions: []                                                          cspell/error
  86:5   high  Unknown word (swiftlint) Suggestions: [swiftlet, sifting, swiftly, shifting, stifling]               cspell/error
  88:5   high  Unknown word (phpstan) Suggestions: [phps, pasta, pisan, pusan, paisan]                              cspell/error
  90:5   high  Unknown word (golangci) Suggestions: [golang, golan, golgi, glance, gobang]                          cspell/error
  98:5   high  Unknown word (detekt) Suggestions: [detect, detent, detest, derek, deter]                            cspell/error
 102:5   high  Unknown word (rubocop) Suggestions: [rubicon, robocopy, Rubicon, rebop, rebook]                      cspell/error
 112:5   high  Unknown word (cppcheck) Suggestions: [check, copeck]     
 ```