### PR TITLE
Add pulumi, d2, jj, and nx tool definitions

### DIFF
--- a/tools/d2/d2.test.ts
+++ b/tools/d2/d2.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "d2",
+  toolVersion: "0.7.1",
+});

--- a/tools/d2/plugin.yaml
+++ b/tools/d2/plugin.yaml
@@ -1,0 +1,29 @@
+version: 0.1
+downloads:
+  - name: d2
+    downloads:
+      # Every platform ships a tarball (windows included; the .msi is skipped).
+      # The archive holds `d2-v${version}/bin/d2`, so one level is stripped and the
+      # nested `bin` is added to PATH rather than stripping two levels, which would
+      # discard the bundled LICENSE/man files.
+      - os:
+          linux: linux
+          macos: macos
+          windows: windows
+        cpu:
+          x86_64: amd64
+          arm_64: arm64
+        url: https://github.com/terrastruct/d2/releases/download/v${version}/d2-v${version}-${os}-${cpu}.tar.gz
+        strip_components: 1
+tools:
+  definitions:
+    - name: d2
+      download: d2
+      known_good_version: 0.7.1
+      environment:
+        - name: PATH
+          list: ["${tool}/bin"]
+      shims: [d2]
+      health_checks:
+        - command: d2 --version
+          parse_regex: ${semver}

--- a/tools/jj/jj.test.ts
+++ b/tools/jj/jj.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "jj",
+  toolVersion: "0.45.1",
+});

--- a/tools/jj/plugin.yaml
+++ b/tools/jj/plugin.yaml
@@ -1,0 +1,32 @@
+version: 0.1
+downloads:
+  - name: jj
+    downloads:
+      # Note the target-triple order: `${cpu}-${os}`, not `${os}-${cpu}`.
+      # The archives hold `jj` at their root alongside README/LICENSE, so there is
+      # nothing to strip.
+      - os:
+          linux: unknown-linux-musl
+          macos: apple-darwin
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        url: https://github.com/jj-vcs/jj/releases/download/v${version}/jj-v${version}-${cpu}-${os}.tar.gz
+      - os:
+          windows: pc-windows-msvc
+        cpu:
+          x86_64: x86_64
+          arm_64: aarch64
+        url: https://github.com/jj-vcs/jj/releases/download/v${version}/jj-v${version}-${cpu}-${os}.zip
+tools:
+  definitions:
+    - name: jj
+      download: jj
+      known_good_version: 0.45.1
+      shims: [jj]
+      health_checks:
+        # Release binaries report `jj <version>-<commit sha>`, so `${semver}`
+        # would capture the sha as a prerelease suffix and never match the
+        # enabled version. Capture just the `x.y.z` prefix.
+        - command: jj --version
+          parse_regex: jj (\d+\.\d+\.\d+)

--- a/tools/nx/nx.test.ts
+++ b/tools/nx/nx.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "nx",
+  toolVersion: "22.5.3",
+});

--- a/tools/nx/plugin.yaml
+++ b/tools/nx/plugin.yaml
@@ -1,0 +1,13 @@
+version: 0.1
+tools:
+  definitions:
+    - name: nx
+      runtime: node
+      package: nx
+      known_good_version: 22.5.3
+      shims: [nx]
+      health_checks:
+        # `nx --version` reports both the workspace-local and the global version;
+        # outside a workspace only the global one is a semver.
+        - command: nx --version
+          parse_regex: ${semver}

--- a/tools/pulumi/plugin.yaml
+++ b/tools/pulumi/plugin.yaml
@@ -1,0 +1,31 @@
+version: 0.1
+downloads:
+  - name: pulumi
+    downloads:
+      # The unix archives hold `pulumi/<binary>`, so one level is stripped to land
+      # the CLI and its bundled language/resource plugins at the tool root.
+      - os:
+          linux: linux
+          macos: darwin
+        cpu:
+          x86_64: x64
+          arm_64: arm64
+        url: https://get.pulumi.com/releases/sdk/pulumi-v${version}-${os}-${cpu}.tar.gz
+        strip_components: 1
+      # The windows zip nests one level deeper (`pulumi/bin/pulumi.exe`).
+      - os:
+          windows: windows
+        cpu:
+          x86_64: x64
+          arm_64: arm64
+        url: https://get.pulumi.com/releases/sdk/pulumi-v${version}-${os}-${cpu}.zip
+        strip_components: 2
+tools:
+  definitions:
+    - name: pulumi
+      download: pulumi
+      known_good_version: 3.210.0
+      shims: [pulumi]
+      health_checks:
+        - command: pulumi version
+          parse_regex: ${semver}

--- a/tools/pulumi/pulumi.test.ts
+++ b/tools/pulumi/pulumi.test.ts
@@ -1,0 +1,6 @@
+import { toolInstallTest } from "tests";
+
+toolInstallTest({
+  toolName: "pulumi",
+  toolVersion: "3.210.0",
+});


### PR DESCRIPTION
## Summary

Adds four tool definitions that trunk-cloud currently carries as custom `downloads` +
`tools.definitions` blocks in its own `.trunk/trunk.yaml`, because none of them exist in this
plugin source. Upstreaming them removes ~60 lines of local config per consuming repo.

- **`tools/pulumi`** — Pulumi CLI (IaC). Unix tarballs hold `pulumi/<binary>` (one level to
  strip); the Windows zip nests one level deeper (`pulumi/bin/pulumi.exe`), so it gets its own
  download entry with `strip_components: 2`. Stripping to the tool root keeps the CLI's bundled
  `pulumi-language-*` / `pulumi-resource-*` plugins adjacent to the binary, which it requires.
- **`tools/d2`** — [D2](https://d2lang.com) declarative diagram language. Every platform ships a
  `.tar.gz` (Windows included; the `.msi` is skipped). Follows the `gh` pattern — `strip_components: 1`
  plus `${tool}/bin` on `PATH` — rather than stripping two levels, so the bundled `LICENSE`/`man`
  files survive.
- **`tools/jj`** — [Jujutsu](https://github.com/jj-vcs/jj) VCS. Note the asset naming is
  `${cpu}-${os}` (a target triple), the reverse of most tools here, and there is **no**
  `strip_components`: the archives hold `jj` at their root alongside `README`/`LICENSE`.
  Windows ships `.zip` instead of `.tar.gz`, so it needs a separate entry.
- **`tools/nx`** — [Nx](https://nx.dev) monorepo task runner, a plain `runtime: node` package.

### Note on the `jj` health check

`jj --version` prints `jj 0.45.1-<commit sha>`. `${semver}` parses the sha as a prerelease suffix,
so the health check fails with `Expected '0.45.1' but got '0.45.1-7c41cdeb...'`. The definition
uses an explicit `jj (\d+\.\d+\.\d+)` to capture only the `x.y.z` prefix; there's a comment in the
file so a future editor doesn't "simplify" it back to `${semver}`.

## Test plan

Each tool uses a `health_checks` entry + `toolInstallTest`, per the guidance in
`repo-tools/tool-test-helper/tool_sample.test.ts`.

- [x] `npm test tools/pulumi tools/d2 tools/jj tools/nx` — 4 suites passed, 4 tests passed
- [x] `trunk tools install` verified against each `known_good_version` (pulumi 3.210.0, d2 0.7.1,
      jj 0.45.1, nx 22.5.3) in a sandbox repo using `plugins: sources: local:`
- [x] Verified again against each tool's latest release resolved by `trunk tools enable`
      (d2 0.8.2, nx 23.2.0), so the definitions aren't pinned-version-specific
- [x] Ran each shim: `d2 --version`, `jj --version`, `nx --version`, `pulumi version`
- [x] `trunk fmt` + `trunk check` clean on the new files
- [ ] Windows and macOS paths are unverified — no runner available locally. All four URL patterns
      and archive layouts were confirmed against the published release assets, and the Windows
      differences (pulumi's deeper zip nesting, jj's `.zip` extension) are handled explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)